### PR TITLE
update CM async support to match spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3531,7 +3531,7 @@ dependencies = [
  "wasi 0.14.0+wasi-0.2.3",
  "wasi-nn",
  "wit-bindgen",
- "wit-bindgen-rt 0.40.0",
+ "wit-bindgen-rt 0.41.0",
 ]
 
 [[package]]
@@ -4127,7 +4127,7 @@ checksum = "6ee99da9c5ba11bd675621338ef6fa52296b76b83305e9b6e5c77d4c286d6d49"
 [[package]]
 name = "wasm-compose"
 version = "0.227.1"
-source = "git+https://github.com/bytecodealliance/wasm-tools#ad5726c3e42228c9088e00f4480ba1ac28069fb4"
+source = "git+https://github.com/dicej/wasm-tools?branch=callback-sig-update#280ac2472cc8370ec52eb4e4f9997b1da902dec4"
 dependencies = [
  "anyhow",
  "heck 0.4.1",
@@ -4147,7 +4147,7 @@ dependencies = [
 [[package]]
 name = "wasm-encoder"
 version = "0.227.1"
-source = "git+https://github.com/bytecodealliance/wasm-tools#ad5726c3e42228c9088e00f4480ba1ac28069fb4"
+source = "git+https://github.com/dicej/wasm-tools?branch=callback-sig-update#280ac2472cc8370ec52eb4e4f9997b1da902dec4"
 dependencies = [
  "leb128fmt",
  "wasmparser",
@@ -4156,7 +4156,7 @@ dependencies = [
 [[package]]
 name = "wasm-metadata"
 version = "0.227.1"
-source = "git+https://github.com/bytecodealliance/wasm-tools#ad5726c3e42228c9088e00f4480ba1ac28069fb4"
+source = "git+https://github.com/dicej/wasm-tools?branch=callback-sig-update#280ac2472cc8370ec52eb4e4f9997b1da902dec4"
 dependencies = [
  "anyhow",
  "auditable-serde",
@@ -4174,7 +4174,7 @@ dependencies = [
 [[package]]
 name = "wasm-mutate"
 version = "0.227.1"
-source = "git+https://github.com/bytecodealliance/wasm-tools#ad5726c3e42228c9088e00f4480ba1ac28069fb4"
+source = "git+https://github.com/dicej/wasm-tools?branch=callback-sig-update#280ac2472cc8370ec52eb4e4f9997b1da902dec4"
 dependencies = [
  "egg",
  "log",
@@ -4187,7 +4187,7 @@ dependencies = [
 [[package]]
 name = "wasm-smith"
 version = "0.227.1"
-source = "git+https://github.com/bytecodealliance/wasm-tools#ad5726c3e42228c9088e00f4480ba1ac28069fb4"
+source = "git+https://github.com/dicej/wasm-tools?branch=callback-sig-update#280ac2472cc8370ec52eb4e4f9997b1da902dec4"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -4206,7 +4206,7 @@ dependencies = [
 [[package]]
 name = "wasm-wave"
 version = "0.227.1"
-source = "git+https://github.com/bytecodealliance/wasm-tools#ad5726c3e42228c9088e00f4480ba1ac28069fb4"
+source = "git+https://github.com/dicej/wasm-tools?branch=callback-sig-update#280ac2472cc8370ec52eb4e4f9997b1da902dec4"
 dependencies = [
  "indexmap 2.7.0",
  "logos",
@@ -4261,7 +4261,7 @@ dependencies = [
 [[package]]
 name = "wasmparser"
 version = "0.227.1"
-source = "git+https://github.com/bytecodealliance/wasm-tools#ad5726c3e42228c9088e00f4480ba1ac28069fb4"
+source = "git+https://github.com/dicej/wasm-tools?branch=callback-sig-update#280ac2472cc8370ec52eb4e4f9997b1da902dec4"
 dependencies = [
  "bitflags 2.6.0",
  "hashbrown 0.15.2",
@@ -4282,7 +4282,7 @@ dependencies = [
 [[package]]
 name = "wasmprinter"
 version = "0.227.1"
-source = "git+https://github.com/bytecodealliance/wasm-tools#ad5726c3e42228c9088e00f4480ba1ac28069fb4"
+source = "git+https://github.com/dicej/wasm-tools?branch=callback-sig-update#280ac2472cc8370ec52eb4e4f9997b1da902dec4"
 dependencies = [
  "anyhow",
  "termcolor",
@@ -4936,7 +4936,7 @@ dependencies = [
 [[package]]
 name = "wast"
 version = "227.0.1"
-source = "git+https://github.com/bytecodealliance/wasm-tools#ad5726c3e42228c9088e00f4480ba1ac28069fb4"
+source = "git+https://github.com/dicej/wasm-tools?branch=callback-sig-update#280ac2472cc8370ec52eb4e4f9997b1da902dec4"
 dependencies = [
  "bumpalo",
  "leb128fmt",
@@ -4948,7 +4948,7 @@ dependencies = [
 [[package]]
 name = "wat"
 version = "1.227.1"
-source = "git+https://github.com/bytecodealliance/wasm-tools#ad5726c3e42228c9088e00f4480ba1ac28069fb4"
+source = "git+https://github.com/dicej/wasm-tools?branch=callback-sig-update#280ac2472cc8370ec52eb4e4f9997b1da902dec4"
 dependencies = [
  "wast 227.0.1",
 ]
@@ -5315,17 +5315,17 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.40.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=1d8cbb92b7aed06b6e762a7b49d3a4691b0280b8#1d8cbb92b7aed06b6e762a7b49d3a4691b0280b8"
+version = "0.41.0"
+source = "git+https://github.com/dicej/wit-bindgen?branch=spec-sync#ca39aa6b1c362fe5e0a7d72b92ac906e23e1e4e6"
 dependencies = [
- "wit-bindgen-rt 0.40.0",
+ "wit-bindgen-rt 0.41.0",
  "wit-bindgen-rust-macro",
 ]
 
 [[package]]
 name = "wit-bindgen-core"
-version = "0.40.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=1d8cbb92b7aed06b6e762a7b49d3a4691b0280b8#1d8cbb92b7aed06b6e762a7b49d3a4691b0280b8"
+version = "0.41.0"
+source = "git+https://github.com/dicej/wit-bindgen?branch=spec-sync#ca39aa6b1c362fe5e0a7d72b92ac906e23e1e4e6"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -5343,8 +5343,8 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rt"
-version = "0.40.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=1d8cbb92b7aed06b6e762a7b49d3a4691b0280b8#1d8cbb92b7aed06b6e762a7b49d3a4691b0280b8"
+version = "0.41.0"
+source = "git+https://github.com/dicej/wit-bindgen?branch=spec-sync#ca39aa6b1c362fe5e0a7d72b92ac906e23e1e4e6"
 dependencies = [
  "bitflags 2.6.0",
  "futures",
@@ -5353,8 +5353,8 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust"
-version = "0.40.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=1d8cbb92b7aed06b6e762a7b49d3a4691b0280b8#1d8cbb92b7aed06b6e762a7b49d3a4691b0280b8"
+version = "0.41.0"
+source = "git+https://github.com/dicej/wit-bindgen?branch=spec-sync#ca39aa6b1c362fe5e0a7d72b92ac906e23e1e4e6"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -5368,8 +5368,8 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust-macro"
-version = "0.40.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=1d8cbb92b7aed06b6e762a7b49d3a4691b0280b8#1d8cbb92b7aed06b6e762a7b49d3a4691b0280b8"
+version = "0.41.0"
+source = "git+https://github.com/dicej/wit-bindgen?branch=spec-sync#ca39aa6b1c362fe5e0a7d72b92ac906e23e1e4e6"
 dependencies = [
  "anyhow",
  "prettyplease",
@@ -5383,7 +5383,7 @@ dependencies = [
 [[package]]
 name = "wit-component"
 version = "0.227.1"
-source = "git+https://github.com/bytecodealliance/wasm-tools#ad5726c3e42228c9088e00f4480ba1ac28069fb4"
+source = "git+https://github.com/dicej/wasm-tools?branch=callback-sig-update#280ac2472cc8370ec52eb4e4f9997b1da902dec4"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -5401,7 +5401,7 @@ dependencies = [
 [[package]]
 name = "wit-parser"
 version = "0.227.1"
-source = "git+https://github.com/bytecodealliance/wasm-tools#ad5726c3e42228c9088e00f4480ba1ac28069fb4"
+source = "git+https://github.com/dicej/wasm-tools?branch=callback-sig-update#280ac2472cc8370ec52eb4e4f9997b1da902dec4"
 dependencies = [
  "anyhow",
  "id-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -300,24 +300,24 @@ system-interface = { version = "0.27.1", features = ["cap_std_impls"] }
 io-lifetimes = { version = "2.0.3", default-features = false }
 io-extras = "0.18.1"
 rustix = "0.38.43"
-# TODO: switch back to released wit-bindgen
-wit-bindgen = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "1d8cbb92b7aed06b6e762a7b49d3a4691b0280b8", default-features = false }
-wit-bindgen-rt = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "1d8cbb92b7aed06b6e762a7b49d3a4691b0280b8", default-features = false }
-wit-bindgen-rust-macro = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "1d8cbb92b7aed06b6e762a7b49d3a4691b0280b8", default-features = false }
+# TODO: switch back to upstream release:
+wit-bindgen = { git = "https://github.com/dicej/wit-bindgen", branch = "spec-sync", default-features = false }
+wit-bindgen-rt = { git = "https://github.com/dicej/wit-bindgen", branch = "spec-sync", default-features = false }
+wit-bindgen-rust-macro = { git = "https://github.com/dicej/wit-bindgen", branch = "spec-sync", default-features = false }
 
 # wasm-tools family:
-# TODO: switch back to release
-wasmparser = { git = 'https://github.com/bytecodealliance/wasm-tools', default-features = false, features = ['simd'] }
-wat = { git = 'https://github.com/bytecodealliance/wasm-tools' }
-wast = { git = 'https://github.com/bytecodealliance/wasm-tools' }
-wasmprinter = { git = 'https://github.com/bytecodealliance/wasm-tools' }
-wasm-encoder = { git = 'https://github.com/bytecodealliance/wasm-tools' }
-wasm-smith = { git = 'https://github.com/bytecodealliance/wasm-tools' }
-wasm-mutate = { git = 'https://github.com/bytecodealliance/wasm-tools' }
-wit-parser = { git = 'https://github.com/bytecodealliance/wasm-tools' }
-wit-component = { git = 'https://github.com/bytecodealliance/wasm-tools' }
-wasm-wave = { git = 'https://github.com/bytecodealliance/wasm-tools' }
-wasm-compose = { git = 'https://github.com/bytecodealliance/wasm-tools' }
+# TODO: switch back to upstream release:
+wasmparser = { git = "https://github.com/dicej/wasm-tools", branch = "callback-sig-update", default-features = false, features = ['simd'] }
+wat = { git = "https://github.com/dicej/wasm-tools", branch = "callback-sig-update" }
+wast = { git = "https://github.com/dicej/wasm-tools", branch = "callback-sig-update" }
+wasmprinter = { git = "https://github.com/dicej/wasm-tools", branch = "callback-sig-update" }
+wasm-encoder = { git = "https://github.com/dicej/wasm-tools", branch = "callback-sig-update" }
+wasm-smith = { git = "https://github.com/dicej/wasm-tools", branch = "callback-sig-update" }
+wasm-mutate = { git = "https://github.com/dicej/wasm-tools", branch = "callback-sig-update" }
+wit-parser = { git = "https://github.com/dicej/wasm-tools", branch = "callback-sig-update" }
+wit-component = { git = "https://github.com/dicej/wasm-tools", branch = "callback-sig-update" }
+wasm-wave = { git = "https://github.com/dicej/wasm-tools", branch = "callback-sig-update" }
+wasm-compose = { git = "https://github.com/dicej/wasm-tools", branch = "callback-sig-update" }
 
 # Non-Bytecode Alliance maintained dependencies:
 # --------------------------
@@ -573,15 +573,15 @@ codegen-units = 1
 lto = true
 
 [patch.crates-io]
-wasmparser = { git = 'https://github.com/bytecodealliance/wasm-tools' }
-wat = { git = 'https://github.com/bytecodealliance/wasm-tools' }
-wast = { git = 'https://github.com/bytecodealliance/wasm-tools' }
-wasmprinter = { git = 'https://github.com/bytecodealliance/wasm-tools' }
-wasm-encoder = { git = 'https://github.com/bytecodealliance/wasm-tools' }
-wasm-smith = { git = 'https://github.com/bytecodealliance/wasm-tools' }
-wasm-mutate = { git = 'https://github.com/bytecodealliance/wasm-tools' }
-wit-parser = { git = 'https://github.com/bytecodealliance/wasm-tools' }
-wit-component = { git = 'https://github.com/bytecodealliance/wasm-tools' }
-wasm-wave = { git = 'https://github.com/bytecodealliance/wasm-tools' }
-wasm-compose = { git = 'https://github.com/bytecodealliance/wasm-tools' }
-wasm-metadata = { git = 'https://github.com/bytecodealliance/wasm-tools' }
+wasmparser = { git = "https://github.com/dicej/wasm-tools", branch = "callback-sig-update" }
+wat = { git = "https://github.com/dicej/wasm-tools", branch = "callback-sig-update" }
+wast = { git = "https://github.com/dicej/wasm-tools", branch = "callback-sig-update" }
+wasmprinter = { git = "https://github.com/dicej/wasm-tools", branch = "callback-sig-update" }
+wasm-encoder = { git = "https://github.com/dicej/wasm-tools", branch = "callback-sig-update" }
+wasm-smith = { git = "https://github.com/dicej/wasm-tools", branch = "callback-sig-update" }
+wasm-mutate = { git = "https://github.com/dicej/wasm-tools", branch = "callback-sig-update" }
+wit-parser = { git = "https://github.com/dicej/wasm-tools", branch = "callback-sig-update" }
+wit-component = { git = "https://github.com/dicej/wasm-tools", branch = "callback-sig-update" }
+wasm-wave = { git = "https://github.com/dicej/wasm-tools", branch = "callback-sig-update" }
+wasm-compose = { git = "https://github.com/dicej/wasm-tools", branch = "callback-sig-update" }
+wasm-metadata = { git = "https://github.com/dicej/wasm-tools", branch = "callback-sig-update" }

--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -1493,17 +1493,26 @@ impl<'a> TrampolineCompiler<'a> {
         let args = self.builder.func.dfg.block_params(self.block0).to_vec();
         let vmctx = args[0];
         let slot = self.builder.ins().iconst(ir::types::I32, i64::from(slot));
-        let call = self.call_libcall(vmctx, host::context_get, &[vmctx, slot]);
-        let result = self.builder.func.dfg.inst_results(call)[0];
-        self.abi_store_results(&[result]);
+
+        self.translate_intrinsic_libcall(
+            vmctx,
+            host::context_get,
+            &[vmctx, slot],
+            TrapSentinel::NegativeOne,
+        );
     }
 
     fn translate_context_set(&mut self, slot: u32) {
         let args = self.abi_load_params();
         let vmctx = args[0];
         let slot = self.builder.ins().iconst(ir::types::I32, i64::from(slot));
-        self.call_libcall(vmctx, host::context_set, &[vmctx, slot, args[2]]);
-        self.abi_store_results(&[]);
+
+        self.translate_intrinsic_libcall(
+            vmctx,
+            host::context_set,
+            &[vmctx, slot, args[2]],
+            TrapSentinel::Falsy,
+        );
     }
 }
 

--- a/crates/environ/src/component.rs
+++ b/crates/environ/src/component.rs
@@ -154,9 +154,9 @@ macro_rules! foreach_builtin_component_function {
             #[cfg(feature = "component-model-async")]
             error_context_transfer(vmctx: vmctx, src_idx: u32, src_table: u32, dst_table: u32) -> u64;
             #[cfg(feature = "component-model-async")]
-            context_get(vmctx: vmctx, slot: u32) -> u32;
+            context_get(vmctx: vmctx, slot: u32) -> u64;
             #[cfg(feature = "component-model-async")]
-            context_set(vmctx: vmctx, slot: u32, val: u32);
+            context_set(vmctx: vmctx, slot: u32, val: u32) -> bool;
 
             trap(vmctx: vmctx, code: u8);
 

--- a/crates/environ/src/fact.rs
+++ b/crates/environ/src/fact.rs
@@ -333,15 +333,9 @@ impl<'a> Module<'a> {
             )
         });
         let callback = callback.as_ref().map(|func| {
-            let ptr = if *memory64 {
-                ValType::I64
-            } else {
-                ValType::I32
-            };
-            let ty = self.core_types.function(
-                &[ptr, ValType::I32, ValType::I32, ValType::I32],
-                &[ValType::I32],
-            );
+            let ty = self
+                .core_types
+                .function(&[ValType::I32, ValType::I32, ValType::I32], &[ValType::I32]);
             self.import_func(
                 "callback",
                 &format!("f{}", self.imported_funcs.len()),

--- a/crates/test-programs/src/bin/async_round_trip_stackful.rs
+++ b/crates/test-programs/src/bin/async_round_trip_stackful.rs
@@ -57,15 +57,42 @@ unsafe extern "C" fn subtask_drop(_task: u32) {
     unreachable!()
 }
 
-const _STATUS_STARTING: u32 = 0;
-const _STATUS_STARTED: u32 = 1;
-const _STATUS_RETURNED: u32 = 2;
-const STATUS_DONE: u32 = 3;
+#[cfg(target_arch = "wasm32")]
+#[link(wasm_import_module = "$root")]
+unsafe extern "C" {
+    #[link_name = "[waitable-set-new]"]
+    fn waitable_set_new() -> u32;
+}
+#[cfg(not(target_arch = "wasm32"))]
+unsafe fn waitable_set_new() -> u32 {
+    unreachable!()
+}
 
-const _EVENT_CALL_STARTING: i32 = 0;
-const _EVENT_CALL_STARTED: i32 = 1;
-const _EVENT_CALL_RETURNED: i32 = 2;
-const EVENT_CALL_DONE: i32 = 3;
+#[cfg(target_arch = "wasm32")]
+#[link(wasm_import_module = "$root")]
+unsafe extern "C" {
+    #[link_name = "[waitable-join]"]
+    fn waitable_join(waitable: u32, set: u32);
+}
+#[cfg(not(target_arch = "wasm32"))]
+unsafe fn waitable_join(_: u32, _: u32) {
+    unreachable!()
+}
+
+#[cfg(target_arch = "wasm32")]
+#[link(wasm_import_module = "$root")]
+unsafe extern "C" {
+    #[link_name = "[waitable-set-drop]"]
+    fn waitable_set_drop(set: u32);
+}
+#[cfg(not(target_arch = "wasm32"))]
+unsafe fn waitable_set_drop(_: u32) {
+    unreachable!()
+}
+
+const STATUS_RETURNED: u32 = 3;
+
+const EVENT_CALL_RETURNED: i32 = 3;
 
 #[unsafe(export_name = "[async-lift-stackful]local:local/baz#foo")]
 unsafe extern "C" fn export_foo(ptr: *mut u8, len: usize) {
@@ -91,17 +118,21 @@ unsafe extern "C" fn export_foo(ptr: *mut u8, len: usize) {
     let result = import_foo(params, results);
     let mut status = result >> 30;
     let call = result & !(0b11 << 30);
-    while status != STATUS_DONE {
+    let set = waitable_set_new();
+    if call != 0 {
+        waitable_join(call, set);
+    }
+    while status != STATUS_RETURNED {
         // Note the use of `Box` here to avoid taking the address of a stack
         // allocation.
         let payload = Box::into_raw(Box::new([0i32; 2]));
-        // TODO: provide a real waitable-set here:
-        let event = waitable_set_wait(0, payload.cast());
+        let event = waitable_set_wait(set, payload.cast());
         let payload = Box::from_raw(payload);
-        if event == EVENT_CALL_DONE {
+        if event == EVENT_CALL_RETURNED {
             assert!(call == payload[0] as u32);
             subtask_drop(call);
-            status = STATUS_DONE;
+            waitable_set_drop(set);
+            status = STATUS_RETURNED;
         }
     }
     alloc::dealloc(params, layout);

--- a/crates/wasmtime/src/runtime/vm/component/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/component/libcalls.rs
@@ -708,15 +708,15 @@ unsafe fn waitable_set_drop(
 unsafe fn waitable_join(
     vmctx: NonNull<VMComponentContext>,
     caller_instance: u32,
-    set: u32,
     waitable: u32,
+    set: u32,
 ) -> Result<()> {
     ComponentInstance::from_vmctx(vmctx, |instance| {
         (*instance.store()).component_async_store().waitable_join(
             instance,
             wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(caller_instance),
-            set,
             waitable,
+            set,
         )
     })
 }
@@ -858,10 +858,13 @@ unsafe fn future_transfer(
     src_table: u32,
     dst_table: u32,
 ) -> Result<u32> {
-    let src_table = wasmtime_environ::component::TypeFutureTableIndex::from_u32(src_table);
-    let dst_table = wasmtime_environ::component::TypeFutureTableIndex::from_u32(dst_table);
     ComponentInstance::from_vmctx(vmctx, |instance| {
-        instance.future_transfer(src_idx, src_table, dst_table)
+        (*instance.store()).component_async_store().future_transfer(
+            instance,
+            src_idx,
+            wasmtime_environ::component::TypeFutureTableIndex::from_u32(src_table),
+            wasmtime_environ::component::TypeFutureTableIndex::from_u32(dst_table),
+        )
     })
 }
 
@@ -872,10 +875,13 @@ unsafe fn stream_transfer(
     src_table: u32,
     dst_table: u32,
 ) -> Result<u32> {
-    let src_table = wasmtime_environ::component::TypeStreamTableIndex::from_u32(src_table);
-    let dst_table = wasmtime_environ::component::TypeStreamTableIndex::from_u32(dst_table);
     ComponentInstance::from_vmctx(vmctx, |instance| {
-        instance.stream_transfer(src_idx, src_table, dst_table)
+        (*instance.store()).component_async_store().stream_transfer(
+            instance,
+            src_idx,
+            wasmtime_environ::component::TypeStreamTableIndex::from_u32(src_table),
+            wasmtime_environ::component::TypeStreamTableIndex::from_u32(dst_table),
+        )
     })
 }
 
@@ -1329,19 +1335,19 @@ unsafe fn error_context_drop(
 }
 
 #[cfg(feature = "component-model-async")]
-unsafe fn context_get(vmctx: NonNull<VMComponentContext>, slot: u32) -> u32 {
+unsafe fn context_get(vmctx: NonNull<VMComponentContext>, slot: u32) -> Result<u32> {
     ComponentInstance::from_vmctx(vmctx, |instance| {
         (*instance.store())
             .component_async_store()
-            .context_get(instance, slot)
+            .context_get(slot)
     })
 }
 
 #[cfg(feature = "component-model-async")]
-unsafe fn context_set(vmctx: NonNull<VMComponentContext>, slot: u32, val: u32) {
+unsafe fn context_set(vmctx: NonNull<VMComponentContext>, slot: u32, val: u32) -> Result<()> {
     ComponentInstance::from_vmctx(vmctx, |instance| {
         (*instance.store())
             .component_async_store()
-            .context_set(instance, slot, val)
+            .context_set(slot, val)
     })
 }

--- a/tests/all/component_model/bindgen.rs
+++ b/tests/all/component_model/bindgen.rs
@@ -95,7 +95,7 @@ mod no_imports_concurrent {
                             call $task-return
                             i32.const 0
                         )
-                        (func (export "callback") (param i32 i32 i32 i32) (result i32) unreachable)
+                        (func (export "callback") (param i32 i32 i32) (result i32) unreachable)
                     )
                     (core func $task-return (canon task.return))
                     (core instance $i (instantiate $m
@@ -236,7 +236,7 @@ mod one_import_concurrent {
                             call $task-return
                             i32.const 0
                         )
-                        (func (export "callback") (param i32 i32 i32 i32) (result i32) unreachable)
+                        (func (export "callback") (param i32 i32 i32) (result i32) unreachable)
                     )
                     (core func $foo (canon lower (func $foo-instance "foo") async (memory $libc-instance "memory")))
                     (core func $task-return (canon task.return))

--- a/tests/all/component_model/func.rs
+++ b/tests/all/component_model/func.rs
@@ -829,7 +829,7 @@ async fn async_reentrance() -> Result<()> {
                 (func (export "export") (param i32) (result i32)
                     (call_indirect (i32.const 0) (local.get 0))
                 )
-                (func (export "callback") (param i32 i32 i32 i32) (result i32) unreachable)
+                (func (export "callback") (param i32 i32 i32) (result i32) unreachable)
             )
             (core func $task-return (canon task.return (result u32)))
             (core instance $shim (instantiate $shim
@@ -856,7 +856,7 @@ async fn async_reentrance() -> Result<()> {
                         (call $task-return (i32.load offset=0 (i32.const 1204)))
                         i32.const 0
                     )
-                    (func (export "callback") (param i32 i32 i32 i32) (result i32) unreachable)
+                    (func (export "callback") (param i32 i32 i32) (result i32) unreachable)
                 )
                 (core type $task-return-type (func (param i32)))
                 (core func $task-return (canon task.return (result u32)))
@@ -890,7 +890,7 @@ async fn async_reentrance() -> Result<()> {
                     i32.const 0
                 )
                 (func $guest-export (export "guest-export") (param i32) (result i32) unreachable)
-                (func (export "callback") (param i32 i32 i32 i32) (result i32) unreachable)
+                (func (export "callback") (param i32 i32 i32) (result i32) unreachable)
                 (func $start
                     (table.set (i32.const 0) (ref.func $guest-export))
                 )
@@ -940,7 +940,7 @@ async fn missing_task_return_call_stackless() -> Result<()> {
                 (func (export "foo") (result i32)
                     i32.const 0
                 )
-                (func (export "callback") (param i32 i32 i32 i32) (result i32) unreachable)
+                (func (export "callback") (param i32 i32 i32) (result i32) unreachable)
             )
             (core func $task-return (canon task.return))
             (core instance $i (instantiate $m
@@ -1146,7 +1146,7 @@ async fn test_many_parameters(dynamic: bool, concurrent: bool) -> Result<()> {
                 (func (export "foo") (param i32) (result i32)
                     {body}
                 )
-                (func (export "callback") (param i32 i32 i32 i32) (result i32) unreachable)
+                (func (export "callback") (param i32 i32 i32) (result i32) unreachable)
             )
             (type $tuple (tuple (list u8) u32))
             (core func $task-return (canon task.return
@@ -1597,7 +1597,7 @@ async fn test_many_results(dynamic: bool, concurrent: bool) -> Result<()> {
 
                     {ret}
                 )
-                (func (export "callback") (param i32 i32 i32 i32) (result i32) unreachable)
+                (func (export "callback") (param i32 i32 i32) (result i32) unreachable)
             )
             (type $tuple (tuple
                 s8

--- a/tests/all/component_model/import.rs
+++ b/tests/all/component_model/import.rs
@@ -646,7 +646,7 @@ async fn test_stack_and_heap_args_and_rets(concurrent: bool) -> Result<()> {
     (import "host" "task.return" (func $task-return))
     {body}
 
-    (func (export "callback") (param i32 i32 i32 i32) (result i32) unreachable)
+    (func (export "callback") (param i32 i32 i32) (result i32) unreachable)
 
     (func $allocate_empty_strings (result i32)
       (local $ret i32)

--- a/tests/misc_testsuite/component-model-async/fused.wast
+++ b/tests/misc_testsuite/component-model-async/fused.wast
@@ -59,7 +59,7 @@
   (component $lifter
     (core module $m
       (import "" "task.return" (func $task-return (param i32)))
-      (func (export "callback") (param i32 i32 i32 i32) (result i32) unreachable)
+      (func (export "callback") (param i32 i32 i32) (result i32) unreachable)
       (func (export "foo") (param i32) (result i32)
         (call $task-return (local.get 0))
         i32.const 0
@@ -204,7 +204,7 @@
   (component $lifter
     (core module $m
       (import "" "task.return" (func $task-return (param i32)))
-      (func (export "callback") (param i32 i32 i32 i32) (result i32) unreachable)
+      (func (export "callback") (param i32 i32 i32) (result i32) unreachable)
       (func (export "foo") (param i32) (result i32)
         (call $task-return (local.get 0))
         i32.const 0

--- a/tests/misc_testsuite/component-model-async/lift.wast
+++ b/tests/misc_testsuite/component-model-async/lift.wast
@@ -16,7 +16,7 @@
 ;; async lift; with callback
 (component
   (core module $m
-    (func (export "callback") (param i32 i32 i32 i32) (result i32) unreachable)
+    (func (export "callback") (param i32 i32 i32) (result i32) unreachable)
     (func (export "foo") (param i32) (result i32) unreachable)
   )
   (core instance $i (instantiate $m))


### PR DESCRIPTION
This updates the CM async support to match recent (and not-so-recent) spec changes:

- Use waitable-sets to track and deliver events for waitables
- Expect packed (`CallbackCode`, waitable-set) tuples from exports and callbacks
- Remove `Event.DONE`, which no longer exists
- Update the semantics of `subtask.drop` given that it can be called before the subtask has finished
- Allow the read and write ends of a stream or future to be added to separate waitable-sets

The last item required a fair amount of refactoring to give each end of a stream or future its own handle.

The `subtask.drop`/`Event.DONE` changes mean that the parent of a subtask may finish before the subtask does, in which case we must "reparent" the subtask to point to its grandparent (or host, if applicable).  This is akin to an "async tail call" such that long-lived subtasks "bubble up" the call stack as its caller (and it's caller's caller, etc.) finish.

Note that I've temporarily pointed the wit-bindgen and wasm-tools deps to my fork; I'll open PRs to get those changes upstreamed soon.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
