### PR TITLE
support calling async-lifted exports with `call_async`

### DIFF
--- a/crates/misc/component-async-tests/src/round_trip.rs
+++ b/crates/misc/component-async-tests/src/round_trip.rs
@@ -15,6 +15,16 @@ pub mod bindings {
     });
 }
 
+pub mod non_concurrent_export_bindings {
+    wasmtime::component::bindgen!({
+        trappable_imports: true,
+        path: "wit",
+        world: "round-trip",
+        concurrent_imports: true,
+        async: true,
+    });
+}
+
 impl bindings::local::local::baz::Host for &mut Ctx {
     async fn foo<T>(_: &mut Accessor<T, Self>, s: String) -> wasmtime::Result<String> {
         tokio::time::sleep(Duration::from_millis(10)).await;

--- a/crates/misc/component-async-tests/src/round_trip_many.rs
+++ b/crates/misc/component-async-tests/src/round_trip_many.rs
@@ -17,6 +17,17 @@ pub mod bindings {
     });
 }
 
+pub mod non_concurrent_export_bindings {
+    wasmtime::component::bindgen!({
+        trappable_imports: true,
+        path: "wit",
+        world: "round-trip-many",
+        concurrent_imports: true,
+        async: true,
+        additional_derives: [ Eq, PartialEq ],
+    });
+}
+
 use bindings::local::local::many::Stuff;
 
 impl bindings::local::local::many::Host for &mut Ctx {

--- a/crates/wasmtime/src/runtime/vm/component/states.rs
+++ b/crates/wasmtime/src/runtime/vm/component/states.rs
@@ -131,4 +131,17 @@ impl<T> StateTable<T> {
         }
         Ok((rep, state))
     }
+
+    pub fn remove_by_rep(&mut self, rep: u32) -> Option<T> {
+        let index = *self
+            .reps_to_indexes
+            .get(usize::try_from(rep).unwrap())
+            .unwrap_or(&0);
+
+        if index > 0 {
+            Some(self.remove_by_index(index).unwrap().1)
+        } else {
+            None
+        }
+    }
 }


### PR DESCRIPTION
This also fixes issues with calling sync-lifted exports which call async-lowered imports, as well as composed components involving some flavor of async, using `call_async`, and expands the round-trip tests to cover those cases.  In the process, I ran into other latent issues which the new tests cases exposed, including redundant nesting of fibers, which I've addressed as well.

Fixes #5

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
