### PR TITLE
fix: ensure TCP listener is closed on drop, fix (mostly) TCP guest test deadlocks

### DIFF
--- a/crates/test-programs/src/bin/sockets_0_3_tcp_bind.rs
+++ b/crates/test-programs/src/bin/sockets_0_3_tcp_bind.rs
@@ -88,8 +88,6 @@ async fn test_tcp_bind_reuseaddr(ip: IpAddress) {
         listener2.bind(bind_addr).unwrap();
         listener2.listen().unwrap();
     }
-
-    drop(client);
 }
 
 // Try binding to an address that is not configured on the system.

--- a/crates/test-programs/src/bin/sockets_0_3_tcp_connect.rs
+++ b/crates/test-programs/src/bin/sockets_0_3_tcp_connect.rs
@@ -8,27 +8,6 @@ test_programs::p3::export!(Component);
 
 const SOME_PORT: u16 = 47; // If the tests pass, this will never actually be connected to.
 
-impl test_programs::p3::exports::wasi::cli::run::Guest for Component {
-    async fn run() -> Result<(), ()> {
-        test_tcp_connect_unspec(IpAddressFamily::Ipv4).await;
-        test_tcp_connect_unspec(IpAddressFamily::Ipv6).await;
-
-        test_tcp_connect_port_0(IpAddressFamily::Ipv4).await;
-        test_tcp_connect_port_0(IpAddressFamily::Ipv6).await;
-
-        test_tcp_connect_wrong_family(IpAddressFamily::Ipv4).await;
-        test_tcp_connect_wrong_family(IpAddressFamily::Ipv6).await;
-
-        test_tcp_connect_non_unicast().await;
-
-        test_tcp_connect_dual_stack().await;
-
-        test_tcp_connect_explicit_bind(IpAddressFamily::Ipv4).await;
-        test_tcp_connect_explicit_bind(IpAddressFamily::Ipv6).await;
-        Ok(())
-    }
-}
-
 /// `0.0.0.0` / `::` is not a valid remote address in WASI.
 async fn test_tcp_connect_unspec(family: IpAddressFamily) {
     let addr = IpSocketAddress::new(IpAddress::new_unspecified(family), SOME_PORT);
@@ -133,6 +112,27 @@ async fn test_tcp_connect_explicit_bind(family: IpAddressFamily) {
 
     // Connect should work:
     client.connect(listener_address).await.unwrap();
+}
+
+impl test_programs::p3::exports::wasi::cli::run::Guest for Component {
+    async fn run() -> Result<(), ()> {
+        test_tcp_connect_unspec(IpAddressFamily::Ipv4).await;
+        test_tcp_connect_unspec(IpAddressFamily::Ipv6).await;
+
+        test_tcp_connect_port_0(IpAddressFamily::Ipv4).await;
+        test_tcp_connect_port_0(IpAddressFamily::Ipv6).await;
+
+        test_tcp_connect_wrong_family(IpAddressFamily::Ipv4).await;
+        test_tcp_connect_wrong_family(IpAddressFamily::Ipv6).await;
+
+        test_tcp_connect_non_unicast().await;
+
+        test_tcp_connect_dual_stack().await;
+
+        test_tcp_connect_explicit_bind(IpAddressFamily::Ipv4).await;
+        test_tcp_connect_explicit_bind(IpAddressFamily::Ipv6).await;
+        Ok(())
+    }
 }
 
 fn main() {}

--- a/crates/test-programs/src/bin/sockets_0_3_tcp_sample_application.rs
+++ b/crates/test-programs/src/bin/sockets_0_3_tcp_sample_application.rs
@@ -8,30 +8,6 @@ struct Component;
 
 test_programs::p3::export!(Component);
 
-impl test_programs::p3::exports::wasi::cli::run::Guest for Component {
-    async fn run() -> Result<(), ()> {
-        test_tcp_sample_application(
-            IpAddressFamily::Ipv4,
-            IpSocketAddress::Ipv4(Ipv4SocketAddress {
-                port: 0,                 // use any free port
-                address: (127, 0, 0, 1), // localhost
-            }),
-        )
-        .await;
-        test_tcp_sample_application(
-            IpAddressFamily::Ipv6,
-            IpSocketAddress::Ipv6(Ipv6SocketAddress {
-                port: 0,                           // use any free port
-                address: (0, 0, 0, 0, 0, 0, 0, 1), // localhost
-                flow_info: 0,
-                scope_id: 0,
-            }),
-        )
-        .await;
-        Ok(())
-    }
-}
-
 async fn test_tcp_sample_application(family: IpAddressFamily, bind_address: IpSocketAddress) {
     let first_message = b"Hello, world!";
     let second_message = b"Greetings, planet!";
@@ -100,6 +76,30 @@ async fn test_tcp_sample_application(family: IpAddressFamily, bind_address: IpSo
         // Check that we sent and received our message!
         assert_eq!(data, second_message); // Not guaranteed to work but should work in practice.
         fut.await.unwrap().unwrap().unwrap()
+    }
+}
+
+impl test_programs::p3::exports::wasi::cli::run::Guest for Component {
+    async fn run() -> Result<(), ()> {
+        test_tcp_sample_application(
+            IpAddressFamily::Ipv4,
+            IpSocketAddress::Ipv4(Ipv4SocketAddress {
+                port: 0,                 // use any free port
+                address: (127, 0, 0, 1), // localhost
+            }),
+        )
+        .await;
+        test_tcp_sample_application(
+            IpAddressFamily::Ipv6,
+            IpSocketAddress::Ipv6(Ipv6SocketAddress {
+                port: 0,                           // use any free port
+                address: (0, 0, 0, 0, 0, 0, 0, 1), // localhost
+                flow_info: 0,
+                scope_id: 0,
+            }),
+        )
+        .await;
+        Ok(())
     }
 }
 

--- a/crates/test-programs/src/bin/sockets_0_3_tcp_sockopts.rs
+++ b/crates/test-programs/src/bin/sockets_0_3_tcp_sockopts.rs
@@ -9,26 +9,6 @@ test_programs::p3::export!(Component);
 
 const SECOND: u64 = 1_000_000_000;
 
-impl test_programs::p3::exports::wasi::cli::run::Guest for Component {
-    async fn run() -> Result<(), ()> {
-        test_tcp_sockopt_defaults(IpAddressFamily::Ipv4);
-        test_tcp_sockopt_defaults(IpAddressFamily::Ipv6);
-
-        test_tcp_sockopt_input_ranges(IpAddressFamily::Ipv4);
-        test_tcp_sockopt_input_ranges(IpAddressFamily::Ipv6);
-
-        test_tcp_sockopt_readback(IpAddressFamily::Ipv4);
-        test_tcp_sockopt_readback(IpAddressFamily::Ipv6);
-
-        test_tcp_sockopt_inheritance(IpAddressFamily::Ipv4).await;
-        test_tcp_sockopt_inheritance(IpAddressFamily::Ipv6).await;
-
-        test_tcp_sockopt_after_listen(IpAddressFamily::Ipv4).await;
-        test_tcp_sockopt_after_listen(IpAddressFamily::Ipv6).await;
-        Ok(())
-    }
-}
-
 fn test_tcp_sockopt_defaults(family: IpAddressFamily) {
     let sock = TcpSocket::new(family);
 
@@ -228,6 +208,26 @@ async fn test_tcp_sockopt_after_listen(family: IpAddressFamily) {
         assert_eq!(sock.hop_limit().unwrap(), 42);
         assert_eq!(sock.receive_buffer_size().unwrap(), 0x10000);
         assert_eq!(sock.send_buffer_size().unwrap(), 0x10000);
+    }
+}
+
+impl test_programs::p3::exports::wasi::cli::run::Guest for Component {
+    async fn run() -> Result<(), ()> {
+        test_tcp_sockopt_defaults(IpAddressFamily::Ipv4);
+        test_tcp_sockopt_defaults(IpAddressFamily::Ipv6);
+
+        test_tcp_sockopt_input_ranges(IpAddressFamily::Ipv4);
+        test_tcp_sockopt_input_ranges(IpAddressFamily::Ipv6);
+
+        test_tcp_sockopt_readback(IpAddressFamily::Ipv4);
+        test_tcp_sockopt_readback(IpAddressFamily::Ipv6);
+
+        test_tcp_sockopt_inheritance(IpAddressFamily::Ipv4).await;
+        test_tcp_sockopt_inheritance(IpAddressFamily::Ipv6).await;
+
+        test_tcp_sockopt_after_listen(IpAddressFamily::Ipv4).await;
+        test_tcp_sockopt_after_listen(IpAddressFamily::Ipv6).await;
+        Ok(())
     }
 }
 

--- a/crates/test-programs/src/bin/sockets_0_3_tcp_states.rs
+++ b/crates/test-programs/src/bin/sockets_0_3_tcp_states.rs
@@ -6,23 +6,6 @@ struct Component;
 
 test_programs::p3::export!(Component);
 
-impl test_programs::p3::exports::wasi::cli::run::Guest for Component {
-    async fn run() -> Result<(), ()> {
-        test_tcp_unbound_state_invariants(IpAddressFamily::Ipv4);
-        test_tcp_unbound_state_invariants(IpAddressFamily::Ipv6);
-
-        test_tcp_bound_state_invariants(IpAddressFamily::Ipv4);
-        test_tcp_bound_state_invariants(IpAddressFamily::Ipv6);
-
-        test_tcp_listening_state_invariants(IpAddressFamily::Ipv4).await;
-        test_tcp_listening_state_invariants(IpAddressFamily::Ipv6).await;
-
-        test_tcp_connected_state_invariants(IpAddressFamily::Ipv4).await;
-        test_tcp_connected_state_invariants(IpAddressFamily::Ipv6).await;
-        Ok(())
-    }
-}
-
 fn test_tcp_unbound_state_invariants(family: IpAddressFamily) {
     let sock = TcpSocket::new(family);
 
@@ -203,6 +186,23 @@ async fn test_tcp_connected_state_invariants(family: IpAddressFamily) {
 
     assert!(sock.send_buffer_size().is_ok());
     assert_eq!(sock.set_send_buffer_size(16000), Ok(()));
+}
+
+impl test_programs::p3::exports::wasi::cli::run::Guest for Component {
+    async fn run() -> Result<(), ()> {
+        test_tcp_unbound_state_invariants(IpAddressFamily::Ipv4);
+        test_tcp_unbound_state_invariants(IpAddressFamily::Ipv6);
+
+        test_tcp_bound_state_invariants(IpAddressFamily::Ipv4);
+        test_tcp_bound_state_invariants(IpAddressFamily::Ipv6);
+
+        test_tcp_listening_state_invariants(IpAddressFamily::Ipv4).await;
+        test_tcp_listening_state_invariants(IpAddressFamily::Ipv6).await;
+
+        test_tcp_connected_state_invariants(IpAddressFamily::Ipv4).await;
+        test_tcp_connected_state_invariants(IpAddressFamily::Ipv6).await;
+        Ok(())
+    }
 }
 
 fn main() {}

--- a/crates/test-programs/src/bin/sockets_0_3_tcp_streams.rs
+++ b/crates/test-programs/src/bin/sockets_0_3_tcp_streams.rs
@@ -10,23 +10,6 @@ struct Component;
 
 test_programs::p3::export!(Component);
 
-impl test_programs::p3::exports::wasi::cli::run::Guest for Component {
-    async fn run() -> Result<(), ()> {
-        test_tcp_input_stream_should_be_closed_by_remote_shutdown(IpAddressFamily::Ipv4).await;
-        test_tcp_input_stream_should_be_closed_by_remote_shutdown(IpAddressFamily::Ipv6).await;
-
-        test_tcp_input_stream_should_be_closed_by_local_shutdown(IpAddressFamily::Ipv4).await;
-        test_tcp_input_stream_should_be_closed_by_local_shutdown(IpAddressFamily::Ipv6).await;
-
-        test_tcp_output_stream_should_be_closed_by_local_shutdown(IpAddressFamily::Ipv4).await;
-        test_tcp_output_stream_should_be_closed_by_local_shutdown(IpAddressFamily::Ipv6).await;
-
-        test_tcp_shutdown_should_not_lose_data(IpAddressFamily::Ipv4).await;
-        test_tcp_shutdown_should_not_lose_data(IpAddressFamily::Ipv6).await;
-        Ok(())
-    }
-}
-
 /// InputStream::read should return `StreamError::Closed` after the connection has been shut down by the server.
 async fn test_tcp_input_stream_should_be_closed_by_remote_shutdown(family: IpAddressFamily) {
     setup(family, |server, client| async move {
@@ -150,6 +133,23 @@ async fn test_tcp_shutdown_should_not_lose_data(family: IpAddressFamily) {
         server_fut.await.unwrap().unwrap().unwrap()
     })
     .await;
+}
+
+impl test_programs::p3::exports::wasi::cli::run::Guest for Component {
+    async fn run() -> Result<(), ()> {
+        test_tcp_input_stream_should_be_closed_by_remote_shutdown(IpAddressFamily::Ipv4).await;
+        test_tcp_input_stream_should_be_closed_by_remote_shutdown(IpAddressFamily::Ipv6).await;
+
+        test_tcp_input_stream_should_be_closed_by_local_shutdown(IpAddressFamily::Ipv4).await;
+        test_tcp_input_stream_should_be_closed_by_local_shutdown(IpAddressFamily::Ipv6).await;
+
+        test_tcp_output_stream_should_be_closed_by_local_shutdown(IpAddressFamily::Ipv4).await;
+        test_tcp_output_stream_should_be_closed_by_local_shutdown(IpAddressFamily::Ipv6).await;
+
+        test_tcp_shutdown_should_not_lose_data(IpAddressFamily::Ipv4).await;
+        test_tcp_shutdown_should_not_lose_data(IpAddressFamily::Ipv6).await;
+        Ok(())
+    }
 }
 
 fn main() {}

--- a/crates/test-programs/src/p3/mod.rs
+++ b/crates/test-programs/src/p3/mod.rs
@@ -10,8 +10,8 @@ wit_bindgen::generate!({
              "wasi:clocks/monotonic-clock@0.3.0#wait-for",
              "wasi:clocks/monotonic-clock@0.3.0#wait-until",
              "wasi:sockets/ip-name-lookup@0.3.0#resolve-addresses",
-             //"wasi:sockets/types@0.3.0#[method]tcp-socket.bind",
              "wasi:sockets/types@0.3.0#[method]tcp-socket.connect",
+             "wasi:sockets/types@0.3.0#[method]tcp-socket.send",
          ],
          exports: [
              "wasi:cli/run@0.3.0#run",

--- a/crates/wasi/tests/all/p3/mod.rs
+++ b/crates/wasi/tests/all/p3/mod.rs
@@ -113,7 +113,7 @@ async fn run(path: &str) -> anyhow::Result<()> {
     promises
         .next(&mut store)
         .await
-        .context("failed to get promise")?
+        .context("guest trapped")?
         .context("promise missing")?
         .map_err(|()| anyhow!("`wasi:cli/run#run` failed"))
 }

--- a/crates/wasi/tests/all/p3/sockets.rs
+++ b/crates/wasi/tests/all/p3/sockets.rs
@@ -18,6 +18,7 @@ async fn sockets_0_3_tcp_connect() -> anyhow::Result<()> {
     run(SOCKETS_0_3_TCP_CONNECT_COMPONENT).await
 }
 
+#[ignore = "trap"]
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn sockets_0_3_tcp_sample_application() -> anyhow::Result<()> {
     run(SOCKETS_0_3_TCP_SAMPLE_APPLICATION_COMPONENT).await

--- a/crates/wasi/tests/all/p3/sockets.rs
+++ b/crates/wasi/tests/all/p3/sockets.rs
@@ -8,7 +8,6 @@ async fn sockets_0_3_ip_name_lookup() -> anyhow::Result<()> {
     run(SOCKETS_0_3_IP_NAME_LOOKUP_COMPONENT).await
 }
 
-#[ignore = "deadlock"]
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn sockets_0_3_tcp_bind() -> anyhow::Result<()> {
     run(SOCKETS_0_3_TCP_BIND_COMPONENT).await
@@ -19,7 +18,6 @@ async fn sockets_0_3_tcp_connect() -> anyhow::Result<()> {
     run(SOCKETS_0_3_TCP_CONNECT_COMPONENT).await
 }
 
-#[ignore = "deadlock"]
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn sockets_0_3_tcp_sample_application() -> anyhow::Result<()> {
     run(SOCKETS_0_3_TCP_SAMPLE_APPLICATION_COMPONENT).await


### PR DESCRIPTION
- move TCP listener into a separate Tokio task and add state synchronisation to ensure it's dropped before `TcpSocket::drop` returns. We should be able to simplify this once tasks spawned via `Accessor::spawn` are "cancellable", as discussed with @dicej 
- send and write to the stream concurrently in the guest to avoid deadlock
- rearrange the tests a bit to better match the wasip2 tests for easier side-by-side comparison