### PR TITLE
fix spurious panics with multiple concurrent instances

### DIFF
--- a/crates/misc/component-async-tests/tests/scenario/round_trip.rs
+++ b/crates/misc/component-async-tests/tests/scenario/round_trip.rs
@@ -163,6 +163,19 @@ pub async fn async_round_trip_stackless() -> Result<()> {
 }
 
 #[tokio::test]
+pub async fn async_round_trip_stackless_joined() -> Result<()> {
+    let component =
+        &fs::read(test_programs_artifacts::ASYNC_ROUND_TRIP_STACKLESS_COMPONENT).await?;
+
+    tokio::join!(
+        async { test_round_trip_uncomposed(component).await.unwrap() },
+        async { test_round_trip_uncomposed(component).await.unwrap() },
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
 pub async fn async_round_trip_stackless_sync_import() -> Result<()> {
     test_round_trip_uncomposed(
         &fs::read(test_programs_artifacts::ASYNC_ROUND_TRIP_STACKLESS_SYNC_IMPORT_COMPONENT)


### PR DESCRIPTION
The thread-local variable management in `ComponentInstance::poll_until` was too coarse-grained; we should have been setting/resetting it on each poll rather than for the lifetime of the future.

Fixes #122

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
