### PR TITLE
add `Accessor::spawn` method

### DIFF
--- a/crates/misc/component-async-tests/wit/test.wit
+++ b/crates/misc/component-async-tests/wit/test.wit
@@ -113,6 +113,14 @@ interface unit-stream {
   run: func(count: u32) -> stream;
 }
 
+interface resource-stream {
+  resource x {
+    foo: func();
+  }
+
+  foo: func(count: u32) -> stream<x>;
+}
+
 world yield-caller {
   import continue;
   import ready;
@@ -221,4 +229,9 @@ world unit-stream-caller {
 
 world unit-stream-callee {
   export unit-stream;
+}
+
+world read-resource-stream {
+  import resource-stream;
+  export run;
 }

--- a/crates/test-programs/src/bin/async_read_resource_stream.rs
+++ b/crates/test-programs/src/bin/async_read_resource_stream.rs
@@ -1,0 +1,47 @@
+mod bindings {
+    wit_bindgen::generate!({
+        path: "../misc/component-async-tests/wit",
+        world: "read-resource-stream",
+        async: {
+            exports: [
+                "local:local/run#run"
+            ]
+        }
+    });
+
+    use super::Component;
+    export!(Component);
+}
+
+use {
+    bindings::{exports::local::local::run::Guest, local::local::resource_stream},
+    futures::StreamExt,
+};
+
+struct Component;
+
+impl Guest for Component {
+    async fn run() {
+        let mut count = 7;
+        let mut stream = resource_stream::foo(count);
+
+        while let Some(Ok(chunk)) = stream.next().await {
+            for x in chunk {
+                if count > 0 {
+                    count -= 1;
+                } else {
+                    panic!("received too many items");
+                }
+
+                x.foo()
+            }
+        }
+
+        if count != 0 {
+            panic!("received too few items");
+        }
+    }
+}
+
+// Unused function; required since this file is built as a `bin`:
+fn main() {}

--- a/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
@@ -1,5 +1,7 @@
 use {
-    super::{table::TableId, Event, GuestTask, HostTaskFuture, HostTaskResult, Promise},
+    super::{
+        table::TableId, Event, GuestTask, HostTaskFuture, HostTaskOutput, HostTaskResult, Promise,
+    },
     crate::{
         component::{
             func::{self, Lift, LiftContext, LowerContext, Options},
@@ -98,17 +100,16 @@ fn push_event<T>(
         .concurrent_state()
         .futures
         .get_mut()
-        .push(Box::pin(future::ready((
-            rep,
-            Box::new(move |_| {
+        .push(Box::pin(future::ready(HostTaskOutput::Call {
+            waitable: rep,
+            fun: Box::new(move |_| {
                 Ok(HostTaskResult {
                     event,
                     param: u32::try_from(param).unwrap(),
                     caller,
                 })
-            })
-                as Box<dyn FnOnce(*mut dyn VMStore) -> Result<HostTaskResult> + Send + Sync>,
-        ))) as HostTaskFuture);
+            }),
+        })) as HostTaskFuture);
 }
 
 fn get_mut_by_index(


### PR DESCRIPTION
From the docs:

> Spawn a background task which will receive an `&mut Accessor<T>` and run
> concurrently with any other tasks in progress for the current instance.
>
> This is particularly useful for host functions which return a `stream`
> or `future` such that the code to write to the write end of that
> `stream` or `future` must run after the function returns.

See the `async_read_resource_stream` test for an example.

Note that I _really_ tried to make this more ergonomic by using closures (either
the old fashioned `move |_| async move { .. }` kind or the soon-to-be stabilized
`async move |_| { ... }` kind.  Neither one worked given the `Send + Sync +
'static` bounds and the `&mut Accessor<T>` parameter type.  I'm hoping once more
async closure features are implemented in `rustc` we'll be able to revist that.
For now, you need to provide a type that implements `BackgroundTask<T>` as
demonstrated by the `async_read_resource_stream` test.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
