### PR TITLE
validate task.return canon options at runtime

### DIFF
--- a/crates/environ/src/component.rs
+++ b/crates/environ/src/component.rs
@@ -86,7 +86,7 @@ macro_rules! foreach_builtin_component_function {
             #[cfg(feature = "component-model-async")]
             backpressure_set(vmctx: vmctx, caller_instance: u32, enabled: u32) -> bool;
             #[cfg(feature = "component-model-async")]
-            task_return(vmctx: vmctx, ty: u32, storage: ptr_u8, storage_len: size) -> bool;
+            task_return(vmctx: vmctx, ty: u32, memory: ptr_u8, string_encoding: u8, storage: ptr_u8, storage_len: size) -> bool;
             #[cfg(feature = "component-model-async")]
             waitable_set_new(vmctx: vmctx, caller_instance: u32) -> u64;
             #[cfg(feature = "component-model-async")]
@@ -102,11 +102,11 @@ macro_rules! foreach_builtin_component_function {
             #[cfg(feature = "component-model-async")]
             subtask_drop(vmctx: vmctx, caller_instance: u32, task_id: u32) -> bool;
             #[cfg(feature = "component-model-async")]
-            sync_enter(vmctx: vmctx, start: ptr_u8, return_: ptr_u8, caller_instance: u32, task_return_type: u32, result_count: u32, storage: ptr_u8, storage_len: size) -> bool;
+            sync_enter(vmctx: vmctx, memory: ptr_u8, start: ptr_u8, return_: ptr_u8, caller_instance: u32, task_return_type: u32, string_encoding: u32, result_count: u32, storage: ptr_u8, storage_len: size) -> bool;
             #[cfg(feature = "component-model-async")]
             sync_exit(vmctx: vmctx, callback: ptr_u8, caller_instance: u32, callee: ptr_u8, callee_instance: u32, param_count: u32, storage: ptr_u8, storage_len: size) -> bool;
             #[cfg(feature = "component-model-async")]
-            async_enter(vmctx: vmctx, start: ptr_u8, return_: ptr_u8, caller_instance: u32, task_return_type: u32, params: u32, results: u32) -> bool;
+            async_enter(vmctx: vmctx, memory: ptr_u8, start: ptr_u8, return_: ptr_u8, caller_instance: u32, task_return_type: u32, string_encoding: u32, params: u32, results: u32) -> bool;
             #[cfg(feature = "component-model-async")]
             async_exit(vmctx: vmctx, callback: ptr_u8, post_return: ptr_u8, caller_instance: u32, callee: ptr_u8, callee_instance: u32, param_count: u32, result_count: u32, flags: u32) -> u64;
             #[cfg(feature = "component-model-async")]

--- a/crates/environ/src/component/dfg.rs
+++ b/crates/environ/src/component/dfg.rs
@@ -388,11 +388,15 @@ pub enum Trampoline {
     ResourceTransferBorrow,
     ResourceEnterCall,
     ResourceExitCall,
-    SyncEnterCall,
+    SyncEnterCall {
+        memory: Option<MemoryId>,
+    },
     SyncExitCall {
         callback: Option<CallbackId>,
     },
-    AsyncEnterCall,
+    AsyncEnterCall {
+        memory: Option<MemoryId>,
+    },
     AsyncExitCall {
         callback: Option<CallbackId>,
         post_return: Option<PostReturnId>,
@@ -917,11 +921,15 @@ impl LinearizeDfg<'_> {
             Trampoline::ResourceTransferBorrow => info::Trampoline::ResourceTransferBorrow,
             Trampoline::ResourceEnterCall => info::Trampoline::ResourceEnterCall,
             Trampoline::ResourceExitCall => info::Trampoline::ResourceExitCall,
-            Trampoline::SyncEnterCall => info::Trampoline::SyncEnterCall,
+            Trampoline::SyncEnterCall { memory } => info::Trampoline::SyncEnterCall {
+                memory: memory.map(|v| self.runtime_memory(v)),
+            },
             Trampoline::SyncExitCall { callback } => info::Trampoline::SyncExitCall {
                 callback: callback.map(|v| self.runtime_callback(v)),
             },
-            Trampoline::AsyncEnterCall => info::Trampoline::AsyncEnterCall,
+            Trampoline::AsyncEnterCall { memory } => info::Trampoline::AsyncEnterCall {
+                memory: memory.map(|v| self.runtime_memory(v)),
+            },
             Trampoline::AsyncExitCall {
                 callback,
                 post_return,

--- a/crates/environ/src/component/info.rs
+++ b/crates/environ/src/component/info.rs
@@ -945,7 +945,12 @@ pub enum Trampoline {
 
     /// An intrinsic used by FACT-generated modules to begin a call involving a
     /// sync-lowered import and async-lifted export.
-    SyncEnterCall,
+    SyncEnterCall {
+        /// The memory used to verify that the memory specified for the
+        /// `task.return` that is called at runtime matches the one specified in
+        /// the lifted export.
+        memory: Option<RuntimeMemoryIndex>,
+    },
 
     /// An intrinsic used by FACT-generated modules to complete a call involving
     /// a sync-lowered import and async-lifted export.
@@ -956,7 +961,12 @@ pub enum Trampoline {
 
     /// An intrinsic used by FACT-generated modules to begin a call involving an
     /// async-lowered import function.
-    AsyncEnterCall,
+    AsyncEnterCall {
+        /// The memory used to verify that the memory specified for the
+        /// `task.return` that is called at runtime (if any) matches the one
+        /// specified in the lifted export.
+        memory: Option<RuntimeMemoryIndex>,
+    },
 
     /// An intrinsic used by FACT-generated modules to complete a call involving
     /// an async-lowered import function.
@@ -1049,9 +1059,9 @@ impl Trampoline {
             ResourceTransferBorrow => format!("component-resource-transfer-borrow"),
             ResourceEnterCall => format!("component-resource-enter-call"),
             ResourceExitCall => format!("component-resource-exit-call"),
-            SyncEnterCall => format!("component-sync-enter-call"),
+            SyncEnterCall { .. } => format!("component-sync-enter-call"),
             SyncExitCall { .. } => format!("component-sync-exit-call"),
-            AsyncEnterCall => format!("component-async-enter-call"),
+            AsyncEnterCall { .. } => format!("component-async-enter-call"),
             AsyncExitCall { .. } => format!("component-async-exit-call"),
             FutureTransfer => format!("future-transfer"),
             StreamTransfer => format!("stream-transfer"),

--- a/crates/wasmtime/src/runtime/component/func/options.rs
+++ b/crates/wasmtime/src/runtime/component/func/options.rs
@@ -31,7 +31,7 @@ pub struct Options {
     ///
     /// Note that this pointer cannot be safely dereferenced unless a store,
     /// verified with `self.store_id`, has the appropriate borrow available.
-    memory: Option<NonNull<VMMemoryDefinition>>,
+    pub(crate) memory: Option<NonNull<VMMemoryDefinition>>,
 
     /// Similar to `memory` but corresponds to the `canonical_abi_realloc`
     /// function.

--- a/crates/wasmtime/src/runtime/vm/component/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/component/libcalls.rs
@@ -601,6 +601,8 @@ unsafe fn backpressure_set(
 unsafe fn task_return(
     vmctx: NonNull<VMComponentContext>,
     ty: u32,
+    memory: *mut u8,
+    string_encoding: u8,
     storage: *mut u8,
     storage_len: usize,
 ) -> Result<()> {
@@ -608,6 +610,8 @@ unsafe fn task_return(
         (*instance.store()).component_async_store().task_return(
             instance,
             wasmtime_environ::component::TypeTupleIndex::from_u32(ty),
+            memory.cast::<crate::vm::VMMemoryDefinition>(),
+            string_encoding,
             storage.cast::<crate::ValRaw>(),
             storage_len,
         )
@@ -744,20 +748,24 @@ unsafe fn subtask_drop(
 #[cfg(feature = "component-model-async")]
 unsafe fn sync_enter(
     vmctx: NonNull<VMComponentContext>,
+    memory: *mut u8,
     start: *mut u8,
     return_: *mut u8,
     caller_instance: u32,
     task_return_type: u32,
+    string_encoding: u32,
     result_count: u32,
     storage: *mut u8,
     storage_len: usize,
 ) -> Result<()> {
     ComponentInstance::from_vmctx(vmctx, |instance| {
         (*instance.store()).component_async_store().sync_enter(
+            memory.cast::<crate::vm::VMMemoryDefinition>(),
             start.cast::<crate::vm::VMFuncRef>(),
             return_.cast::<crate::vm::VMFuncRef>(),
             wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(caller_instance),
             wasmtime_environ::component::TypeTupleIndex::from_u32(task_return_type),
+            u8::try_from(string_encoding).unwrap(),
             result_count,
             storage.cast::<crate::ValRaw>(),
             storage_len,
@@ -793,19 +801,23 @@ unsafe fn sync_exit(
 #[cfg(feature = "component-model-async")]
 unsafe fn async_enter(
     vmctx: NonNull<VMComponentContext>,
+    memory: *mut u8,
     start: *mut u8,
     return_: *mut u8,
     caller_instance: u32,
     task_return_type: u32,
+    string_encoding: u32,
     params: u32,
     results: u32,
 ) -> Result<()> {
     ComponentInstance::from_vmctx(vmctx, |instance| {
         (*instance.store()).component_async_store().async_enter(
+            memory.cast::<crate::vm::VMMemoryDefinition>(),
             start.cast::<crate::vm::VMFuncRef>(),
             return_.cast::<crate::vm::VMFuncRef>(),
             wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(caller_instance),
             wasmtime_environ::component::TypeTupleIndex::from_u32(task_return_type),
+            u8::try_from(string_encoding).unwrap(),
             params,
             results,
         )


### PR DESCRIPTION
Per https://github.com/bytecodealliance/wasmtime/issues/10338, we need to validate three things match for every call to `task.return` relative to the canonical lift options for the export being executed:

- The type being returned
- The memory option (if applicable)
- The string encoding (if applicable)

We were already checking the first of those; this adds the other two.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
