### PR TITLE
refactor `concurrent_imports` support in wasmtime-wit-bindgen

### DIFF
--- a/crates/wasmtime/src/runtime/component/linker.rs
+++ b/crates/wasmtime/src/runtime/component/linker.rs
@@ -457,22 +457,11 @@ impl<T> LinkerInstance<'_, T> {
     /// method because it takes a function which returns a future that owns a
     /// unique reference to the Store, meaning the Store can't be used for
     /// anything else until the future resolves.
-    ///
-    /// Ideally, we'd have a way to thread a `StoreContextMut<T>` through an
-    /// arbitrary `Future` such that it has access to the `Store` only while
-    /// being polled (i.e. between, but not across, await points). However,
-    /// there's currently no way to express that in async Rust, so we make do
-    /// with a more awkward scheme: each function registered using
-    /// `func_wrap_concurrent` gets access to the `Store` twice: once before
-    /// doing any concurrent operations (i.e. before awaiting) and once
-    /// afterward. This allows multiple calls to proceed concurrently without
-    /// any one of them monopolizing the store.
     #[cfg(feature = "component-model-async")]
-    pub fn func_wrap_concurrent<Params, Return, F, N, FN>(&mut self, name: &str, f: F) -> Result<()>
+    pub fn func_wrap_concurrent<Params, Return, F, Fut>(&mut self, name: &str, f: F) -> Result<()>
     where
-        N: FnOnce(StoreContextMut<T>) -> Result<Return> + Send + Sync + 'static,
-        FN: Future<Output = N> + Send + Sync + 'static,
-        F: Fn(StoreContextMut<T>, Params) -> FN + Send + Sync + 'static,
+        Fut: Future<Output = Result<Return>> + Send + Sync + 'static,
+        F: Fn(StoreContextMut<T>, Params) -> Fut + Send + Sync + 'static,
         Params: ComponentNamedList + Lift + 'static,
         Return: ComponentNamedList + Lower + Send + Sync + 'static,
     {
@@ -648,11 +637,10 @@ impl<T> LinkerInstance<'_, T> {
     /// afterward. This allows multiple calls to proceed concurrently without
     /// any one of them monopolizing the store.
     #[cfg(feature = "component-model-async")]
-    pub fn func_new_concurrent<F, N, FN>(&mut self, name: &str, f: F) -> Result<()>
+    pub fn func_new_concurrent<F, Fut>(&mut self, name: &str, f: F) -> Result<()>
     where
-        N: FnOnce(StoreContextMut<T>) -> Result<Vec<Val>> + Send + Sync + 'static,
-        FN: Future<Output = N> + Send + Sync + 'static,
-        F: Fn(StoreContextMut<T>, Vec<Val>) -> FN + Send + Sync + 'static,
+        Fut: Future<Output = Result<Vec<Val>>> + Send + Sync + 'static,
+        F: Fn(StoreContextMut<T>, Vec<Val>) -> Fut + Send + Sync + 'static,
     {
         assert!(
             self.engine.config().async_support,

--- a/crates/wasmtime/src/runtime/component/mod.rs
+++ b/crates/wasmtime/src/runtime/component/mod.rs
@@ -116,7 +116,7 @@ mod values;
 pub use self::component::{Component, ComponentExportIndex};
 #[cfg(feature = "component-model-async")]
 pub use self::concurrent::{
-    for_any, future, stream, ErrorContext, FutureReader, FutureWriter, Promise, PromisesUnordered,
+    future, stream, Accessor, ErrorContext, FutureReader, FutureWriter, Promise, PromisesUnordered,
     StreamReader, StreamWriter, VMComponentAsyncStore,
 };
 pub use self::func::{

--- a/crates/wasmtime/src/runtime/store/context.rs
+++ b/crates/wasmtime/src/runtime/store/context.rs
@@ -18,6 +18,13 @@ pub struct StoreContext<'a, T>(pub(crate) &'a StoreInner<T>);
 #[repr(transparent)]
 pub struct StoreContextMut<'a, T>(pub(crate) &'a mut StoreInner<T>);
 
+impl<'a, T> StoreContextMut<'a, T> {
+    #[doc(hidden)]
+    pub fn traitobj(&self) -> std::ptr::NonNull<dyn crate::runtime::vm::VMStore> {
+        self.0.traitobj()
+    }
+}
+
 /// A trait used to get shared access to a [`Store`] in Wasmtime.
 ///
 /// This trait is used as a bound on the first argument of many methods within

--- a/tests/all/component_model/bindgen.rs
+++ b/tests/all/component_model/bindgen.rs
@@ -188,11 +188,7 @@ mod one_import {
 }
 
 mod one_import_concurrent {
-    use {
-        super::*,
-        std::future::Future,
-        wasmtime::{component, StoreContextMut},
-    };
+    use {super::*, wasmtime::component::Accessor};
 
     wasmtime::component::bindgen!({
         inline: "
@@ -269,14 +265,8 @@ mod one_import_concurrent {
         impl foo::Host for MyImports {
             type Data = MyImports;
 
-            fn foo(
-                mut store: StoreContextMut<'_, Self::Data>,
-            ) -> impl Future<Output = impl FnOnce(StoreContextMut<'_, Self::Data>) + 'static>
-                   + Send
-                   + Sync
-                   + 'static {
-                store.data_mut().hit = true;
-                async { component::for_any(|_| ()) }
+            async fn foo(accessor: &mut Accessor<Self::Data>) {
+                accessor.with(|mut store| store.data_mut().hit = true);
             }
         }
 

--- a/tests/all/component_model/import.rs
+++ b/tests/all/component_model/import.rs
@@ -3,7 +3,6 @@
 use super::REALLOC_AND_FREE;
 use anyhow::Result;
 use std::ops::Deref;
-use wasmtime::component;
 use wasmtime::component::*;
 use wasmtime::{Config, Engine, Store, StoreContextMut, Trap, WasmBacktrace};
 
@@ -737,7 +736,7 @@ async fn test_stack_and_heap_args_and_rets(concurrent: bool) -> Result<()> {
             .root()
             .func_wrap_concurrent("f1", |_, (x,): (u32,)| {
                 assert_eq!(x, 1);
-                async { component::for_any(|_| Ok((2u32,))) }
+                async { Ok((2u32,)) }
             })?;
         linker.root().func_wrap_concurrent(
             "f2",
@@ -754,14 +753,14 @@ async fn test_stack_and_heap_args_and_rets(concurrent: bool) -> Result<()> {
                 WasmStr,
             ),)| {
                 assert_eq!(arg.0.to_str(&cx).unwrap(), "abc");
-                async { component::for_any(|_| Ok((3u32,))) }
+                async { Ok((3u32,)) }
             },
         )?;
         linker
             .root()
             .func_wrap_concurrent("f3", |_, (arg,): (u32,)| {
                 assert_eq!(arg, 8);
-                async { component::for_any(|_| Ok(("xyz".to_string(),))) }
+                async { Ok(("xyz".to_string(),)) }
             })?;
         linker.root().func_wrap_concurrent(
             "f4",
@@ -778,7 +777,7 @@ async fn test_stack_and_heap_args_and_rets(concurrent: bool) -> Result<()> {
                 WasmStr,
             ),)| {
                 assert_eq!(arg.0.to_str(&cx).unwrap(), "abc");
-                async { component::for_any(|_| Ok(("xyz".to_string(),))) }
+                async { Ok(("xyz".to_string(),)) }
             },
         )?;
     } else {
@@ -851,7 +850,7 @@ async fn test_stack_and_heap_args_and_rets(concurrent: bool) -> Result<()> {
         linker.root().func_new_concurrent("f1", |_, args| {
             if let Val::U32(x) = &args[0] {
                 assert_eq!(*x, 1);
-                async { component::for_any(|_| Ok(vec![Val::U32(2)])) }
+                async { Ok(vec![Val::U32(2)]) }
             } else {
                 panic!()
             }
@@ -860,7 +859,7 @@ async fn test_stack_and_heap_args_and_rets(concurrent: bool) -> Result<()> {
             if let Val::Tuple(tuple) = &args[0] {
                 if let Val::String(s) = &tuple[0] {
                     assert_eq!(s.deref(), "abc");
-                    async { component::for_any(|_| Ok(vec![Val::U32(3)])) }
+                    async { Ok(vec![Val::U32(3)]) }
                 } else {
                     panic!()
                 }
@@ -871,7 +870,7 @@ async fn test_stack_and_heap_args_and_rets(concurrent: bool) -> Result<()> {
         linker.root().func_new_concurrent("f3", |_, args| {
             if let Val::U32(x) = &args[0] {
                 assert_eq!(*x, 8);
-                async { component::for_any(|_| Ok(vec![Val::String("xyz".into())])) }
+                async { Ok(vec![Val::String("xyz".into())]) }
             } else {
                 panic!();
             }
@@ -880,7 +879,7 @@ async fn test_stack_and_heap_args_and_rets(concurrent: bool) -> Result<()> {
             if let Val::Tuple(tuple) = &args[0] {
                 if let Val::String(s) = &tuple[0] {
                     assert_eq!(s.deref(), "abc");
-                    async { component::for_any(|_| Ok(vec![Val::String("xyz".into())])) }
+                    async { Ok(vec![Val::String("xyz".into())]) }
                 } else {
                     panic!()
                 }


### PR DESCRIPTION
I had a few goals with this PR:

  1. Improve the ergonomics of concurrent import bindings by supporting `async`/`await` sugar and allowing store access to be arbitrarily interspersed between `await` points -- while still preventing references to the store across `await` points.

  2. Get rid of the `Data` associated types for `Host` traits and support `add_to_linker_get_host` where the `Host` impl is not the same as the `T` in `Store<T>`.

  3. Allow creating, reading from, writing to, etc. streams and futures without exposing `StoreContextMut` directly.

Unfortunately, after a day of intense type tetris I failed to achieve items 2 or 3, so this only covers item 1.

Regarding item 1: I've introduced a new `Accessor` type which wraps a `*mut dyn VMStore` and provides access to it only via a `with` method that accepts a synchronous closure which takes a `StoreContextMut<T>` parameter.  The closure can do what it likes and return an arbitrary value as long as that result has a `'static` lifetime (i.e. does not borrow from the store).  This ensures that the host function is able to access the store only between `await`s and not across them; we prohibit the latter because it would prevent other async-lowered imports from running concurrently.  Finally, since host function takes a `&mut Accessor<T>`, it is not possible for the reference to outlive the future returned by the host function, and since the `with` method takes `&mut self` it cannot be used recursively.

Regarding items 2 and 3: In order to read from or write to streams/futures, we need to be able to efficiently lift and lower their payload types, which requires that both the payload type (of which there could be several for a given world) and the `T` in `Store<T>` be in scope.  I was unable to find a way to thread those types through the various layers of closures, futures, and generated code without adding unwanted `'static` bounds and/or breaking the blanket `impl`s used for forwarding calls from `&mut X` to `X`.  Also, the usual tricks of using dyn objects or vtables could only be used ergonomically to erase one of the two types but not both.  I'd love to revisit this later with the help of a Rust type wizard to see if there's a strategy I missed.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
