### PR TITLE
add `Instance::promise` for wrapping a `Future` in a  `Promise`

### DIFF
--- a/crates/misc/component-async-tests/tests/scenario/streams.rs
+++ b/crates/misc/component-async-tests/tests/scenario/streams.rs
@@ -104,7 +104,7 @@ pub async fn async_watch_streams() -> Result<()> {
     promises.push(
         watch
             .into_inner()
-            .write(Single::new(42))
+            .write_all(Single::new(42))
             .map(|(w, _)| Event::Write(w)),
     );
     promises.push(rx.read(Single::default()).map(|(r, b)| Event::Read(r, b)));
@@ -129,7 +129,7 @@ pub async fn async_watch_streams() -> Result<()> {
         .await?;
     assert!(watch
         .into_inner()
-        .write(Single::new(42))
+        .write_all(Single::new(42))
         .get(&mut store)
         .await?
         .0
@@ -208,7 +208,7 @@ pub async fn test_closed_streams(watch: bool) -> Result<()> {
 
         let mut promises = PromisesUnordered::new();
         promises.push(
-            tx.write(values.clone().into())
+            tx.write_all(values.clone().into())
                 .map(|(w, _)| StreamEvent::FirstWrite(w)),
         );
         promises.push(
@@ -229,7 +229,7 @@ pub async fn test_closed_streams(watch: bool) -> Result<()> {
                         );
                     } else {
                         promises.push(
-                            tx.write(values.clone().into())
+                            tx.write_all(values.clone().into())
                                 .map(|(w, _)| StreamEvent::SecondWrite(w)),
                         );
                     }
@@ -304,7 +304,7 @@ pub async fn test_closed_streams(watch: bool) -> Result<()> {
                 .map(|()| StreamEvent::GuestCompleted),
         );
         promises.push(
-            tx.write(values.clone().into())
+            tx.write_all(values.clone().into())
                 .map(|(w, _)| StreamEvent::FirstWrite(w)),
         );
 
@@ -317,7 +317,7 @@ pub async fn test_closed_streams(watch: bool) -> Result<()> {
                         promises.push(tx.watch_reader().0.map(|()| StreamEvent::SecondWrite(None)));
                     } else {
                         promises.push(
-                            tx.write(values.clone().into())
+                            tx.write_all(values.clone().into())
                                 .map(|(w, _)| StreamEvent::SecondWrite(w)),
                         );
                     }

--- a/crates/misc/component-async-tests/tests/scenario/transmit.rs
+++ b/crates/misc/component-async-tests/tests/scenario/transmit.rs
@@ -251,13 +251,13 @@ async fn test_transmit_with<Test: TransmitTest + 'static>(component: &[u8]) -> R
 
     promises.push(
         control_tx
-            .write(Single::new(Control::ReadStream("a".into())))
+            .write_all(Single::new(Control::ReadStream("a".into())))
             .map(|(w, _)| Event::ControlWriteA(w)),
     );
 
     promises.push(
         caller_stream_tx
-            .write(Single::new(String::from("a")))
+            .write_all(Single::new(String::from("a")))
             .map(|_| Event::WriteA),
     );
 
@@ -286,7 +286,7 @@ async fn test_transmit_with<Test: TransmitTest + 'static>(component: &[u8]) -> R
             Event::ControlWriteA(tx) => {
                 promises.push(
                     tx.unwrap()
-                        .write(Single::new(Control::ReadFuture("b".into())))
+                        .write_all(Single::new(Control::ReadFuture("b".into())))
                         .map(|(w, _)| Event::ControlWriteB(w)),
                 );
             }
@@ -302,7 +302,7 @@ async fn test_transmit_with<Test: TransmitTest + 'static>(component: &[u8]) -> R
             Event::ControlWriteB(tx) => {
                 promises.push(
                     tx.unwrap()
-                        .write(Single::new(Control::WriteStream("c".into())))
+                        .write_all(Single::new(Control::WriteStream("c".into())))
                         .map(|(w, _)| Event::ControlWriteC(w)),
                 );
             }
@@ -319,7 +319,7 @@ async fn test_transmit_with<Test: TransmitTest + 'static>(component: &[u8]) -> R
             Event::ControlWriteC(tx) => {
                 promises.push(
                     tx.unwrap()
-                        .write(Single::new(Control::WriteFuture("d".into())))
+                        .write_all(Single::new(Control::WriteFuture("d".into())))
                         .map(|_| Event::ControlWriteD),
                 );
             }


### PR DESCRIPTION
This may be useful as e.g. an alternative or complement to `PromisesUnordered`
where you want to compose some number of `Promise`s in an `async` function or
block with arbitrary control flow that might be cumbersome to express using
`PromisesUnordered` by itself.  It can also be used to reverse a previous
`Promise::into_future` operation.

This also contains minor, unrelated tweaks to tests which I meant to include in previous PR.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
