### PR TITLE
fix async_http_middleware.rs test program

### DIFF
--- a/crates/misc/component-async-tests/tests/scenario/proxy.rs
+++ b/crates/misc/component-async-tests/tests/scenario/proxy.rs
@@ -123,7 +123,10 @@ async fn test_http_echo(component: &[u8], use_compression: bool) -> Result<()> {
                 .chain(if use_compression {
                     vec![
                         ("content-encoding".into(), b"deflate".into()),
-                        ("accept-encoding".into(), b"deflate".into()),
+                        (
+                            "accept-encoding".into(),
+                            b"nonexistent-encoding, deflate".into(),
+                        ),
                     ]
                 } else {
                     Vec::new()
@@ -169,6 +172,11 @@ async fn test_http_echo(component: &[u8], use_compression: bool) -> Result<()> {
                         (k.as_str(), v.as_slice()),
                         ("content-encoding", b"deflate")
                     )));
+                    assert!(response
+                        .headers
+                        .0
+                        .iter()
+                        .all(|(k, _)| k.as_str() != "content-length"));
                 }
 
                 response_trailers = response.body.trailers.take();


### PR DESCRIPTION
This fixes two issues I noticed when testing the program via the network using cURL:

- Should send a compressed body if `accept-encoding` contains `deflate` (but might contain other options as well)

- Unset the `content-length` header when compressing the body since the compressed body size will probably differ.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
