### PR TITLE
feat(sockets/tcp): switch to `AbortOnDropHandle`

### DIFF
--- a/crates/wasi/src/p3/sockets/udp.rs
+++ b/crates/wasi/src/p3/sockets/udp.rs
@@ -8,13 +8,11 @@ use rustix::net::bind;
 
 use crate::p3::bindings::sockets::types::{ErrorCode, IpAddressFamily, IpSocketAddress};
 use crate::p3::sockets::util::{
-    get_unicast_hop_limit, receive_buffer_size, send_buffer_size, set_receive_buffer_size,
-    set_send_buffer_size, set_unicast_hop_limit,
+    get_unicast_hop_limit, is_valid_address_family, receive_buffer_size, send_buffer_size,
+    set_receive_buffer_size, set_send_buffer_size, set_unicast_hop_limit,
 };
 use crate::p3::sockets::SocketAddressFamily;
 use crate::runtime::with_ambient_tokio_runtime;
-
-use super::util::is_valid_address_family;
 
 /// The state of a UDP socket.
 ///


### PR DESCRIPTION
Switch to `AbortOnDropHandle` introduced in https://github.com/bytecodealliance/wasip3-prototyping/pull/18

This simplifies the `Drop` logic and brings back single-threaded program support. I originally planned to introduce similar constructs for `send` and `connect` (https://github.com/bytecodealliance/wasip3-prototyping/pull/31), but I'm holding that off until we have a discussion about the expected behavior for those cases.

closes #29 