### PR TITLE
feat: setup `wasi:filesystem` scaffolding

### DIFF
--- a/crates/wasi/src/p3/bindings.rs
+++ b/crates/wasi/src/p3/bindings.rs
@@ -16,8 +16,10 @@
 //!
 //! use wasmtime_wasi::p3::cli::{WasiCliCtx, WasiCliView};
 //! use wasmtime_wasi::p3::clocks::{WasiClocksCtx, WasiClocksView};
+//! use wasmtime_wasi::p3::filesystem::{WasiFilesystemCtx, WasiFilesystemView};
 //! use wasmtime_wasi::p3::random::{WasiRandomCtx, WasiRandomView};
 //! use wasmtime_wasi::p3::sockets::{WasiSocketsCtx, WasiSocketsView};
+//! use wasmtime_wasi::p3::ResourceView;
 //! use wasmtime::{Result, StoreContextMut, Engine, Config};
 //! use wasmtime::component::{Accessor, Linker, ResourceTable};
 //!
@@ -66,6 +68,7 @@
 //! struct MyState {
 //!     cli: WasiCliCtx,
 //!     clocks: WasiClocksCtx,
+//!     filesystem: WasiFilesystemCtx,
 //!     random: WasiRandomCtx,
 //!     sockets: WasiSocketsCtx,
 //!     table: ResourceTable,
@@ -77,6 +80,10 @@
 //!     }
 //! }
 //!
+//! impl ResourceView for MyState {
+//!     fn table(&mut self) -> &mut ResourceTable { &mut self.table }
+//! }
+//!
 //! impl WasiCliView for MyState {
 //!     fn cli(&self) -> &WasiCliCtx { &self.cli }
 //! }
@@ -85,14 +92,16 @@
 //!     fn clocks(&self) -> &WasiClocksCtx { &self.clocks }
 //! }
 //!
+//! impl WasiFilesystemView for MyState {
+//!     fn filesystem(&mut self) -> &mut WasiFilesystemCtx { &mut self.filesystem }
+//! }
+//!
 //! impl WasiRandomView for MyState {
 //!     fn random(&mut self) -> &mut WasiRandomCtx { &mut self.random }
 //! }
 //!
 //! impl WasiSocketsView for MyState {
 //!     fn sockets(&self) -> &WasiSocketsCtx { &self.sockets }
-//!
-//!     fn table(&mut self) -> &mut ResourceTable { &mut self.table }
 //! }
 //!
 //! fn main() -> Result<()> {

--- a/crates/wasi/src/p3/filesystem/host.rs
+++ b/crates/wasi/src/p3/filesystem/host.rs
@@ -1,0 +1,244 @@
+#![allow(unused)] // TODO: remove
+
+use wasmtime::component::{FutureReader, Resource, StreamReader};
+
+use crate::p3::bindings::filesystem::types::{
+    Advice, Descriptor, DescriptorFlags, DescriptorStat, DescriptorType, DirectoryEntry, ErrorCode,
+    Filesize, MetadataHashValue, NewTimestamp, OpenFlags, PathFlags,
+};
+use crate::p3::bindings::filesystem::{preopens, types};
+use crate::p3::filesystem::{WasiFilesystemImpl, WasiFilesystemView};
+
+impl<T> types::Host for WasiFilesystemImpl<T> where T: WasiFilesystemView {}
+
+impl<T> types::HostDescriptor for WasiFilesystemImpl<T>
+where
+    T: WasiFilesystemView,
+{
+    fn read_via_stream(
+        &mut self,
+        descriptor: Resource<Descriptor>,
+        offset: Filesize,
+    ) -> wasmtime::Result<(StreamReader<u8>, FutureReader<Result<(), ErrorCode>>)> {
+        todo!()
+    }
+
+    fn write_via_stream(
+        &mut self,
+        descriptor: Resource<Descriptor>,
+        data: StreamReader<u8>,
+        offset: Filesize,
+    ) -> wasmtime::Result<Result<(), ErrorCode>> {
+        todo!()
+    }
+
+    fn append_via_stream(
+        &mut self,
+        descriptor: Resource<Descriptor>,
+        data: StreamReader<u8>,
+    ) -> wasmtime::Result<Result<(), ErrorCode>> {
+        todo!()
+    }
+
+    fn advise(
+        &mut self,
+        descriptor: Resource<Descriptor>,
+        offset: Filesize,
+        length: Filesize,
+        advice: Advice,
+    ) -> wasmtime::Result<Result<(), ErrorCode>> {
+        todo!()
+    }
+
+    fn sync_data(
+        &mut self,
+        descriptor: Resource<Descriptor>,
+    ) -> wasmtime::Result<Result<(), ErrorCode>> {
+        todo!()
+    }
+
+    fn get_flags(
+        &mut self,
+        descriptor: Resource<Descriptor>,
+    ) -> wasmtime::Result<Result<DescriptorFlags, ErrorCode>> {
+        todo!()
+    }
+
+    fn get_type(
+        &mut self,
+        descriptor: Resource<Descriptor>,
+    ) -> wasmtime::Result<Result<DescriptorType, ErrorCode>> {
+        todo!()
+    }
+
+    fn set_size(
+        &mut self,
+        descriptor: Resource<Descriptor>,
+        size: Filesize,
+    ) -> wasmtime::Result<Result<(), ErrorCode>> {
+        todo!()
+    }
+
+    fn set_times(
+        &mut self,
+        descriptor: Resource<Descriptor>,
+        data_access_timestamp: NewTimestamp,
+        data_modification_timestamp: NewTimestamp,
+    ) -> wasmtime::Result<Result<(), ErrorCode>> {
+        todo!()
+    }
+
+    fn read_directory(
+        &mut self,
+        descriptor: Resource<Descriptor>,
+    ) -> wasmtime::Result<(
+        StreamReader<DirectoryEntry>,
+        FutureReader<Result<(), ErrorCode>>,
+    )> {
+        todo!()
+    }
+
+    fn sync(
+        &mut self,
+        descriptor: Resource<Descriptor>,
+    ) -> wasmtime::Result<Result<(), ErrorCode>> {
+        todo!()
+    }
+
+    fn create_directory_at(
+        &mut self,
+        descriptor: Resource<Descriptor>,
+        path: String,
+    ) -> wasmtime::Result<Result<(), ErrorCode>> {
+        todo!()
+    }
+
+    fn stat(
+        &mut self,
+        descriptor: Resource<Descriptor>,
+    ) -> wasmtime::Result<Result<DescriptorStat, ErrorCode>> {
+        todo!()
+    }
+
+    fn stat_at(
+        &mut self,
+        descriptor: Resource<Descriptor>,
+        path_flags: PathFlags,
+        path: String,
+    ) -> wasmtime::Result<Result<DescriptorStat, ErrorCode>> {
+        todo!()
+    }
+
+    fn set_times_at(
+        &mut self,
+        descriptor: Resource<Descriptor>,
+        path_flags: PathFlags,
+        path: String,
+        data_access_timestamp: NewTimestamp,
+        data_modification_timestamp: NewTimestamp,
+    ) -> wasmtime::Result<Result<(), ErrorCode>> {
+        todo!()
+    }
+
+    fn link_at(
+        &mut self,
+        descriptor: Resource<Descriptor>,
+        old_path_flags: PathFlags,
+        old_path: String,
+        new_descriptor: Resource<Descriptor>,
+        new_path: String,
+    ) -> wasmtime::Result<Result<(), ErrorCode>> {
+        todo!()
+    }
+
+    fn open_at(
+        &mut self,
+        descriptor: Resource<Descriptor>,
+        path_flags: PathFlags,
+        path: String,
+        open_flags: OpenFlags,
+        flags: DescriptorFlags,
+    ) -> wasmtime::Result<Result<Resource<Descriptor>, ErrorCode>> {
+        todo!()
+    }
+
+    fn readlink_at(
+        &mut self,
+        descriptor: Resource<Descriptor>,
+        path: String,
+    ) -> wasmtime::Result<Result<String, ErrorCode>> {
+        todo!()
+    }
+
+    fn remove_directory_at(
+        &mut self,
+        descriptor: Resource<Descriptor>,
+        path: String,
+    ) -> wasmtime::Result<Result<(), ErrorCode>> {
+        todo!()
+    }
+
+    fn rename_at(
+        &mut self,
+        descriptor: Resource<Descriptor>,
+        old_path: String,
+        new_descriptor: Resource<Descriptor>,
+        new_path: String,
+    ) -> wasmtime::Result<Result<(), ErrorCode>> {
+        todo!()
+    }
+
+    fn symlink_at(
+        &mut self,
+        descriptor: Resource<Descriptor>,
+        old_path: String,
+        new_path: String,
+    ) -> wasmtime::Result<Result<(), ErrorCode>> {
+        todo!()
+    }
+
+    fn unlink_file_at(
+        &mut self,
+        descriptor: Resource<Descriptor>,
+        path: String,
+    ) -> wasmtime::Result<Result<(), ErrorCode>> {
+        todo!()
+    }
+
+    fn is_same_object(
+        &mut self,
+        descriptor: Resource<Descriptor>,
+        other: Resource<Descriptor>,
+    ) -> wasmtime::Result<bool> {
+        todo!()
+    }
+
+    fn metadata_hash(
+        &mut self,
+        descriptor: Resource<Descriptor>,
+    ) -> wasmtime::Result<Result<MetadataHashValue, ErrorCode>> {
+        todo!()
+    }
+
+    fn metadata_hash_at(
+        &mut self,
+        descriptor: Resource<Descriptor>,
+        path_flags: PathFlags,
+        path: String,
+    ) -> wasmtime::Result<Result<MetadataHashValue, ErrorCode>> {
+        todo!()
+    }
+
+    fn drop(&mut self, rep: Resource<Descriptor>) -> wasmtime::Result<()> {
+        todo!()
+    }
+}
+
+impl<T> preopens::Host for WasiFilesystemImpl<T>
+where
+    T: WasiFilesystemView,
+{
+    fn get_directories(&mut self) -> wasmtime::Result<Vec<(Resource<Descriptor>, String)>> {
+        Ok(vec![])
+    }
+}

--- a/crates/wasi/src/p3/filesystem/mod.rs
+++ b/crates/wasi/src/p3/filesystem/mod.rs
@@ -1,0 +1,105 @@
+use wasmtime::component::{Linker, ResourceTable};
+
+use crate::p3::ResourceView;
+
+mod host;
+
+#[repr(transparent)]
+pub struct WasiFilesystemImpl<T>(pub T);
+
+impl<T: WasiFilesystemView> WasiFilesystemView for &mut T {
+    fn filesystem(&mut self) -> &mut WasiFilesystemCtx {
+        (**self).filesystem()
+    }
+}
+
+impl<T: WasiFilesystemView> WasiFilesystemView for WasiFilesystemImpl<T> {
+    fn filesystem(&mut self) -> &mut WasiFilesystemCtx {
+        self.0.filesystem()
+    }
+}
+
+impl<T: ResourceView> ResourceView for WasiFilesystemImpl<T> {
+    fn table(&mut self) -> &mut ResourceTable {
+        self.0.table()
+    }
+}
+
+pub trait WasiFilesystemView: ResourceView + Send {
+    fn filesystem(&mut self) -> &mut WasiFilesystemCtx;
+}
+
+#[derive(Default)]
+pub struct WasiFilesystemCtx {}
+
+/// Add all WASI interfaces from this module into the `linker` provided.
+///
+/// This function will add the `async` variant of all interfaces into the
+/// [`Linker`] provided. By `async` this means that this function is only
+/// compatible with [`Config::async_support(true)`][async]. For embeddings with
+/// async support disabled see [`add_to_linker_sync`] instead.
+///
+/// This function will add all interfaces implemented by this crate to the
+/// [`Linker`], which corresponds to the `wasi:filesystem/imports` world supported by
+/// this crate.
+///
+/// [async]: wasmtime::Config::async_support
+///
+/// # Example
+///
+/// ```
+/// use wasmtime::{Engine, Result, Store, Config};
+/// use wasmtime::component::{ResourceTable, Linker};
+/// use wasmtime_wasi::p3::filesystem::{WasiFilesystemView, WasiFilesystemCtx};
+/// use wasmtime_wasi::p3::ResourceView;
+///
+/// fn main() -> Result<()> {
+///     let mut config = Config::new();
+///     config.async_support(true);
+///     let engine = Engine::new(&config)?;
+///
+///     let mut linker = Linker::<MyState>::new(&engine);
+///     wasmtime_wasi::p3::filesystem::add_to_linker(&mut linker)?;
+///     // ... add any further functionality to `linker` if desired ...
+///
+///     let mut store = Store::new(
+///         &engine,
+///         MyState {
+///             filesystem: WasiFilesystemCtx::default(),
+///             table: ResourceTable::default(),
+///         },
+///     );
+///
+///     // ... use `linker` to instantiate within `store` ...
+///
+///     Ok(())
+/// }
+///
+/// struct MyState {
+///     filesystem: WasiFilesystemCtx,
+///     table: ResourceTable,
+/// }
+///
+/// impl ResourceView for MyState {
+///     fn table(&mut self) -> &mut ResourceTable { &mut self.table }
+/// }
+///
+/// impl WasiFilesystemView for MyState {
+///     fn filesystem(&mut self) -> &mut WasiFilesystemCtx { &mut self.filesystem }
+/// }
+/// ```
+pub fn add_to_linker<T: WasiFilesystemView + 'static>(
+    linker: &mut Linker<T>,
+) -> wasmtime::Result<()> {
+    let closure = annotate_filesystem(|cx| WasiFilesystemImpl(cx));
+    crate::p3::bindings::filesystem::types::add_to_linker_get_host(linker, closure)?;
+    crate::p3::bindings::filesystem::preopens::add_to_linker_get_host(linker, closure)?;
+    Ok(())
+}
+
+fn annotate_filesystem<T, F>(val: F) -> F
+where
+    F: Fn(&mut T) -> WasiFilesystemImpl<&mut T>,
+{
+    val
+}

--- a/crates/wasi/src/p3/sockets/host/types/tcp.rs
+++ b/crates/wasi/src/p3/sockets/host/types/tcp.rs
@@ -23,6 +23,7 @@ use crate::p3::sockets::util::{
     is_valid_address_family, is_valid_remote_address, is_valid_unicast_address,
 };
 use crate::p3::sockets::{SocketAddrUse, SocketAddressFamily, WasiSocketsImpl, WasiSocketsView};
+use crate::p3::ResourceView as _;
 
 use super::is_addr_allowed;
 

--- a/crates/wasi/src/p3/sockets/host/types/udp.rs
+++ b/crates/wasi/src/p3/sockets/host/types/udp.rs
@@ -8,6 +8,7 @@ use crate::p3::bindings::sockets::types::{
 };
 use crate::p3::sockets::udp::{UdpSocket, MAX_UDP_DATAGRAM_SIZE};
 use crate::p3::sockets::{SocketAddrUse, WasiSocketsImpl, WasiSocketsView};
+use crate::p3::ResourceView as _;
 
 use super::is_addr_allowed;
 

--- a/crates/wasi/tests/all/p3/mod.rs
+++ b/crates/wasi/tests/all/p3/mod.rs
@@ -6,10 +6,12 @@ use wasmtime::Store;
 use wasmtime_wasi::p3::bindings::Command;
 use wasmtime_wasi::p3::cli::{WasiCliCtx, WasiCliView};
 use wasmtime_wasi::p3::clocks::{WasiClocksCtx, WasiClocksView};
+use wasmtime_wasi::p3::filesystem::{WasiFilesystemCtx, WasiFilesystemView};
 use wasmtime_wasi::p3::random::{WasiRandomCtx, WasiRandomView};
 use wasmtime_wasi::p3::sockets::{
     AllowedNetworkUses, SocketAddrCheck, WasiSocketsCtx, WasiSocketsView,
 };
+use wasmtime_wasi::p3::ResourceView;
 use wasmtime_wasi::{IoView, WasiCtx, WasiCtxBuilder, WasiView};
 
 macro_rules! assert_test_exists {
@@ -22,6 +24,7 @@ macro_rules! assert_test_exists {
 struct Ctx {
     cli: WasiCliCtx,
     clocks: WasiClocksCtx,
+    filesystem: WasiFilesystemCtx,
     random: WasiRandomCtx,
     sockets: WasiSocketsCtx,
     table: ResourceTable,
@@ -33,6 +36,7 @@ impl Default for Ctx {
         Self {
             cli: WasiCliCtx::default(),
             clocks: WasiClocksCtx::default(),
+            filesystem: WasiFilesystemCtx::default(),
             sockets: WasiSocketsCtx {
                 socket_addr_check: SocketAddrCheck::new(|_, _| Box::pin(async { true })),
                 allowed_network_uses: AllowedNetworkUses {
@@ -60,6 +64,12 @@ impl IoView for Ctx {
     }
 }
 
+impl ResourceView for Ctx {
+    fn table(&mut self) -> &mut ResourceTable {
+        &mut self.table
+    }
+}
+
 impl WasiCliView for Ctx {
     fn cli(&self) -> &WasiCliCtx {
         &self.cli
@@ -72,6 +82,12 @@ impl WasiClocksView for Ctx {
     }
 }
 
+impl WasiFilesystemView for Ctx {
+    fn filesystem(&mut self) -> &mut WasiFilesystemCtx {
+        &mut self.filesystem
+    }
+}
+
 impl WasiRandomView for Ctx {
     fn random(&mut self) -> &mut WasiRandomCtx {
         &mut self.random
@@ -81,10 +97,6 @@ impl WasiRandomView for Ctx {
 impl WasiSocketsView for Ctx {
     fn sockets(&self) -> &WasiSocketsCtx {
         &self.sockets
-    }
-
-    fn table(&mut self) -> &mut ResourceTable {
-        &mut self.table
     }
 }
 


### PR DESCRIPTION
- Generate `wasi:filesystem` interface stubs
- Add `WasiFilesystem{Ctx,View}`
- Link `wasi:filesystem`
- Introduce `ResourceView` trait (eventually we will have to figure out how to merge this one with `wasmtime_wasi_io::IoView`
- Remove unused `wasi:sockets` helper

Since this PR does not contain any functional changes, I'll merge it as soon as CI passes