### PR TITLE
fix save/restore of PC/FP/SP/limit on fiber switch

### DIFF
--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -3446,6 +3446,10 @@ impl ConcurrentState {
             global_error_context_ref_counts: BTreeMap::new(),
         }
     }
+
+    pub fn drop_table(&mut self) {
+        self.table = Table::new();
+    }
 }
 
 fn dummy_waker() -> Waker {

--- a/crates/wasmtime/src/runtime/component/store.rs
+++ b/crates/wasmtime/src/runtime/component/store.rs
@@ -5,7 +5,7 @@ macro_rules! component_store_data {
     ($($field:ident => $t:ty,)*) => (
         #[derive(Default)]
         pub struct ComponentStoreData {
-            $($field: Vec<$t>,)*
+            $(pub(crate) $field: Vec<$t>,)*
         }
 
         $(

--- a/crates/wasmtime/src/runtime/vm/component.rs
+++ b/crates/wasmtime/src/runtime/vm/component.rs
@@ -890,6 +890,11 @@ impl OwnedComponentInstance {
     pub fn resource_types_mut(&mut self) -> &mut Arc<dyn Any + Send + Sync> {
         unsafe { &mut (*self.ptr.as_ptr()).resource_types }
     }
+
+    #[cfg(feature = "component-model-async")]
+    pub fn drop_table(&mut self) {
+        unsafe { self.instance_mut().concurrent_state.drop_table() }
+    }
 }
 
 impl Deref for OwnedComponentInstance {


### PR DESCRIPTION
This fixes stack backtrace panics/SIGSEGVs due to broken `CallThreadState`/`VMStoreContext` PC/FP/SP/limit info which wasn't been updated correctly for nested fiber invocations.

Thanks to Alex for walking me through the code and sketching the solution.

Fixes #102

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
