### PR TITLE
add `watch_{reader|writer}` to `{Stream|Future}{Writer|Reader}`

### DIFF
--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -122,6 +122,11 @@ impl<T: Send + Sync + 'static> Promise<T> {
     pub fn into_future(self) -> Pin<Box<dyn Future<Output = T> + Send + Sync + 'static>> {
         self.0
     }
+
+    /// Wrap the specified `Future` in a `Promise`.
+    pub fn from(fut: impl Future<Output = T> + Send + Sync + 'static) -> Self {
+        Self(Box::pin(fut))
+    }
 }
 
 /// Represents a collection of zero or more concurrent operations.


### PR DESCRIPTION
These methods allow the caller to wait for the other end to be closed.  This can be useful in the case where the owner of the write end needs to `await` input from some other source before it can write, in which case it may want to select over both the input future and the future returned by `watch_reader`, canceling the former if the reader is closed.

Note that `watch_{reader|writer}` takes `self` by value and returns a `Watch<Self>` which can be converted back into a `Self` at any time using `Watch::into_inner`.  Continuing the example above: if the input future yields a value before the read end is closed, then the writer can call `Watch::into_inner` to get the `StreamWriter` back and call `StreamWriter::write` on it, then loop around again to read more input.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
