### PR TITLE
reuse `wasmtime_environ::fast::EXIT_FLAG_ASYNC_CALLEE` in concurrent.rs

### DIFF
--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -37,10 +37,13 @@ use {
         vec::Vec,
     },
     table::{Table, TableId},
-    wasmtime_environ::component::{
-        InterfaceType, RuntimeComponentInstanceIndex, StringEncoding,
-        TypeComponentLocalErrorContextTableIndex, TypeFutureTableIndex, TypeStreamTableIndex,
-        TypeTupleIndex, MAX_FLAT_PARAMS, MAX_FLAT_RESULTS,
+    wasmtime_environ::{
+        component::{
+            InterfaceType, RuntimeComponentInstanceIndex, StringEncoding,
+            TypeComponentLocalErrorContextTableIndex, TypeFutureTableIndex, TypeStreamTableIndex,
+            TypeTupleIndex, MAX_FLAT_PARAMS, MAX_FLAT_RESULTS,
+        },
+        fact,
     },
     wasmtime_fiber::{Fiber, Suspend},
 };
@@ -81,7 +84,7 @@ enum Event {
     FutureWrite,
 }
 
-const EXIT_FLAG_ASYNC_CALLEE: u32 = 1 << 0;
+const EXIT_FLAG_ASYNC_CALLEE: u32 = fact::EXIT_FLAG_ASYNC_CALLEE as u32;
 
 /// Represents the result of a concurrent operation.
 ///


### PR DESCRIPTION
I meant to include this in an earlier commit, but lost track of it.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
