### PR TITLE
refactor host stream/future APIs

### DIFF
--- a/crates/wasi/src/p3/cli/host.rs
+++ b/crates/wasi/src/p3/cli/host.rs
@@ -70,7 +70,7 @@ impl<T> stdin::Host for WasiCliImpl<T>
 where
     T: WasiCliView,
 {
-    fn get_stdin(&mut self) -> wasmtime::Result<wasmtime::component::StreamReader<u8>> {
+    fn get_stdin(&mut self) -> wasmtime::Result<wasmtime::component::HostStream<u8>> {
         todo!()
     }
 }
@@ -79,7 +79,7 @@ impl<T> stdout::Host for WasiCliImpl<T>
 where
     T: WasiCliView,
 {
-    fn set_stdout(&mut self, data: wasmtime::component::StreamReader<u8>) -> wasmtime::Result<()> {
+    fn set_stdout(&mut self, data: wasmtime::component::HostStream<u8>) -> wasmtime::Result<()> {
         todo!()
     }
 }
@@ -88,7 +88,7 @@ impl<T> stderr::Host for WasiCliImpl<T>
 where
     T: WasiCliView,
 {
-    fn set_stderr(&mut self, data: wasmtime::component::StreamReader<u8>) -> wasmtime::Result<()> {
+    fn set_stderr(&mut self, data: wasmtime::component::HostStream<u8>) -> wasmtime::Result<()> {
         todo!()
     }
 }

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -385,6 +385,7 @@ component-model-async = [
   "async",
   "component-model",
   "std",
+  "futures/std",
   "wasmtime-environ/compile",
   "wasmtime-component-macro?/component-model-async",
   "dep:futures"

--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -49,7 +49,8 @@ use {
 };
 
 pub use futures_and_streams::{
-    future, stream, ErrorContext, FutureReader, FutureWriter, StreamReader, StreamWriter,
+    future, stream, ErrorContext, FutureReader, FutureWriter, HostFuture, HostStream, StreamReader,
+    StreamWriter,
 };
 use futures_and_streams::{FlatAbi, TableIndex, TransmitState};
 

--- a/crates/wasmtime/src/runtime/component/mod.rs
+++ b/crates/wasmtime/src/runtime/component/mod.rs
@@ -117,7 +117,8 @@ pub use self::component::{Component, ComponentExportIndex};
 #[cfg(feature = "component-model-async")]
 pub use self::concurrent::{
     future, stream, AbortOnDropHandle, Accessor, AccessorTask, ErrorContext, FutureReader,
-    FutureWriter, Promise, PromisesUnordered, StreamReader, StreamWriter, VMComponentAsyncStore,
+    FutureWriter, HostFuture, HostStream, Promise, PromisesUnordered, StreamReader, StreamWriter,
+    VMComponentAsyncStore,
 };
 pub use self::func::{
     ComponentNamedList, ComponentType, Func, Lift, Lower, TypedFunc, WasmList, WasmStr,
@@ -784,11 +785,11 @@ pub(crate) mod concurrent {
         }
     }
 
-    pub struct StreamReader<P> {
+    pub struct HostStream<P> {
         _phantom: PhantomData<P>,
     }
 
-    impl<P> StreamReader<P> {
+    impl<P> HostStream<P> {
         pub(crate) fn new(_rep: u32) -> Self {
             unreachable!()
         }
@@ -832,11 +833,11 @@ pub(crate) mod concurrent {
         }
     }
 
-    pub struct FutureReader<P> {
+    pub struct HostFuture<P> {
         _phantom: PhantomData<P>,
     }
 
-    impl<P> FutureReader<P> {
+    impl<P> HostFuture<P> {
         pub(crate) fn new(_rep: u32) -> Self {
             unreachable!()
         }

--- a/crates/wit-bindgen/src/rust.rs
+++ b/crates/wit-bindgen/src/rust.rs
@@ -166,12 +166,12 @@ pub trait RustGenerator<'a> {
                 panic!("unsupported anonymous type reference: enum")
             }
             TypeDefKind::Future(ty) => {
-                self.push_str("wasmtime::component::FutureReader<");
+                self.push_str("wasmtime::component::HostFuture<");
                 self.print_optional_ty(ty.as_ref(), TypeMode::Owned);
                 self.push_str(">");
             }
             TypeDefKind::Stream(ty) => {
-                self.push_str("wasmtime::component::StreamReader<");
+                self.push_str("wasmtime::component::HostStream<");
                 self.print_optional_ty(ty.as_ref(), TypeMode::Owned);
                 self.push_str(">");
             }
@@ -226,14 +226,14 @@ pub trait RustGenerator<'a> {
 
     fn print_stream(&mut self, ty: Option<&Type>) {
         let wt = self.wasmtime_path();
-        self.push_str(&format!("{wt}::component::StreamReader<"));
+        self.push_str(&format!("{wt}::component::HostStream<"));
         self.print_optional_ty(ty, TypeMode::Owned);
         self.push_str(">");
     }
 
     fn print_future(&mut self, ty: Option<&Type>) {
         let wt = self.wasmtime_path();
-        self.push_str(&format!("{wt}::component::FutureReader<"));
+        self.push_str(&format!("{wt}::component::HostFuture<"));
         self.print_optional_ty(ty, TypeMode::Owned);
         self.push_str(">");
     }


### PR DESCRIPTION
This adds close-on-drop functionality to `{Stream|Future}{Writer|Reader}` and support for reading and writing without a `StoreContextMut`.  Both of those features are enabled by spawning background tasks which do the actual reading, writing, and closing.

I've also tweaked the return types for `{Stream|Future}Reader` to reduce nesting and reflect every possible outcome:
- Value(s) were read
- Write end closed with error before value(s) could be read
- Write end closed without error before value(s) could be read (streams only)
- Guest trapped before value(s) could be read (streams or futures)

Note that this introduces new `Host{Stream|Future}` types representing a stream or future which has either just been lifted from the guest or is about to be lowered to a guest.  These can be converted into `{Stream|Future}Reader`s via the `into_reader` method, which requires a `StoreContextMut` in order to spawn the background task mentioned above.  Ideally, we would support lifting and lowering `{Stream|Future}Reader`s directly, in which case we could eliminate the `Host{Stream|Future}` types, but we don't currently have access to a `StoreContextMut` when lifting with a `LiftContext`, and it's not clear how to work around that without some major refactoring.

Fixes #28

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
