### PR TITLE
Publish `dev` artifacts in CI

### DIFF
--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -13,7 +13,7 @@ jobs:
   publish:
     name: Publish artifacts of build
     runs-on: ubuntu-latest
-    if: github.repository == 'bytecodealliance/wasmtime'
+    if: github.repository == 'bytecodealliance/wasmtime' || github.repository == 'bytecodealliance/wasip3-prototyping'
     steps:
     - uses: actions/checkout@v4
     - uses: ./.github/actions/fetch-run-id


### PR DESCRIPTION
In thinking about how to set up `wit-bindgen` tests I'm reversing course and thinking it might be better to have everything live in `wit-bindgen`. Otherwise figuring out how to get the patches and stars to align to get everything tested feels kind of daunting, so my hope is that we'll eat some instability in the `wit-bindgen` CI for now by downloading a `dev` version of the `wasmtime` binary from here for async tests. If that causes too much instability in the `wit-bindgen` CI I figure we can reevaluate at that point.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
