### PR TITLE
consolidate redundant `Config` code in `component-async-tests`

### DIFF
--- a/crates/misc/component-async-tests/src/util.rs
+++ b/crates/misc/component-async-tests/src/util.rs
@@ -23,6 +23,21 @@ pub fn init_logger() {
     ONCE.call_once(env_logger::init);
 }
 
+pub fn config() -> Config {
+    init_logger();
+
+    let mut config = Config::new();
+    config.debug_info(true);
+    config.cranelift_debug_verifier(true);
+    config.wasm_component_model(true);
+    config.wasm_component_model_async(true);
+    config.wasm_component_model_async_builtins(true);
+    config.wasm_component_model_async_stackful(true);
+    config.wasm_component_model_error_context(true);
+    config.async_support(true);
+    config
+}
+
 /// Compose two components
 ///
 /// a is the "root" component, and b is composed into it
@@ -53,16 +68,7 @@ pub async fn test_run(component: &[u8]) -> Result<()> {
 }
 
 pub async fn test_run_with_count(component: &[u8], count: usize) -> Result<()> {
-    init_logger();
-
-    let mut config = Config::new();
-    config.debug_info(true);
-    config.cranelift_debug_verifier(true);
-    config.wasm_component_model(true);
-    config.wasm_component_model_async(true);
-    config.wasm_component_model_async_builtins(true);
-    config.wasm_component_model_error_context(true);
-    config.async_support(true);
+    let mut config = config();
     config.epoch_interruption(true);
 
     let engine = Engine::new(&config)?;

--- a/crates/misc/component-async-tests/tests/scenario/borrowing.rs
+++ b/crates/misc/component-async-tests/tests/scenario/borrowing.rs
@@ -5,10 +5,10 @@ use anyhow::Result;
 use futures::stream::{FuturesUnordered, TryStreamExt};
 use tokio::fs;
 use wasmtime::component::{Component, Linker, ResourceTable};
-use wasmtime::{Config, Engine, Store};
+use wasmtime::{Engine, Store};
 use wasmtime_wasi::p2::WasiCtxBuilder;
 
-use component_async_tests::util::{annotate, compose, init_logger};
+use component_async_tests::util::{annotate, compose, config};
 
 #[tokio::test]
 pub async fn async_borrowing_caller() -> Result<()> {
@@ -46,14 +46,7 @@ pub async fn async_borrowing_callee() -> Result<()> {
 }
 
 pub async fn test_run_bool(component: &[u8], v: bool) -> Result<()> {
-    init_logger();
-
-    let mut config = Config::new();
-    config.debug_info(true);
-    config.cranelift_debug_verifier(true);
-    config.wasm_component_model(true);
-    config.wasm_component_model_async(true);
-    config.async_support(true);
+    let mut config = config();
     config.epoch_interruption(true);
 
     let engine = Engine::new(&config)?;

--- a/crates/misc/component-async-tests/tests/scenario/common.rs
+++ b/crates/misc/component-async-tests/tests/scenario/common.rs
@@ -48,14 +48,7 @@ pub async fn compose(a: &[u8], b: &[u8]) -> Result<Vec<u8>> {
 
 #[allow(unused)]
 pub async fn test_run(component: &[u8]) -> Result<()> {
-    init_logger();
-
-    let mut config = Config::new();
-    config.debug_info(true);
-    config.cranelift_debug_verifier(true);
-    config.wasm_component_model(true);
-    config.wasm_component_model_async(true);
-    config.async_support(true);
+    let mut config = config();
     config.epoch_interruption(true);
 
     let engine = Engine::new(&config)?;

--- a/crates/misc/component-async-tests/tests/scenario/proxy.rs
+++ b/crates/misc/component-async-tests/tests/scenario/proxy.rs
@@ -13,10 +13,10 @@ use tokio::fs;
 use wasi_http_draft::wasi::http::types::{ErrorCode, Method, Scheme};
 use wasi_http_draft::{Body, Fields, Request, Response};
 use wasmtime::component::{Component, Linker, Resource, ResourceTable, StreamReader, StreamWriter};
-use wasmtime::{Config, Engine, Store};
+use wasmtime::{Engine, Store};
 use wasmtime_wasi::p2::{IoView, WasiCtxBuilder};
 
-use component_async_tests::util::{annotate, compose, init_logger};
+use component_async_tests::util::{annotate, compose, config, init_logger};
 
 #[tokio::test]
 pub async fn async_http_echo() -> Result<()> {
@@ -103,13 +103,7 @@ async fn test_http_echo(component: &[u8], use_compression: bool) -> Result<()> {
 
     init_logger();
 
-    let mut config = Config::new();
-    config.cranelift_debug_verifier(true);
-    config.wasm_component_model(true);
-    config.wasm_component_model_async(true);
-    config.async_support(true);
-
-    let engine = Engine::new(&config)?;
+    let engine = Engine::new(&config())?;
 
     let component = Component::new(&engine, component)?;
 

--- a/crates/misc/component-async-tests/tests/scenario/round_trip.rs
+++ b/crates/misc/component-async-tests/tests/scenario/round_trip.rs
@@ -15,12 +15,12 @@ use tokio::fs;
 use wasmtime::component::{
     Accessor, AccessorTask, Component, Instance, Linker, ResourceTable, Val,
 };
-use wasmtime::{Config, Engine, Store};
+use wasmtime::{Engine, Store};
 use wasmtime_wasi::p2::WasiCtxBuilder;
 
 use component_async_tests::Ctx;
 
-pub use component_async_tests::util::{annotate, compose, init_logger};
+pub use component_async_tests::util::{annotate, compose, config};
 
 #[tokio::test]
 pub async fn async_round_trip_stackful() -> Result<()> {
@@ -185,18 +185,7 @@ pub async fn async_round_trip_stackless_sync_import() -> Result<()> {
 }
 
 pub async fn test_round_trip(component: &[u8], inputs_and_outputs: &[(&str, &str)]) -> Result<()> {
-    init_logger();
-
-    let mut config = Config::new();
-    config.debug_info(true);
-    config.cranelift_debug_verifier(true);
-    config.wasm_component_model(true);
-    config.wasm_component_model_async(true);
-    config.wasm_component_model_async_builtins(true);
-    config.wasm_component_model_async_stackful(true);
-    config.async_support(true);
-
-    let engine = Engine::new(&config)?;
+    let engine = Engine::new(&config())?;
 
     let make_store = || {
         Store::new(
@@ -513,20 +502,9 @@ pub async fn panic_on_recursive_run() {
 }
 
 async fn test_panic(component: &[u8], kind: PanicKind) -> Result<()> {
-    init_logger();
-
     let inputs_and_outputs = &[("a", "b"), ("c", "d")];
 
-    let mut config = Config::new();
-    config.debug_info(true);
-    config.cranelift_debug_verifier(true);
-    config.wasm_component_model(true);
-    config.wasm_component_model_async(true);
-    config.wasm_component_model_async_builtins(true);
-    config.wasm_component_model_async_stackful(true);
-    config.async_support(true);
-
-    let engine = Engine::new(&config)?;
+    let engine = Engine::new(&config())?;
 
     let make_store = || {
         Store::new(

--- a/crates/misc/component-async-tests/tests/scenario/round_trip_direct.rs
+++ b/crates/misc/component-async-tests/tests/scenario/round_trip_direct.rs
@@ -5,10 +5,10 @@ use anyhow::{anyhow, Result};
 use futures::stream::{FuturesUnordered, TryStreamExt};
 use tokio::fs;
 use wasmtime::component::{Component, Linker, ResourceTable, Val};
-use wasmtime::{Config, Engine, Store};
+use wasmtime::{Engine, Store};
 use wasmtime_wasi::p2::WasiCtxBuilder;
 
-use component_async_tests::util::{annotate, init_logger};
+use component_async_tests::util::{annotate, config};
 use component_async_tests::Ctx;
 
 #[tokio::test]
@@ -39,16 +39,7 @@ async fn test_round_trip_direct(
     input: &str,
     expected_output: &str,
 ) -> Result<()> {
-    init_logger();
-
-    let mut config = Config::new();
-    config.debug_info(true);
-    config.cranelift_debug_verifier(true);
-    config.wasm_component_model(true);
-    config.wasm_component_model_async(true);
-    config.async_support(true);
-
-    let engine = Engine::new(&config)?;
+    let engine = Engine::new(&config())?;
 
     let make_store = || {
         Store::new(

--- a/crates/misc/component-async-tests/tests/scenario/round_trip_many.rs
+++ b/crates/misc/component-async-tests/tests/scenario/round_trip_many.rs
@@ -9,10 +9,10 @@ use futures::{
 };
 use tokio::fs;
 use wasmtime::component::{Component, Linker, ResourceTable, Val};
-use wasmtime::{Config, Engine, Store};
+use wasmtime::{Engine, Store};
 use wasmtime_wasi::p2::WasiCtxBuilder;
 
-use component_async_tests::util::{annotate, compose, init_logger};
+use component_async_tests::util::{annotate, compose, config};
 use component_async_tests::Ctx;
 
 #[tokio::test]
@@ -184,18 +184,7 @@ async fn test_round_trip_many_uncomposed(component: &[u8]) -> Result<()> {
 async fn test_round_trip_many(component: &[u8], inputs_and_outputs: &[(&str, &str)]) -> Result<()> {
     use component_async_tests::round_trip_many::bindings::exports::local::local::many;
 
-    init_logger();
-
-    let mut config = Config::new();
-    config.debug_info(true);
-    config.cranelift_debug_verifier(true);
-    config.wasm_component_model(true);
-    config.wasm_component_model_async(true);
-    config.wasm_component_model_async_builtins(true);
-    config.wasm_component_model_async_stackful(true);
-    config.async_support(true);
-
-    let engine = Engine::new(&config)?;
+    let engine = Engine::new(&config())?;
 
     let make_store = || {
         Store::new(

--- a/crates/misc/component-async-tests/tests/scenario/streams.rs
+++ b/crates/misc/component-async-tests/tests/scenario/streams.rs
@@ -1,6 +1,6 @@
 use {
     anyhow::Result,
-    component_async_tests::{closed_streams, util::init_logger, Ctx},
+    component_async_tests::{closed_streams, util::config, Ctx},
     futures::{
         future::{self, FutureExt},
         stream::{FuturesUnordered, StreamExt, TryStreamExt},
@@ -12,21 +12,14 @@ use {
     tokio::fs,
     wasmtime::{
         component::{Component, Linker, ResourceTable, StreamReader, StreamWriter, VecBuffer},
-        Config, Engine, Store,
+        Engine, Store,
     },
     wasmtime_wasi::p2::WasiCtxBuilder,
 };
 
 #[tokio::test]
 pub async fn async_watch_streams() -> Result<()> {
-    init_logger();
-
-    let mut config = Config::new();
-    config.wasm_component_model(true);
-    config.wasm_component_model_async(true);
-    config.async_support(true);
-
-    let engine = Engine::new(&config)?;
+    let engine = Engine::new(&config())?;
 
     let mut store = Store::new(
         &engine,
@@ -151,16 +144,7 @@ pub async fn async_closed_streams_with_watch() -> Result<()> {
 }
 
 pub async fn test_closed_streams(watch: bool) -> Result<()> {
-    init_logger();
-
-    let mut config = Config::new();
-    config.debug_info(true);
-    config.cranelift_debug_verifier(true);
-    config.wasm_component_model(true);
-    config.wasm_component_model_async(true);
-    config.async_support(true);
-
-    let engine = Engine::new(&config)?;
+    let engine = Engine::new(&config())?;
 
     let mut store = Store::new(
         &engine,

--- a/crates/misc/component-async-tests/tests/scenario/transmit.rs
+++ b/crates/misc/component-async-tests/tests/scenario/transmit.rs
@@ -12,11 +12,11 @@ use wasmtime::component::{
     Component, HostFuture, HostStream, Instance, Linker, ResourceTable, StreamReader, StreamWriter,
     Val,
 };
-use wasmtime::{AsContextMut, Config, Engine, Store};
+use wasmtime::{AsContextMut, Engine, Store};
 use wasmtime_wasi::p2::WasiCtxBuilder;
 
 use component_async_tests::transmit::bindings::exports::local::local::transmit::Control;
-use component_async_tests::util::{compose, init_logger, test_run, test_run_with_count};
+use component_async_tests::util::{compose, config, test_run, test_run_with_count};
 use component_async_tests::{transmit, Ctx};
 
 #[tokio::test]
@@ -208,21 +208,12 @@ impl TransmitTest for DynamicTransmitTest {
 }
 
 async fn test_transmit(component: &[u8]) -> Result<()> {
-    init_logger();
-
     test_transmit_with::<StaticTransmitTest>(component).await?;
     test_transmit_with::<DynamicTransmitTest>(component).await
 }
 
 async fn test_transmit_with<Test: TransmitTest + 'static>(component: &[u8]) -> Result<()> {
-    let mut config = Config::new();
-    config.debug_info(true);
-    config.cranelift_debug_verifier(true);
-    config.wasm_component_model(true);
-    config.wasm_component_model_async(true);
-    config.async_support(true);
-
-    let engine = Engine::new(&config)?;
+    let engine = Engine::new(&config())?;
 
     let make_store = || {
         Store::new(


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
