### PR TITLE
remove `Bytes{Mut}Buffer` in favor of `Cursor<Bytes{Mut}>`

### DIFF
--- a/crates/wasi/src/p3/cli/host.rs
+++ b/crates/wasi/src/p3/cli/host.rs
@@ -1,8 +1,9 @@
 use anyhow::{anyhow, Context as _};
 use bytes::BytesMut;
+use std::io::Cursor;
 use tokio::io::{AsyncRead, AsyncReadExt as _, AsyncWrite, AsyncWriteExt as _};
 use wasmtime::component::{
-    Accessor, AccessorTask, BytesMutBuffer, HostStream, Resource, StreamReader, StreamWriter,
+    Accessor, AccessorTask, HostStream, Resource, StreamReader, StreamWriter,
 };
 
 use crate::p3::bindings::cli::{
@@ -14,7 +15,7 @@ use crate::p3::ResourceView as _;
 
 struct InputTask<T> {
     input: T,
-    tx: StreamWriter<BytesMutBuffer>,
+    tx: StreamWriter<Cursor<BytesMut>>,
 }
 
 impl<T, U, V> AccessorTask<T, U, wasmtime::Result<()>> for InputTask<V>
@@ -29,7 +30,7 @@ where
                 Ok(0) => return Ok(()),
                 Ok(_) => {
                     let (Some(tail), buf_again) =
-                        tx.write_all(BytesMutBuffer::from(buf)).into_future().await
+                        tx.write_all(Cursor::new(buf)).into_future().await
                     else {
                         break Ok(());
                     };

--- a/crates/wasi/src/p3/sockets/host/types/tcp.rs
+++ b/crates/wasi/src/p3/sockets/host/types/tcp.rs
@@ -9,7 +9,7 @@ use io_lifetimes::AsSocketlike as _;
 use rustix::io::Errno;
 use tokio::sync::mpsc;
 use wasmtime::component::{
-    Accessor, AccessorTask, HostFuture, HostStream, Resource, ResourceTable, Single, StreamWriter,
+    Accessor, AccessorTask, HostFuture, HostStream, Resource, ResourceTable, StreamWriter,
 };
 
 use crate::p3::bindings::sockets::types::{
@@ -51,7 +51,7 @@ fn get_socket_mut<'a>(
 
 struct ListenTask {
     family: SocketAddressFamily,
-    tx: StreamWriter<Single<Resource<TcpSocket>>>,
+    tx: StreamWriter<Option<Resource<TcpSocket>>>,
     rx: mpsc::Receiver<std::io::Result<(tokio::net::TcpStream, SocketAddr)>>,
 
     // The socket options below are not automatically inherited from the listener
@@ -170,7 +170,7 @@ impl<T, U: WasiSocketsView> AccessorTask<T, U, wasmtime::Result<()>> for ListenT
                     .table()
                     .push(TcpSocket::from_state(state, self.family))
                     .context("failed to push socket to table")?;
-                Ok::<_, wasmtime::Error>(tx.write(Single::new(socket)))
+                Ok::<_, wasmtime::Error>(tx.write(Some(socket)))
             })?;
             let (Some(tail), _) = fut.into_future().await else {
                 return Ok(());

--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -60,8 +60,8 @@ pub(crate) use futures_and_streams::{
     lower_error_context_to_index, lower_future_to_index, lower_stream_to_index, ResourcePair,
 };
 pub use futures_and_streams::{
-    BytesBuffer, BytesMutBuffer, ErrorContext, FutureReader, FutureWriter, HostFuture, HostStream,
-    ReadBuffer, Single, StreamReader, StreamWriter, VecBuffer, Watch, WriteBuffer,
+    ErrorContext, FutureReader, FutureWriter, HostFuture, HostStream, ReadBuffer, StreamReader,
+    StreamWriter, VecBuffer, Watch, WriteBuffer,
 };
 
 mod error_contexts;
@@ -2369,7 +2369,7 @@ impl Instance {
     pub fn promise<U: Send, V: Send + Sync + 'static>(
         &self,
         mut store: impl AsContextMut<Data = U>,
-        fut: impl Future<Output = V> + Send + 'static,
+        inner: Pin<Box<dyn Future<Output = V> + Send + 'static>>,
     ) -> Promise<V> {
         let store = store.as_context_mut();
         let instance = SendSyncPtr::new(
@@ -2377,7 +2377,7 @@ impl Instance {
         );
         let id = store.0.id();
         Promise {
-            inner: Box::pin(fut),
+            inner,
             instance,
             id,
         }

--- a/crates/wasmtime/src/runtime/component/mod.rs
+++ b/crates/wasmtime/src/runtime/component/mod.rs
@@ -116,9 +116,9 @@ mod values;
 pub use self::component::{Component, ComponentExportIndex};
 #[cfg(feature = "component-model-async")]
 pub use self::concurrent::{
-    AbortOnDropHandle, Accessor, AccessorTask, BytesBuffer, BytesMutBuffer, ErrorContext,
-    FutureReader, FutureWriter, HostFuture, HostStream, Promise, PromisesUnordered, ReadBuffer,
-    Single, StreamReader, StreamWriter, VMComponentAsyncStore, VecBuffer, Watch, WriteBuffer,
+    AbortOnDropHandle, Accessor, AccessorTask, ErrorContext, FutureReader, FutureWriter,
+    HostFuture, HostStream, Promise, PromisesUnordered, ReadBuffer, StreamReader, StreamWriter,
+    VMComponentAsyncStore, VecBuffer, Watch, WriteBuffer,
 };
 pub use self::func::{
     ComponentNamedList, ComponentType, Func, Lift, Lower, TypedFunc, WasmList, WasmStr,


### PR DESCRIPTION
Also, remove `Single` in favor of `Option` and refactor the `ReadBuffer` and `WriteBuffer` traits to avoid orphan rule issues.

Finally, update `Instance::promise` parameter type to accept an already-boxed `Future` to avoid redundant re-boxing.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
