### PR TITLE
generic buffer types for `Stream{Writer|Reader}`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -634,6 +634,7 @@ name = "component-async-tests"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "bytes",
  "flate2",
  "futures",
  "pretty_env_logger",
@@ -4024,6 +4025,7 @@ name = "wasi-http-draft"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bytes",
  "futures",
  "wasmtime",
 ]
@@ -4284,6 +4286,7 @@ dependencies = [
  "async-trait",
  "bitflags 2.6.0",
  "bumpalo",
+ "bytes",
  "cc",
  "cfg-if",
  "cranelift-native",

--- a/crates/misc/component-async-tests/Cargo.toml
+++ b/crates/misc/component-async-tests/Cargo.toml
@@ -28,3 +28,4 @@ wasmtime-wasi = { workspace = true }
 
 [dev-dependencies]
 test-programs-artifacts = { workspace = true }
+bytes = { workspace = true }

--- a/crates/misc/component-async-tests/http/Cargo.toml
+++ b/crates/misc/component-async-tests/http/Cargo.toml
@@ -8,3 +8,4 @@ publish = false
 anyhow = { workspace = true }
 futures = { workspace = true }
 wasmtime = { workspace = true, features = ["component-model-async"] }
+bytes = { workspace = true }

--- a/crates/misc/component-async-tests/http/src/lib.rs
+++ b/crates/misc/component-async-tests/http/src/lib.rs
@@ -27,6 +27,7 @@ wasmtime::component::bindgen!({
 
 use {
     anyhow::anyhow,
+    bytes::Bytes,
     std::{fmt, future::Future, mem},
     wasi::http::types::{ErrorCode, HeaderError, Method, RequestOptionsError, Scheme},
     wasmtime::component::{
@@ -106,7 +107,7 @@ impl<T: WasiHttpView> WasiHttpView for WasiHttpImpl<T> {
 }
 
 pub struct Body {
-    pub stream: Option<StreamReader<u8>>,
+    pub stream: Option<StreamReader<Bytes>>,
     pub trailers: Option<FutureReader<Resource<Fields>>>,
 }
 

--- a/crates/misc/component-async-tests/src/resource_stream.rs
+++ b/crates/misc/component-async-tests/src/resource_stream.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use wasmtime::component::{Accessor, AccessorTask, HostStream, Resource, StreamWriter};
+use wasmtime::component::{Accessor, AccessorTask, HostStream, Resource, Single, StreamWriter};
 use wasmtime_wasi::IoView;
 
 use super::Ctx;
@@ -40,7 +40,7 @@ impl bindings::local::local::resource_stream::Host for &mut Ctx {
         count: u32,
     ) -> wasmtime::Result<HostStream<Resource<ResourceStreamX>>> {
         struct Task {
-            tx: StreamWriter<Resource<ResourceStreamX>>,
+            tx: StreamWriter<Single<Resource<ResourceStreamX>>>,
             count: u32,
         }
 
@@ -52,7 +52,7 @@ impl bindings::local::local::resource_stream::Host for &mut Ctx {
                         .with(|mut view| {
                             let item = IoView::table(&mut *view).push(ResourceStreamX)?;
                             Ok::<_, anyhow::Error>(
-                                tx.take().unwrap().write(vec![item]).into_future(),
+                                tx.take().unwrap().write(Single(item)).into_future(),
                             )
                         })?
                         .await;

--- a/crates/wasi/src/p3/cli/host.rs
+++ b/crates/wasi/src/p3/cli/host.rs
@@ -13,7 +13,7 @@ use crate::p3::ResourceView as _;
 
 struct InputTask<T> {
     input: T,
-    tx: StreamWriter<u8>,
+    tx: StreamWriter<Vec<u8>>,
 }
 
 impl<T, U, V> AccessorTask<T, U, wasmtime::Result<()>> for InputTask<V>
@@ -45,7 +45,7 @@ where
 
 struct OutputTask<T> {
     output: T,
-    data: StreamReader<u8>,
+    data: StreamReader<Vec<u8>>,
 }
 
 impl<T, U, V> AccessorTask<T, U, wasmtime::Result<()>> for OutputTask<V>

--- a/crates/wasi/src/p3/filesystem/host.rs
+++ b/crates/wasi/src/p3/filesystem/host.rs
@@ -140,7 +140,7 @@ where
         mut offset: Filesize,
     ) -> wasmtime::Result<Result<(), ErrorCode>> {
         let (fd, fut) = store.with(|mut view| {
-            let data = data.into_reader(&mut view);
+            let data = data.into_reader::<Vec<u8>, _, _>(&mut view);
             let fut = data.read();
             let fd = get_descriptor(view.table(), &fd)?;
             anyhow::Ok((fd.clone(), fut))
@@ -185,7 +185,7 @@ where
         data: HostStream<u8>,
     ) -> wasmtime::Result<Result<(), ErrorCode>> {
         let (fd, fut) = store.with(|mut view| {
-            let data = data.into_reader(&mut view);
+            let data = data.into_reader::<Vec<u8>, _, _>(&mut view);
             let fut = data.read();
             let fd = get_descriptor(view.table(), &fd)?;
             anyhow::Ok((fd.clone(), fut))

--- a/crates/wasi/src/p3/mod.rs
+++ b/crates/wasi/src/p3/mod.rs
@@ -152,7 +152,7 @@ where
 }
 
 pub struct IoTask<T, E> {
-    pub data: StreamWriter<T>,
+    pub data: StreamWriter<Vec<T>>,
     pub result: FutureWriter<Result<(), E>>,
     pub rx: mpsc::Receiver<Result<Vec<T>, E>>,
 }

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -63,6 +63,7 @@ smallvec = { workspace = true, optional = true }
 hashbrown = { workspace = true, features = ["default-hasher"] }
 bitflags = { workspace = true }
 futures = { workspace = true, features = ["alloc"], optional = true }
+bytes = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies.windows-sys]
 workspace = true
@@ -388,5 +389,6 @@ component-model-async = [
   "futures/std",
   "wasmtime-environ/compile",
   "wasmtime-component-macro?/component-model-async",
-  "dep:futures"
+  "dep:futures",
+  "dep:bytes",
 ]

--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -49,8 +49,8 @@ use {
 };
 
 pub use futures_and_streams::{
-    future, stream, ErrorContext, FutureReader, FutureWriter, HostFuture, HostStream, StreamReader,
-    StreamWriter,
+    future, stream, ErrorContext, FutureReader, FutureWriter, HostFuture, HostStream, Single,
+    StreamReader, StreamWriter,
 };
 use futures_and_streams::{FlatAbi, TableIndex, TransmitState};
 

--- a/crates/wasmtime/src/runtime/component/mod.rs
+++ b/crates/wasmtime/src/runtime/component/mod.rs
@@ -117,8 +117,8 @@ pub use self::component::{Component, ComponentExportIndex};
 #[cfg(feature = "component-model-async")]
 pub use self::concurrent::{
     future, get, stream, AbortOnDropHandle, Accessor, AccessorTask, ErrorContext, FutureReader,
-    FutureWriter, HostFuture, HostStream, Promise, PromisesUnordered, StreamReader, StreamWriter,
-    VMComponentAsyncStore,
+    FutureWriter, HostFuture, HostStream, Promise, PromisesUnordered, Single, StreamReader,
+    StreamWriter, VMComponentAsyncStore,
 };
 pub use self::func::{
     ComponentNamedList, ComponentType, Func, Lift, Lower, TypedFunc, WasmList, WasmStr,


### PR DESCRIPTION
Previously, `Stream{Writer|Reader}` was hard-coded to use `Vec<T>` as a buffer type.  Now it's generic over any type that implements `Buffer`, including `Vec<T>` for any `T`, `bytes::Bytes` for `u8`, and `Single<T>` for any `T`.  The latter supports sending one item at a time without any extra allocations.

The main motivation here is that `wasmtime-wasi-http` uses `bytes::Bytes` as its `Body::Data` type, and although converting from a `Vec<u8>` to a `Bytes` is fairly cheap, going the other way is generally expensive, so we should try to avoid it.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
