### PR TITLE
return `None` if `FutureReader::read` sender is dropped

### DIFF
--- a/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
@@ -837,9 +837,8 @@ impl<T> FutureReader<T> {
         let recv = host_read::<T, _, _>(store, self.rep)?;
         let result = recv.map(|v| match v {
             Ok(HostReadResult::Values(v)) => v.into_iter().next().map(Result::Ok),
-            Ok(HostReadResult::EndOfStream(None)) => None,
+            Ok(HostReadResult::EndOfStream(None)) | Err(_) => None,
             Ok(HostReadResult::EndOfStream(s)) => s.map(Result::Err),
-            Err(_) => unreachable!(),
         });
         Ok(Promise(Box::pin(result)))
     }


### PR DESCRIPTION
This can happen if the write end of the future is closed before the reader tried to read it.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
