### PR TITLE
fix `Watch::into_inner` backpressure and add test case

### DIFF
--- a/crates/wasmtime/src/runtime/component/mod.rs
+++ b/crates/wasmtime/src/runtime/component/mod.rs
@@ -116,7 +116,7 @@ mod values;
 pub use self::component::{Component, ComponentExportIndex};
 #[cfg(feature = "component-model-async")]
 pub use self::concurrent::{
-    future, stream, AbortOnDropHandle, Accessor, AccessorTask, ErrorContext, FutureReader,
+    future, get, stream, AbortOnDropHandle, Accessor, AccessorTask, ErrorContext, FutureReader,
     FutureWriter, HostFuture, HostStream, Promise, PromisesUnordered, StreamReader, StreamWriter,
     VMComponentAsyncStore,
 };


### PR DESCRIPTION
Previously, `Watch::into_inner` was a non-`async` function, which meant you could call e.g. `StreamWriter::watch_reader` and immediately convert the returned `Watch<StreamWriter<T>>` back into a `StreamWriter<T>` and try to write to it again, which would panic since the channel it uses to send messages to the background task only has a capacity of one.  This commit makes `Watch::into_inner` an `async` function which applies backpressure by only yielding a value once the channel is ready.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
