### PR TITLE
Update ABI of `waitable-set.poll`

### DIFF
--- a/crates/test-programs/src/async_.rs
+++ b/crates/test-programs/src/async_.rs
@@ -42,13 +42,10 @@ unsafe extern "C" {
     pub fn waitable_set_poll_raw(_: u32, _: *mut u32) -> u32;
 }
 
-pub fn waitable_set_poll(set: u32) -> Option<(u32, u32, u32)> {
-    let mut payload = [0u32; 3];
-    if unsafe { waitable_set_poll_raw(set, payload.as_mut_ptr()) } != 0 {
-        Some((payload[0], payload[1], payload[2]))
-    } else {
-        None
-    }
+pub fn waitable_set_poll(set: u32) -> (u32, u32, u32) {
+    let mut payload = [0u32; 2];
+    let ret0 = unsafe { waitable_set_poll_raw(set, payload.as_mut_ptr()) };
+    (ret0, payload[0], payload[1])
 }
 
 #[cfg(target_arch = "wasm32")]


### PR DESCRIPTION
Match `waitable-set.wait` effectively, using `EVENT_NONE` for "nothing ready".

Closes #139

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
