### PR TITLE
update wasm-tools deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4127,8 +4127,7 @@ checksum = "6ee99da9c5ba11bd675621338ef6fa52296b76b83305e9b6e5c77d4c286d6d49"
 [[package]]
 name = "wasm-compose"
 version = "0.227.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "606f006290e2964ba8075a8dd079358ede1e588971cb761720db43b3824f26e5"
+source = "git+https://github.com/bytecodealliance/wasm-tools#ad5726c3e42228c9088e00f4480ba1ac28069fb4"
 dependencies = [
  "anyhow",
  "heck 0.4.1",
@@ -4157,8 +4156,7 @@ dependencies = [
 [[package]]
 name = "wasm-metadata"
 version = "0.227.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1ef0faabbbba6674e97a56bee857ccddf942785a336c8b47b42373c922a91d"
+source = "git+https://github.com/bytecodealliance/wasm-tools#ad5726c3e42228c9088e00f4480ba1ac28069fb4"
 dependencies = [
  "anyhow",
  "auditable-serde",
@@ -4176,8 +4174,7 @@ dependencies = [
 [[package]]
 name = "wasm-mutate"
 version = "0.227.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c676dda860c58c2277992ca6d839d05fd1c654a79ccb8c0697ac8ce662ffdf"
+source = "git+https://github.com/bytecodealliance/wasm-tools#ad5726c3e42228c9088e00f4480ba1ac28069fb4"
 dependencies = [
  "egg",
  "log",
@@ -4190,8 +4187,7 @@ dependencies = [
 [[package]]
 name = "wasm-smith"
 version = "0.227.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71cea6760943ceda69f5f1c3ea8b74ee1b2c257cb56b52ee5d23972054c7b1a7"
+source = "git+https://github.com/bytecodealliance/wasm-tools#ad5726c3e42228c9088e00f4480ba1ac28069fb4"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -4210,8 +4206,7 @@ dependencies = [
 [[package]]
 name = "wasm-wave"
 version = "0.227.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b083d8142b4fef44d40ed8575eded95f59a0b1cbbb256a0f47b2432104c7ebb7"
+source = "git+https://github.com/bytecodealliance/wasm-tools#ad5726c3e42228c9088e00f4480ba1ac28069fb4"
 dependencies = [
  "indexmap 2.7.0",
  "logos",
@@ -4941,8 +4936,7 @@ dependencies = [
 [[package]]
 name = "wast"
 version = "227.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c14e5042b16c9d267da3b9b0f4529870455178415286312c25c34dfc1b2816"
+source = "git+https://github.com/bytecodealliance/wasm-tools#ad5726c3e42228c9088e00f4480ba1ac28069fb4"
 dependencies = [
  "bumpalo",
  "leb128fmt",
@@ -4954,8 +4948,7 @@ dependencies = [
 [[package]]
 name = "wat"
 version = "1.227.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d394d5bef7006ff63338d481ca10f1af76601e65ebdf5ed33d29302994e9cc"
+source = "git+https://github.com/bytecodealliance/wasm-tools#ad5726c3e42228c9088e00f4480ba1ac28069fb4"
 dependencies = [
  "wast 227.0.1",
 ]
@@ -5390,8 +5383,7 @@ dependencies = [
 [[package]]
 name = "wit-component"
 version = "0.227.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "635c3adc595422cbf2341a17fb73a319669cc8d33deed3a48368a841df86b676"
+source = "git+https://github.com/bytecodealliance/wasm-tools#ad5726c3e42228c9088e00f4480ba1ac28069fb4"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -5409,8 +5401,7 @@ dependencies = [
 [[package]]
 name = "wit-parser"
 version = "0.227.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddf445ed5157046e4baf56f9138c124a0824d4d1657e7204d71886ad8ce2fc11"
+source = "git+https://github.com/bytecodealliance/wasm-tools#ad5726c3e42228c9088e00f4480ba1ac28069fb4"
 dependencies = [
  "anyhow",
  "id-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -306,17 +306,18 @@ wit-bindgen-rt = { git = "https://github.com/bytecodealliance/wit-bindgen", rev 
 wit-bindgen-rust-macro = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "1d8cbb92b7aed06b6e762a7b49d3a4691b0280b8", default-features = false }
 
 # wasm-tools family:
-wasmparser = { version = "0.227.1", default-features = false, features = ['simd'] }
-wat = "1.227.1"
-wast = "227.0.1"
-wasmprinter = "0.227.1"
-wasm-encoder = "0.227.1"
-wasm-smith = "0.227.1"
-wasm-mutate = "0.227.1"
-wit-parser = "0.227.1"
-wit-component = "0.227.1"
-wasm-wave = "0.227.1"
-wasm-compose = "0.227.1"
+# TODO: switch back to release
+wasmparser = { git = 'https://github.com/bytecodealliance/wasm-tools', default-features = false, features = ['simd'] }
+wat = { git = 'https://github.com/bytecodealliance/wasm-tools' }
+wast = { git = 'https://github.com/bytecodealliance/wasm-tools' }
+wasmprinter = { git = 'https://github.com/bytecodealliance/wasm-tools' }
+wasm-encoder = { git = 'https://github.com/bytecodealliance/wasm-tools' }
+wasm-smith = { git = 'https://github.com/bytecodealliance/wasm-tools' }
+wasm-mutate = { git = 'https://github.com/bytecodealliance/wasm-tools' }
+wit-parser = { git = 'https://github.com/bytecodealliance/wasm-tools' }
+wit-component = { git = 'https://github.com/bytecodealliance/wasm-tools' }
+wasm-wave = { git = 'https://github.com/bytecodealliance/wasm-tools' }
+wasm-compose = { git = 'https://github.com/bytecodealliance/wasm-tools' }
 
 # Non-Bytecode Alliance maintained dependencies:
 # --------------------------
@@ -573,5 +574,14 @@ lto = true
 
 [patch.crates-io]
 wasmparser = { git = 'https://github.com/bytecodealliance/wasm-tools' }
+wat = { git = 'https://github.com/bytecodealliance/wasm-tools' }
+wast = { git = 'https://github.com/bytecodealliance/wasm-tools' }
 wasmprinter = { git = 'https://github.com/bytecodealliance/wasm-tools' }
 wasm-encoder = { git = 'https://github.com/bytecodealliance/wasm-tools' }
+wasm-smith = { git = 'https://github.com/bytecodealliance/wasm-tools' }
+wasm-mutate = { git = 'https://github.com/bytecodealliance/wasm-tools' }
+wit-parser = { git = 'https://github.com/bytecodealliance/wasm-tools' }
+wit-component = { git = 'https://github.com/bytecodealliance/wasm-tools' }
+wasm-wave = { git = 'https://github.com/bytecodealliance/wasm-tools' }
+wasm-compose = { git = 'https://github.com/bytecodealliance/wasm-tools' }
+wasm-metadata = { git = 'https://github.com/bytecodealliance/wasm-tools' }


### PR DESCRIPTION
The Cargo.toml patch isn't sufficient if e.g. this project is used as a git dep by another project, so we need to actually change the deps themselves.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
