### PR TITLE
assert suspend pointer is non-null in `suspend_fiber`

### DIFF
--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -2223,6 +2223,7 @@ unsafe fn suspend_fiber<'a, T>(
 ) -> Result<Option<StoreContextMut<'a, T>>> {
     let _reset_suspend = Reset(suspend, *suspend);
     let _reset_stack_limit = Reset(stack_limit, *stack_limit);
+    assert!(!(*suspend).is_null());
     let (store, result) = (**suspend).suspend(store.map(|s| s.0.traitobj().as_ptr()));
     result?;
     Ok(store.map(|v| StoreContextMut(&mut *v.cast())))


### PR DESCRIPTION
This ensures we panic rather than segfault when attempting to suspend from a top-level (i.e. non-fiber) stack.  I'm working on refactoring parts of concurrent.rs to avoid avoid triggering this panic, but that will be a separate PR.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
