### PR TITLE
feat(wasmtime-cli): enable async CM feature

### DIFF
--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -95,6 +95,7 @@ impl RunCommand {
 
         let mut config = self.run.common.config(None)?;
         config.async_support(true);
+        config.wasm_component_model_async(true);
 
         if self.run.common.wasm.timeout.is_some() {
             config.epoch_interruption(true);


### PR DESCRIPTION
With this I was able to run:
```rust
mod bindings {
    wit_bindgen::generate!({
        world: "wasi:cli/command",
        async: {
            exports: [
                "wasi:cli/run@0.3.0#run",
            ],
        },
        generate_all,
    });

    use super::Component;

    export!(Component);
}

use bindings::wit_stream;
use futures::SinkExt as _;

struct Component;

impl bindings::exports::wasi::cli::run::Guest for Component {
    async fn run() -> Result<(), ()> {
        let (mut tx, rx) = wit_stream::new();
        bindings::wasi::cli::stdout::set_stdout(rx);
        tx.send(b"hello".into())
            .await
            .expect("failed to write to STDOUT");
        Ok(())
    }
}
```

built via:
```
$ cargo build --target wasm32-unknown-unknown --release
$ wasm-tools component new --skip-validation  ./target/wasm32-unknown-unknown/release/p3_cli.wasm -o component.wasm
```

Using the `wasmtime` binary built from this commit