### PR TITLE
Align return code of imports with the spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5267,7 +5267,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen"
 version = "0.41.0"
-source = "git+https://github.com/bytecodealliance/witx-bindgen#ef8647453a7bc5f1c1ec1876fb2d5554214c124d"
+source = "git+https://github.com/bytecodealliance/witx-bindgen#adbeb1bdadea0b85754fefef79a28198f6fdfd6c"
 dependencies = [
  "wit-bindgen-rt 0.41.0",
  "wit-bindgen-rust-macro",
@@ -5276,7 +5276,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-core"
 version = "0.41.0"
-source = "git+https://github.com/bytecodealliance/witx-bindgen#ef8647453a7bc5f1c1ec1876fb2d5554214c124d"
+source = "git+https://github.com/bytecodealliance/witx-bindgen#adbeb1bdadea0b85754fefef79a28198f6fdfd6c"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -5295,7 +5295,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-rt"
 version = "0.41.0"
-source = "git+https://github.com/bytecodealliance/witx-bindgen#ef8647453a7bc5f1c1ec1876fb2d5554214c124d"
+source = "git+https://github.com/bytecodealliance/witx-bindgen#adbeb1bdadea0b85754fefef79a28198f6fdfd6c"
 dependencies = [
  "bitflags 2.6.0",
  "futures",
@@ -5305,7 +5305,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-rust"
 version = "0.41.0"
-source = "git+https://github.com/bytecodealliance/witx-bindgen#ef8647453a7bc5f1c1ec1876fb2d5554214c124d"
+source = "git+https://github.com/bytecodealliance/witx-bindgen#adbeb1bdadea0b85754fefef79a28198f6fdfd6c"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -5320,7 +5320,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-rust-macro"
 version = "0.41.0"
-source = "git+https://github.com/bytecodealliance/witx-bindgen#ef8647453a7bc5f1c1ec1876fb2d5554214c124d"
+source = "git+https://github.com/bytecodealliance/witx-bindgen#adbeb1bdadea0b85754fefef79a28198f6fdfd6c"
 dependencies = [
  "anyhow",
  "prettyplease",

--- a/crates/environ/src/component/info.rs
+++ b/crates/environ/src/component/info.rs
@@ -643,6 +643,7 @@ pub struct Resource {
 ///
 /// Note that this type does not implement `Serialize` or `Deserialize` and
 /// that's intentional as this isn't stored in the final compilation artifact.
+#[derive(Debug)]
 pub enum Trampoline {
     /// Description of a lowered import used in conjunction with
     /// `GlobalInitializer::LowerImport`.

--- a/crates/test-programs/src/bin/async_poll_stackless.rs
+++ b/crates/test-programs/src/bin/async_poll_stackless.rs
@@ -79,8 +79,8 @@ unsafe extern "C" fn callback_run(event0: u32, event1: u32, _event2: u32) -> u32
 
             let set = *set;
             let result = async_when_ready();
-            let status = result >> 30;
-            let call = result & !(0b11 << 30);
+            let status = result & 0xf;
+            let call = result >> 4;
             assert!(status != STATUS_RETURNED);
             waitable_join(call, set);
 
@@ -117,7 +117,7 @@ unsafe extern "C" fn callback_run(event0: u32, event1: u32, _event2: u32) -> u32
             assert_eq!(event0, EVENT_NONE);
 
             let set = *set;
-            assert!(async_when_ready() == STATUS_RETURNED << 30);
+            assert!(async_when_ready() == STATUS_RETURNED);
 
             *state = State::S5 { set };
 

--- a/crates/test-programs/src/bin/async_poll_synchronous.rs
+++ b/crates/test-programs/src/bin/async_poll_synchronous.rs
@@ -45,8 +45,8 @@ impl Guest for Component {
             assert!(waitable_set_poll(set).is_none());
 
             let result = async_when_ready();
-            let status = result >> 30;
-            let call = result & !(0b11 << 30);
+            let status = result & 0xf;
+            let call = result >> 4;
             assert!(status != STATUS_RETURNED);
             waitable_join(call, set);
 
@@ -64,7 +64,7 @@ impl Guest for Component {
 
             assert!(waitable_set_poll(set).is_none());
 
-            assert!(async_when_ready() == STATUS_RETURNED << 30);
+            assert!(async_when_ready() == STATUS_RETURNED);
 
             assert!(waitable_set_poll(set).is_none());
 

--- a/crates/test-programs/src/bin/async_round_trip_many_stackful.rs
+++ b/crates/test-programs/src/bin/async_round_trip_many_stackful.rs
@@ -86,8 +86,8 @@ unsafe extern "C" fn export_foo(args: *mut u8) {
     let results = alloc::alloc(layout);
 
     let result = import_foo(params, results);
-    let mut status = result >> 30;
-    let call = result & !(0b11 << 30);
+    let mut status = result & 0xf;
+    let call = result >> 4;
     let set = waitable_set_new();
     if call != 0 {
         waitable_join(call, set);

--- a/crates/test-programs/src/bin/async_round_trip_stackful.rs
+++ b/crates/test-programs/src/bin/async_round_trip_stackful.rs
@@ -72,8 +72,8 @@ unsafe extern "C" fn export_foo(ptr: *mut u8, len: usize) {
     let results = alloc::alloc(layout);
 
     let result = import_foo(params, results);
-    let mut status = result >> 30;
-    let call = result & !(0b11 << 30);
+    let mut status = result & 0xf;
+    let call = result >> 4;
     let set = waitable_set_new();
     if call != 0 {
         waitable_join(call, set);

--- a/crates/wasmtime/src/runtime/component/func/host.rs
+++ b/crates/wasmtime/src/runtime/component/func/host.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "component-model-async")]
-use crate::component::concurrent::Accessor;
+use crate::component::concurrent::{Accessor, Status};
 use crate::component::func::{LiftContext, LowerContext, Options};
 use crate::component::matching::InstanceType;
 use crate::component::storage::slice_to_storage_mut;
@@ -22,11 +22,6 @@ use wasmtime_environ::component::{
     CanonicalAbiInfo, ComponentTypes, InterfaceType, RuntimeComponentInstanceIndex, StringEncoding,
     TypeFuncIndex, MAX_FLAT_PARAMS, MAX_FLAT_RESULTS,
 };
-
-#[cfg(feature = "component-model-async")]
-const STATUS_PARAMS_READ: u32 = 1;
-#[cfg(feature = "component-model-async")]
-const STATUS_DONE: u32 = 3;
 
 pub struct HostFunc {
     entrypoint: VMLoweringCallee,
@@ -335,9 +330,9 @@ where
             })?;
 
             let status = if let Some(task) = task {
-                (STATUS_PARAMS_READ << 30) | task
+                Status::Started.pack(Some(task))
             } else {
-                STATUS_DONE << 30
+                Status::Returned.pack(None)
             };
 
             storage[0] = MaybeUninit::new(ValRaw::i32(status as i32));
@@ -591,9 +586,9 @@ where
                 })?;
 
             let status = if let Some(task) = task {
-                (STATUS_PARAMS_READ << 30) | task
+                Status::Started.pack(Some(task))
             } else {
-                STATUS_DONE << 30
+                Status::Returned.pack(None)
             };
 
             storage[0] = MaybeUninit::new(ValRaw::i32(status as i32));


### PR DESCRIPTION
Instead of using the upper 2 bits for the status code use the lower 4 bits. This fixes an outstanding mismatch with the spec (but more still remain).

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
