### PR TITLE
simplify handling of `StoreContextMut` in concurrent.rs

### DIFF
--- a/crates/wasmtime/src/runtime/component/func.rs
+++ b/crates/wasmtime/src/runtime/component/func.rs
@@ -336,7 +336,6 @@ impl Func {
                 self.call_impl(store, params, results)
             })
             .await?
-            .0
         }
         #[cfg(not(feature = "component-model-async"))]
         {
@@ -371,7 +370,6 @@ impl Func {
             self.start_call(store.as_context_mut(), params)
         })
         .await?
-        .0
     }
 
     #[cfg(feature = "component-model-async")]
@@ -398,7 +396,7 @@ impl Func {
             Self::lift_results_sync as LiftFn<_>
         };
 
-        Ok(self.start_call_raw_async(store, params, lower, lift)?.0)
+        self.start_call_raw_async(store, params, lower, lift)
     }
 
     fn call_impl<U: Send>(
@@ -437,7 +435,6 @@ impl Func {
                         Self::lower_args,
                         Self::lift_results_async,
                     )?
-                    .0
                     .into_iter()
                     .zip(results)
                 {
@@ -477,7 +474,7 @@ impl Func {
         params: Params,
         lower: LowerFn<T, Params, LowerParams>,
         lift: LiftFn<Return>,
-    ) -> Result<(Return, StoreContextMut<'a, T>)>
+    ) -> Result<Return>
     where
         LowerParams: Copy,
     {
@@ -519,7 +516,7 @@ impl Func {
         params: Params,
         lower: LowerFn<T, Params, LowerParams>,
         lift: LiftFn<Return>,
-    ) -> Result<(Promise<Return>, StoreContextMut<'a, T>)>
+    ) -> Result<Promise<Return>>
     where
         LowerParams: Copy,
     {

--- a/crates/wasmtime/src/runtime/component/func/host.rs
+++ b/crates/wasmtime/src/runtime/component/func/host.rs
@@ -321,7 +321,7 @@ where
 
         let future = closure(cx.as_context_mut(), params);
 
-        let (ret, cx) = concurrent::poll_and_block(cx, future, caller_instance)?;
+        let ret = concurrent::poll_and_block(cx.as_context_mut(), future, caller_instance)?;
 
         flags.set_may_leave(false);
         let mut lower = LowerContext::new(cx, &options, types, instance);
@@ -574,7 +574,8 @@ where
         };
 
         let future = closure(store.as_context_mut(), args, result_tys.types.len());
-        let (result_vals, store) = concurrent::poll_and_block(store, future, caller_instance)?;
+        let result_vals =
+            concurrent::poll_and_block(store.as_context_mut(), future, caller_instance)?;
 
         flags.set_may_leave(false);
 

--- a/crates/wasmtime/src/runtime/component/func/typed.rs
+++ b/crates/wasmtime/src/runtime/component/func/typed.rs
@@ -203,7 +203,6 @@ where
                 self.call_impl(store, params)
             })
             .await?
-            .0
         }
         #[cfg(not(feature = "component-model-async"))]
         {
@@ -242,7 +241,6 @@ where
             self.start_call(store.as_context_mut(), params)
         })
         .await?
-        .0
     }
 
     #[cfg(feature = "component-model-async")]
@@ -255,7 +253,7 @@ where
         Params: Send + Sync + 'static,
         Return: Send + Sync + 'static,
     {
-        Ok(if store.0[self.func.0].options.async_() {
+        if store.0[self.func.0].options.async_() {
             #[cfg(feature = "component-model-async")]
             {
                 if Params::flatten_count() <= MAX_FLAT_PARAMS {
@@ -331,8 +329,7 @@ where
                     Self::lift_heap_result_raw,
                 )
             }
-        }?
-        .0)
+        }
     }
 
     fn call_impl<T: Send>(
@@ -348,7 +345,7 @@ where
         if store.0[self.func.0].options.async_() {
             #[cfg(feature = "component-model-async")]
             {
-                return Ok(if Params::flatten_count() <= MAX_FLAT_PARAMS {
+                return if Params::flatten_count() <= MAX_FLAT_PARAMS {
                     if Return::flatten_count() <= MAX_FLAT_PARAMS {
                         self.func.call_raw_async(
                             store,
@@ -380,8 +377,7 @@ where
                             Self::lift_heap_result_raw,
                         )
                     }
-                }?
-                .0);
+                };
             }
             #[cfg(not(feature = "component-model-async"))]
             {

--- a/crates/wasmtime/src/runtime/component/instance.rs
+++ b/crates/wasmtime/src/runtime/component/instance.rs
@@ -843,7 +843,6 @@ impl<T> InstancePre<T> {
                 self.instantiate_impl(store)
             })
             .await?
-            .0
         }
         #[cfg(not(feature = "component-model-async"))]
         {

--- a/crates/wasmtime/src/runtime/component/mod.rs
+++ b/crates/wasmtime/src/runtime/component/mod.rs
@@ -727,12 +727,12 @@ pub(crate) mod concurrent {
     }
 
     pub(crate) fn poll_and_block<'a, T, R: Send + Sync + 'static>(
-        store: StoreContextMut<'a, T>,
+        _store: StoreContextMut<'a, T>,
         future: impl Future<Output = Result<R>> + Send + Sync + 'static,
         _caller_instance: RuntimeComponentInstanceIndex,
-    ) -> Result<(R, StoreContextMut<'a, T>)> {
+    ) -> Result<R> {
         match pin!(future).poll(&mut Context::from_waker(&dummy_waker())) {
-            Poll::Ready(result) => Ok((result?, store)),
+            Poll::Ready(result) => result,
             Poll::Pending => {
                 unreachable!()
             }

--- a/crates/wasmtime/src/runtime/externals/table.rs
+++ b/crates/wasmtime/src/runtime/externals/table.rs
@@ -104,7 +104,6 @@ impl Table {
                 Table::_new(store.0, ty, init)
             })
             .await?
-            .0
         }
         #[cfg(not(feature = "component-model-async"))]
         {
@@ -310,7 +309,6 @@ impl Table {
                 self.grow(store, delta, init)
             })
             .await?
-            .0
         }
         #[cfg(not(feature = "component-model-async"))]
         {

--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -1187,7 +1187,6 @@ impl Func {
                 self.call_impl_do_call(store, params, results)
             })
             .await?
-            .0
         }
         #[cfg(not(feature = "component-model-async"))]
         {

--- a/crates/wasmtime/src/runtime/func/typed.rs
+++ b/crates/wasmtime/src/runtime/func/typed.rs
@@ -148,7 +148,6 @@ where
                 unsafe { Self::call_raw(store, &self.ty, func, params) }
             })
             .await?
-            .0
         }
         #[cfg(not(feature = "component-model-async"))]
         {

--- a/crates/wasmtime/src/runtime/instance.rs
+++ b/crates/wasmtime/src/runtime/instance.rs
@@ -234,7 +234,6 @@ impl Instance {
                 Self::new_started_impl(store, module, imports)
             })
             .await?
-            .0
         }
         #[cfg(not(feature = "component-model-async"))]
         {

--- a/crates/wasmtime/src/runtime/memory.rs
+++ b/crates/wasmtime/src/runtime/memory.rs
@@ -272,7 +272,6 @@ impl Memory {
                 Self::_new(store.0, ty)
             })
             .await?
-            .0
         }
         #[cfg(not(feature = "component-model-async"))]
         {
@@ -636,7 +635,6 @@ impl Memory {
                 self.grow(store, delta)
             })
             .await?
-            .0
         }
         #[cfg(not(feature = "component-model-async"))]
         {


### PR DESCRIPTION
Previously, several functions in concurrent.rs which accepted a `StoreContextMut` parameter also returned a `StoreContextMut`.  That was motivated by a concern that functions which (directly or transitively) convert a `&mut StoreInner` into a raw pointer would invalidate the original reference. However, that turned out to be unnecessary paranoia; it's no less sound than a reborrow assuming we scope the use of that raw pointer appropriately.

This commit removes the unnecessary return values, which helps simplify both the internal code and the `pub(crate)` API.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
