### PR TITLE
fix incorrect count calculation for host->guest stream writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5317,7 +5317,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen"
 version = "0.41.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=3df706cf#3df706cf7bea2a32093d1c3dc7a4dc759322bdf7"
+source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=ec56282b#ec56282b62be6b9619df4ea0cb8b79d828b5d070"
 dependencies = [
  "wit-bindgen-rt 0.41.0",
  "wit-bindgen-rust-macro",
@@ -5326,7 +5326,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-core"
 version = "0.41.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=3df706cf#3df706cf7bea2a32093d1c3dc7a4dc759322bdf7"
+source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=ec56282b#ec56282b62be6b9619df4ea0cb8b79d828b5d070"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -5345,7 +5345,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-rt"
 version = "0.41.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=3df706cf#3df706cf7bea2a32093d1c3dc7a4dc759322bdf7"
+source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=ec56282b#ec56282b62be6b9619df4ea0cb8b79d828b5d070"
 dependencies = [
  "bitflags 2.6.0",
  "futures",
@@ -5355,7 +5355,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-rust"
 version = "0.41.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=3df706cf#3df706cf7bea2a32093d1c3dc7a4dc759322bdf7"
+source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=ec56282b#ec56282b62be6b9619df4ea0cb8b79d828b5d070"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -5370,7 +5370,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-rust-macro"
 version = "0.41.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=3df706cf#3df706cf7bea2a32093d1c3dc7a4dc759322bdf7"
+source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=ec56282b#ec56282b62be6b9619df4ea0cb8b79d828b5d070"
 dependencies = [
  "anyhow",
  "prettyplease",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -301,9 +301,9 @@ io-lifetimes = { version = "2.0.3", default-features = false }
 io-extras = "0.18.1"
 rustix = "0.38.43"
 # TODO: switch back to release:
-wit-bindgen = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "3df706cf", default-features = false }
-wit-bindgen-rt = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "3df706cf", default-features = false }
-wit-bindgen-rust-macro = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "3df706cf", default-features = false }
+wit-bindgen = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "ec56282b", default-features = false }
+wit-bindgen-rt = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "ec56282b", default-features = false }
+wit-bindgen-rust-macro = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "ec56282b", default-features = false }
 
 # wasm-tools family:
 # TODO: switch back to release:

--- a/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
@@ -143,7 +143,7 @@ fn accept<T: func::Lower + Send + Sync + 'static, B: Buffer<T>, U>(
                     .and_then(|b| b.get_mut(..T::SIZE32 * count))
                     .ok_or_else(|| anyhow::anyhow!("read pointer out of bounds of memory"))?;
 
-                let count = values.len().min(usize::try_from(count).unwrap());
+                let count = (values.len() - offset).min(usize::try_from(count).unwrap());
 
                 if let Some(ty) = payload(ty, types) {
                     T::store_list(lower, ty, address, &values[offset..][..count])?;


### PR DESCRIPTION
This also updates the `wit-bindgen` dep to pull in an alignment fix.

Fixes #85

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
