### PR TITLE
add a bunch of `wasmtime_environ::fact` comments

### DIFF
--- a/crates/environ/src/fact.rs
+++ b/crates/environ/src/fact.rs
@@ -37,7 +37,7 @@ mod transcode;
 mod traps;
 
 /// Bit flag for indicating async-lifted exports
-/// 
+///
 /// This flag may be passed to the `async-exit` built-in function (which is
 /// called from both async->async and async->sync adapters) to indicate that the
 /// callee is an async-lifted export.

--- a/crates/environ/src/fact.rs
+++ b/crates/environ/src/fact.rs
@@ -36,6 +36,8 @@ mod trampoline;
 mod transcode;
 mod traps;
 
+/// Bit flag for indicating async-lifted exports
+/// 
 /// This flag may be passed to the `async-exit` built-in function (which is
 /// called from both async->async and async->sync adapters) to indicate that the
 /// callee is an async-lifted export.

--- a/crates/environ/src/fact/signature.rs
+++ b/crates/environ/src/fact/signature.rs
@@ -27,8 +27,9 @@ impl ComponentTypesBuilder {
         let ptr_ty = options.options.ptr();
 
         // The async lower ABI is always `(param i32 i32) (result i32)` (for
-        // wasm32, anyway), regardless of the component-level signature.  The
-        // first param is a pointer to linear memory where the parameters have
+        // wasm32, anyway), regardless of the component-level signature.  
+        //
+        // The first param is a pointer to linear memory where the parameters have
         // been stored by the caller, the second param is a pointer to linear
         // memory where the results should be stored by the callee, and the
         // result is a status code optionally ORed with a subtask ID.

--- a/crates/environ/src/fact/signature.rs
+++ b/crates/environ/src/fact/signature.rs
@@ -27,7 +27,7 @@ impl ComponentTypesBuilder {
         let ptr_ty = options.options.ptr();
 
         // The async lower ABI is always `(param i32 i32) (result i32)` (for
-        // wasm32, anyway), regardless of the component-level signature.  
+        // wasm32, anyway), regardless of the component-level signature.
         //
         // The first param is a pointer to linear memory where the parameters have
         // been stored by the caller, the second param is a pointer to linear
@@ -55,10 +55,10 @@ impl ComponentTypesBuilder {
 
         // If we're lifting async with a callback, the result is an `i32` status
         // code, optionally ORed with a guest task identifier, and the result
-        // will be returned via `task.return`.  
-        // 
-        // If we're lifting async without a callback, then there's no need to return 
-        // anything here since the result will be returned via `task.return` and the 
+        // will be returned via `task.return`.
+        //
+        // If we're lifting async without a callback, then there's no need to return
+        // anything here since the result will be returned via `task.return` and the
         // guest will use `task.wait` rather than return a status code in order to suspend
         // itself, if necessary.
         if options.options.async_ {

--- a/crates/environ/src/fact/signature.rs
+++ b/crates/environ/src/fact/signature.rs
@@ -55,10 +55,11 @@ impl ComponentTypesBuilder {
 
         // If we're lifting async with a callback, the result is an `i32` status
         // code, optionally ORed with a guest task identifier, and the result
-        // will be returned via `task.return`.  If we're lifting async without a
-        // callback, then there's no need to return anything here since the
-        // result will be returned via `task.return` and the guest will use
-        // `task.wait` rather than return a status code in order to suspend
+        // will be returned via `task.return`.  
+        // 
+        // If we're lifting async without a callback, then there's no need to return 
+        // anything here since the result will be returned via `task.return` and the 
+        // guest will use `task.wait` rather than return a status code in order to suspend
         // itself, if necessary.
         if options.options.async_ {
             return Signature {

--- a/crates/environ/src/fact/trampoline.rs
+++ b/crates/environ/src/fact/trampoline.rs
@@ -666,7 +666,9 @@ impl<'a, 'b> Compiler<'a, 'b> {
         // Note that we pass `param_locals` as _both_ the `param_locals` and
         // `result_locals` parameters to `translate_results`.  That's because
         // the _parameters_ to `task.return` are actually the _results_ that the
-        // caller is waiting for.  Additionally, the host will append a return
+        // caller is waiting for.  
+        //
+        // Additionally, the host will append a return
         // pointer to the end of that list before calling this adapter's
         // `async-return` function if the results exceed `MAX_FLAT_RESULTS` or
         // the import is lowered async, in which case `translate_results` will

--- a/crates/environ/src/fact/trampoline.rs
+++ b/crates/environ/src/fact/trampoline.rs
@@ -666,7 +666,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
         // Note that we pass `param_locals` as _both_ the `param_locals` and
         // `result_locals` parameters to `translate_results`.  That's because
         // the _parameters_ to `task.return` are actually the _results_ that the
-        // caller is waiting for.  
+        // caller is waiting for.
         //
         // Additionally, the host will append a return
         // pointer to the end of that list before calling this adapter's


### PR DESCRIPTION
...and make a constant public so we can reuse it in the `wasmtime` crate.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
