### PR TITLE
fix incorrect management of `ConcurrentState::guest_task`

### DIFF
--- a/crates/misc/component-async-tests/tests/test_all.rs
+++ b/crates/misc/component-async-tests/tests/test_all.rs
@@ -19,7 +19,7 @@ use scenario::error_context::{
     async_error_context_stream_callee, async_error_context_stream_caller,
 };
 use scenario::post_return::{async_post_return_callee, async_post_return_caller};
-use scenario::proxy::{async_http_echo, async_http_middleware};
+use scenario::proxy::{async_http_echo, async_http_middleware, async_http_middleware_with_chain};
 use scenario::read_resource_stream::async_read_resource_stream;
 use scenario::round_trip::{
     async_round_trip_stackful, async_round_trip_stackless, async_round_trip_stackless_sync_import,

--- a/crates/misc/component-async-tests/wit/test.wit
+++ b/crates/misc/component-async-tests/wit/test.wit
@@ -126,6 +126,16 @@ interface closed {
   read-future: func(rx: future<u8>, expected: u8, rx-ignore: future<u8>);
 }
 
+interface chain-http {
+  use wasi:http/types@0.3.0-draft.{request, response, error-code};
+
+  handle: func(request: request) -> result<response, error-code>;
+}
+
+interface sleep {
+  sleep-millis: func(time-in-millis: u64);
+}
+
 world yield-caller {
   import continue;
   import ready;
@@ -245,3 +255,13 @@ world closed-streams {
   export closed;
 }
 
+world middleware-with-chain {
+  include wasi:http/proxy@0.3.0-draft;
+
+  import sleep;
+  import chain-http;
+}
+
+world sleep-host {
+  import sleep;
+}

--- a/crates/test-programs/src/bin/async_http_middleware_with_chain.rs
+++ b/crates/test-programs/src/bin/async_http_middleware_with_chain.rs
@@ -1,0 +1,42 @@
+mod bindings {
+    wit_bindgen::generate!({
+        path: "../misc/component-async-tests/wit",
+        world: "middleware-with-chain",
+        async: {
+            imports: [
+                "local:local/chain-http#handle",
+                "local:local/sleep#sleep-millis"
+            ],
+            exports: [
+                "wasi:http/handler@0.3.0-draft#handle",
+            ]
+        },
+        generate_all,
+    });
+
+    use super::Component;
+    export!(Component);
+}
+
+use bindings::{
+    exports::wasi::http::handler::Guest as Handler,
+    local::local::{chain_http, sleep},
+    wasi::http::types::{ErrorCode, Request, Response},
+};
+
+struct Component;
+
+impl Handler for Component {
+    async fn handle(request: Request) -> Result<Response, ErrorCode> {
+        // First, sleep briefly.  This will ensure the next call happens via a
+        // host->guest call to the `wit_bindgen_rt::async_support::callback`
+        // function, which exercises different code paths in both the host and
+        // the guest, which we want to test here.
+        sleep::sleep_millis(10).await;
+
+        chain_http::handle(request).await
+    }
+}
+
+// Unused function; required since this file is built as a `bin`:
+fn main() {}


### PR DESCRIPTION
Previously, `maybe_send_event` would "temporarily" replace `ConcurrentState::guest_task` but then return early without restoring it.  This would only occur for async->async component-to-component calls where the caller had already suspended at least once before making the call.  In that case, we'd try to deliver a `Started` event to the caller via its callback before we had actually returned the `waitable` handle for that call.

As a result, we were both failing to restore the original `ConcurrentState::guest_task` value _and_ dropping a valid message.  This fixes both issues and adds a test to cover the scenario.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
