### PR TITLE
trap if sync->async call fails to produce a result

### DIFF
--- a/tests/misc_testsuite/component-model-async/fused.wast
+++ b/tests/misc_testsuite/component-model-async/fused.wast
@@ -51,8 +51,7 @@
   (func (export "run") (alias export $lowerer "run"))
 )
 
-;; TODO: this requires async support in `wasmtime-wast`:
-;;(assert_return (invoke "run"))
+(assert_return (invoke "run"))
 
 ;; async lower -> async lift with callback
 (component
@@ -105,8 +104,7 @@
   (func (export "run") (alias export $lowerer "run"))
 )
 
-;; TODO: this requires async support in `wasmtime-wast`:
-;;(assert_return (invoke "run"))
+(assert_return (invoke "run"))
 
 ;; async lower -> sync lift
 (component
@@ -152,8 +150,7 @@
   (func (export "run") (alias export $lowerer "run"))
 )
 
-;; TODO: this requires async support in `wasmtime-wast`:
-;;(assert_return (invoke "run"))
+(assert_return (invoke "run"))
 
 ;; sync lower -> async lift without callback
 (component
@@ -196,8 +193,7 @@
   (func (export "run") (alias export $lowerer "run"))
 )
 
-;; TODO: this requires async support in `wasmtime-wast`:
-;;(assert_return (invoke "run"))
+(assert_return (invoke "run"))
 
 ;; sync lower -> async lift with callback
 (component
@@ -244,5 +240,4 @@
   (func (export "run") (alias export $lowerer "run"))
 )
 
-;; TODO: this requires async support in `wasmtime-wast`:
-;;(assert_return (invoke "run"))
+(assert_return (invoke "run"))

--- a/tests/misc_testsuite/component-model-async/wait-forever.wast
+++ b/tests/misc_testsuite/component-model-async/wait-forever.wast
@@ -1,0 +1,56 @@
+;;! cm_async = true
+;;! reference_types = true
+;;! gc_types = true
+;;! multi_memory = true
+
+(component
+  (component $child
+    (core module $libc (memory (export "memory") 1))
+    (core instance $libc (instantiate $libc))
+
+    (core module $m
+      (import "" "waitable-set-new" (func $waitable-set-new (result i32)))
+      (func (export "run") (result i32)
+        call $waitable-set-new
+        i32.const 4
+        i32.shl
+        i32.const 2 ;; CallbackCode.WAIT
+        i32.or
+      )
+
+      (func (export "cb") (param i32 i32 i32) (result i32)
+        unreachable)
+    )
+
+    (core func $waitable-set-new (canon waitable-set.new))
+
+    (core instance $i (instantiate $m
+      (with "" (instance
+        (export "waitable-set-new" (func $waitable-set-new))
+      ))
+    ))
+    
+    (func (export "run")
+      (canon lift (core func $i "run") async (callback (func $i "cb"))))
+  )
+  (instance $child (instantiate $child))
+
+  (core func $child-run (canon lower (func $child "run")))
+
+  (core module $m
+    (import "" "child-run" (func $child-run))
+
+    (func (export "run")
+      (call $child-run))
+  )
+  (core instance $i (instantiate $m
+    (with "" (instance
+      (export "child-run" (func $child-run))
+    ))
+  ))
+
+  (func (export "run")
+    (canon lift (core func $i "run")))
+)
+
+(assert_trap (invoke "run") "async-lifted export failed to produce a result")


### PR DESCRIPTION
If the callee returns `CallbackCode.WAIT` and the event loop runs out of futures without producing a ready waitable, we should trap.  We were doing that in other contexts, but not for sync->async calls.

Fixes #73

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
