### PR TITLE
Remove write of adapter module to /tmp/adapter.wasm

### DIFF
--- a/crates/environ/src/component/translate/adapt.rs
+++ b/crates/environ/src/component/translate/adapt.rs
@@ -196,7 +196,6 @@ impl<'data> Translator<'_, 'data> {
                 names.push(name);
             }
             let wasm = module.encode();
-            std::fs::write("/tmp/adapter.wasm", &wasm).unwrap();
             wasmparser::Validator::new().validate_all(&wasm).unwrap();
             let imports = module.imports().to_vec();
 


### PR DESCRIPTION
I am assuming this was accidentally merged to main, because I can't see the file being used anywhere else.

I found this because I am using Windows so this line is panicking

