### PR TITLE
report whether read end was closed on write to stream/future

### DIFF
--- a/crates/misc/component-async-tests/src/closed_streams.rs
+++ b/crates/misc/component-async-tests/src/closed_streams.rs
@@ -1,0 +1,14 @@
+pub mod bindings {
+    wasmtime::component::bindgen!({
+        path: "wit",
+        world: "closed-streams",
+        concurrent_imports: true,
+        concurrent_exports: true,
+        async: {
+            only_imports: [
+                "local:local/closed#read-stream",
+                "local:local/closed#read-future",
+            ]
+        },
+    });
+}

--- a/crates/misc/component-async-tests/src/lib.rs
+++ b/crates/misc/component-async-tests/src/lib.rs
@@ -5,6 +5,7 @@ use wasmtime::component::ResourceTable;
 use wasmtime_wasi::{IoView, WasiCtx, WasiView};
 
 pub mod borrowing_host;
+pub mod closed_streams;
 pub mod proxy;
 pub mod resource_stream;
 pub mod round_trip;

--- a/crates/misc/component-async-tests/src/resource_stream.rs
+++ b/crates/misc/component-async-tests/src/resource_stream.rs
@@ -56,7 +56,8 @@ impl bindings::local::local::resource_stream::Host for &mut Ctx {
                                 tx.write(view.as_context_mut(), vec![item])?.into_future(),
                             )
                         })?
-                        .await;
+                        .await
+                        .unwrap();
                 }
                 accessor.with(|mut view| tx.close(view.as_context_mut()))
             }

--- a/crates/misc/component-async-tests/tests/scenario/mod.rs
+++ b/crates/misc/component-async-tests/tests/scenario/mod.rs
@@ -7,6 +7,7 @@ pub mod read_resource_stream;
 pub mod round_trip;
 pub mod round_trip_direct;
 pub mod round_trip_many;
+pub mod streams;
 pub mod transmit;
 pub mod unit_stream;
 pub mod yield_;

--- a/crates/misc/component-async-tests/tests/scenario/streams.rs
+++ b/crates/misc/component-async-tests/tests/scenario/streams.rs
@@ -1,0 +1,221 @@
+use {
+    anyhow::Result,
+    component_async_tests::{closed_streams, Ctx},
+    std::sync::{Arc, Mutex},
+    tokio::fs,
+    wasmtime::{
+        component::{
+            self, Component, ErrorContext, Linker, PromisesUnordered, ResourceTable, StreamReader,
+            StreamWriter,
+        },
+        Config, Engine, Store,
+    },
+    wasmtime_wasi::WasiCtxBuilder,
+};
+
+#[tokio::test]
+pub async fn async_closed_streams() -> Result<()> {
+    let mut config = Config::new();
+    config.debug_info(true);
+    config.cranelift_debug_verifier(true);
+    config.wasm_component_model(true);
+    config.wasm_component_model_async(true);
+    config.async_support(true);
+
+    let engine = Engine::new(&config)?;
+
+    let mut store = Store::new(
+        &engine,
+        Ctx {
+            wasi: WasiCtxBuilder::new().inherit_stdio().build(),
+            table: ResourceTable::default(),
+            continue_: false,
+            wakers: Arc::new(Mutex::new(None)),
+        },
+    );
+
+    let mut linker = Linker::new(&engine);
+
+    wasmtime_wasi::add_to_linker_async(&mut linker)?;
+
+    let component = Component::new(
+        &engine,
+        &fs::read(test_programs_artifacts::ASYNC_CLOSED_STREAMS_COMPONENT).await?,
+    )?;
+
+    let closed_streams =
+        closed_streams::bindings::ClosedStreams::instantiate_async(&mut store, &component, &linker)
+            .await?;
+
+    enum StreamEvent {
+        FirstWrite(Option<StreamWriter<u8>>),
+        FirstRead(Option<(StreamReader<u8>, Vec<u8>)>),
+        SecondWrite(Option<StreamWriter<u8>>),
+        GuestCompleted,
+    }
+
+    enum FutureEvent {
+        Write(bool),
+        Read(Option<Result<u8, ErrorContext>>),
+        WriteIgnored(bool),
+        GuestCompleted,
+    }
+
+    let values = vec![42_u8, 43, 44];
+
+    let value = 42_u8;
+
+    // First, test stream host->host
+    {
+        let (tx, rx) = component::stream(&mut store)?;
+
+        let mut promises = PromisesUnordered::new();
+        promises.push(
+            tx.write(&mut store, values.clone())?
+                .map(StreamEvent::FirstWrite),
+        );
+        promises.push(rx.read(&mut store)?.map(StreamEvent::FirstRead));
+
+        let mut count = 0;
+        while let Some(event) = promises.next(&mut store).await? {
+            count += 1;
+            match event {
+                StreamEvent::FirstWrite(Some(tx)) => {
+                    promises.push(
+                        tx.write(&mut store, values.clone())?
+                            .map(StreamEvent::SecondWrite),
+                    );
+                }
+                StreamEvent::FirstWrite(None) => panic!("first write should have been accepted"),
+                StreamEvent::FirstRead(Some((rx, results))) => {
+                    assert_eq!(values, results);
+                    rx.close(&mut store)?;
+                }
+                StreamEvent::FirstRead(None) => unreachable!(),
+                StreamEvent::SecondWrite(None) => {}
+                StreamEvent::SecondWrite(Some(_)) => {
+                    panic!("second write should _not_ have been accepted")
+                }
+                StreamEvent::GuestCompleted => unreachable!(),
+            }
+        }
+
+        assert_eq!(count, 3);
+    }
+
+    // Next, test futures host->host
+    {
+        let (tx, rx) = component::future(&mut store)?;
+        let (tx_ignored, rx_ignored) = component::future(&mut store)?;
+
+        let mut promises = PromisesUnordered::new();
+        promises.push(tx.write(&mut store, value)?.map(FutureEvent::Write));
+        promises.push(rx.read(&mut store)?.map(FutureEvent::Read));
+        promises.push(
+            tx_ignored
+                .write(&mut store, value)?
+                .map(FutureEvent::WriteIgnored),
+        );
+        rx_ignored.close(&mut store)?;
+
+        let mut count = 0;
+        while let Some(event) = promises.next(&mut store).await? {
+            count += 1;
+            match event {
+                FutureEvent::Write(delivered) => {
+                    assert!(delivered);
+                }
+                FutureEvent::Read(Some(Ok(result))) => {
+                    assert_eq!(value, result);
+                }
+                FutureEvent::Read(_) => panic!("read should have succeeded"),
+                FutureEvent::WriteIgnored(delivered) => {
+                    assert!(!delivered);
+                }
+                FutureEvent::GuestCompleted => unreachable!(),
+            }
+        }
+
+        assert_eq!(count, 3);
+    }
+
+    // Next, test stream host->guest
+    {
+        let (tx, rx) = component::stream(&mut store)?;
+
+        let mut promises = PromisesUnordered::new();
+        promises.push(
+            closed_streams
+                .local_local_closed()
+                .call_read_stream(&mut store, rx, values.clone())
+                .await?
+                .map(|()| StreamEvent::GuestCompleted),
+        );
+        promises.push(
+            tx.write(&mut store, values.clone())?
+                .map(StreamEvent::FirstWrite),
+        );
+
+        let mut count = 0;
+        while let Some(event) = promises.next(&mut store).await? {
+            count += 1;
+            match event {
+                StreamEvent::FirstWrite(Some(tx)) => {
+                    promises.push(
+                        tx.write(&mut store, values.clone())?
+                            .map(StreamEvent::SecondWrite),
+                    );
+                }
+                StreamEvent::FirstWrite(None) => panic!("first write should have been accepted"),
+                StreamEvent::FirstRead(_) => unreachable!(),
+                StreamEvent::SecondWrite(None) => {}
+                StreamEvent::SecondWrite(Some(_)) => {
+                    panic!("second write should _not_ have been accepted")
+                }
+                StreamEvent::GuestCompleted => {}
+            }
+        }
+
+        assert_eq!(count, 3);
+    }
+
+    // Next, test futures host->guest
+    {
+        let (tx, rx) = component::future(&mut store)?;
+        let (tx_ignored, rx_ignored) = component::future(&mut store)?;
+
+        let mut promises = PromisesUnordered::new();
+        promises.push(
+            closed_streams
+                .local_local_closed()
+                .call_read_future(&mut store, rx, value, rx_ignored)
+                .await?
+                .map(|()| FutureEvent::GuestCompleted),
+        );
+        promises.push(tx.write(&mut store, value)?.map(FutureEvent::Write));
+        promises.push(
+            tx_ignored
+                .write(&mut store, value)?
+                .map(FutureEvent::WriteIgnored),
+        );
+
+        let mut count = 0;
+        while let Some(event) = promises.next(&mut store).await? {
+            count += 1;
+            match event {
+                FutureEvent::Write(delivered) => {
+                    assert!(delivered);
+                }
+                FutureEvent::Read(_) => unreachable!(),
+                FutureEvent::WriteIgnored(delivered) => {
+                    assert!(!delivered);
+                }
+                FutureEvent::GuestCompleted => {}
+            }
+        }
+
+        assert_eq!(count, 3);
+    }
+
+    Ok(())
+}

--- a/crates/misc/component-async-tests/tests/test_all.rs
+++ b/crates/misc/component-async-tests/tests/test_all.rs
@@ -30,6 +30,7 @@ use scenario::round_trip_many::{
     async_round_trip_many_stackful, async_round_trip_many_stackless,
     async_round_trip_many_synchronous, async_round_trip_many_wait,
 };
+use scenario::streams::async_closed_streams;
 use scenario::transmit::{async_poll, async_transmit_callee, async_transmit_caller};
 use scenario::unit_stream::{async_unit_stream_callee, async_unit_stream_caller};
 use scenario::yield_::{async_yield_callee, async_yield_caller};

--- a/crates/misc/component-async-tests/wit/test.wit
+++ b/crates/misc/component-async-tests/wit/test.wit
@@ -121,6 +121,11 @@ interface resource-stream {
   foo: func(count: u32) -> stream<x>;
 }
 
+interface closed {
+  read-stream: func(rx: stream<u8>, expected: list<u8>);
+  read-future: func(rx: future<u8>, expected: u8, rx-ignore: future<u8>);
+}
+
 world yield-caller {
   import continue;
   import ready;
@@ -235,3 +240,8 @@ world read-resource-stream {
   import resource-stream;
   export run;
 }
+
+world closed-streams {
+  export closed;
+}
+

--- a/crates/test-programs/src/bin/async_closed_streams.rs
+++ b/crates/test-programs/src/bin/async_closed_streams.rs
@@ -1,0 +1,30 @@
+mod bindings {
+    wit_bindgen::generate!({
+        path: "../misc/component-async-tests/wit",
+        world: "closed-streams",
+        async: true,
+    });
+
+    use super::Component;
+    export!(Component);
+}
+
+use {
+    bindings::exports::local::local::closed::Guest,
+    wit_bindgen_rt::async_support::{futures::StreamExt, FutureReader, StreamReader},
+};
+
+struct Component;
+
+impl Guest for Component {
+    async fn read_stream(mut rx: StreamReader<u8>, expected: Vec<u8>) {
+        assert_eq!(rx.next().await.unwrap().unwrap(), expected);
+    }
+
+    async fn read_future(rx: FutureReader<u8>, expected: u8, _rx_ignored: FutureReader<u8>) {
+        assert_eq!(rx.await.unwrap().unwrap(), expected);
+    }
+}
+
+// Unused function; required since this file is built as a `bin`:
+fn main() {}

--- a/crates/test-programs/src/bin/async_http_echo.rs
+++ b/crates/test-programs/src/bin/async_http_echo.rs
@@ -50,15 +50,13 @@ impl Handler for Component {
 
                 drop(pipe_tx);
 
-                let trailers = Body::finish(body);
-                trailers_tx
-                    .write(
-                        trailers
-                            .await
-                            .expect("trailers be present")
-                            .expect("stream not closed early w/ error"),
-                    )
-                    .await;
+                if let Some(trailers) = Body::finish(body)
+                    .await
+                    .transpose()
+                    .expect("stream not closed early w/ error")
+                {
+                    trailers_tx.write(trailers).await;
+                }
             });
 
             Ok(Response::new(

--- a/crates/test-programs/src/bin/async_http_middleware.rs
+++ b/crates/test-programs/src/bin/async_http_middleware.rs
@@ -84,15 +84,13 @@ impl Handler for Component {
                     drop(pipe_tx);
                 }
 
-                let trailers = Body::finish(body);
-                trailers_tx
-                    .write(
-                        trailers
-                            .await
-                            .expect("trailers present")
-                            .expect("stream not closed early w/ error"),
-                    )
-                    .await;
+                if let Some(trailers) = Body::finish(body)
+                    .await
+                    .transpose()
+                    .expect("stream not closed early w/ error")
+                {
+                    trailers_tx.write(trailers).await;
+                }
             });
 
             Body::new_with_trailers(pipe_rx, trailers_rx)
@@ -143,15 +141,13 @@ impl Handler for Component {
                     drop(pipe_tx);
                 }
 
-                let trailers = Body::finish(body);
-                trailers_tx
-                    .write(
-                        trailers
-                            .await
-                            .expect("trailers present")
-                            .expect("stream not closed early w/ error"),
-                    )
-                    .await;
+                if let Some(trailers) = Body::finish(body)
+                    .await
+                    .transpose()
+                    .expect("stream not closed early w/ error")
+                {
+                    trailers_tx.write(trailers).await;
+                }
             });
 
             Body::new_with_trailers(pipe_rx, trailers_rx)


### PR DESCRIPTION
This changes the return types of `{Future|Stream}Writer::write` to report whether the read end was closed before all values were delivered.  In the case of `StreamWriter`, it also auto-closes the write end if the read end was closed.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
