### PR TITLE
return pending event if present instead of cancelling reads/writes

### DIFF
--- a/tests/misc_testsuite/component-model-async/future-cancel-read-closed.wast
+++ b/tests/misc_testsuite/component-model-async/future-cancel-read-closed.wast
@@ -1,0 +1,60 @@
+;;! component_model_async = true
+;;! reference_types = true
+;;! gc_types = true
+;;! multi_memory = true
+
+;; Create a future, start a read, close the write end, and cancel the read.
+(component
+  (type $f (future))
+  (core func $new (canon future.new $f))
+  (core module $libc (memory (export "mem") 1))
+  (core instance $libc (instantiate $libc))
+  (core func $read (canon future.read $f async (memory $libc "mem")))
+  (core func $cancel (canon future.cancel-read $f))
+  (core func $close-write (canon future.close-writable $f))
+  (core module $m
+    (import "" "new" (func $new (result i64)))
+    (import "" "read" (func $read (param i32 i32) (result i32)))
+    (import "" "cancel" (func $cancel (param i32) (result i32)))
+    (import "" "close-write" (func $close-write (param i32)))
+
+    (func (export "f") (result i32)
+      (local $read i32)
+      (local $write i32)
+      (local $new i64)
+
+      (local.set $new (call $new))
+      (local.set $read (i32.wrap_i64 (local.get $new)))
+      (local.set $write (i32.wrap_i64 (i64.shr_u (local.get $new) (i64.const 32))))
+
+      ;; start a read
+      local.get $read
+      i32.const 0
+      call $read
+      i32.const -1
+      i32.ne
+      if unreachable end
+
+      ;; close the write end
+      local.get $write
+      call $close-write
+
+      ;; cancel the read, returning the result
+      local.get $read
+      call $cancel
+    )
+  )
+
+  (core instance $i (instantiate $m
+    (with "" (instance
+      (export "new" (func $new))
+      (export "read" (func $read))
+      (export "cancel" (func $cancel))
+      (export "close-write" (func $close-write))
+    ))
+  ))
+
+  (func (export "f") (result u32) (canon lift (core func $i "f")))
+)
+
+(assert_return (invoke "f") (u32.const 1)) ;; expect CLOSED status (not CANCELLED)

--- a/tests/misc_testsuite/component-model-async/future-cancel-read-closed.wast
+++ b/tests/misc_testsuite/component-model-async/future-cancel-read-closed.wast
@@ -1,7 +1,4 @@
 ;;! component_model_async = true
-;;! reference_types = true
-;;! gc_types = true
-;;! multi_memory = true
 
 ;; Create a future, start a read, close the write end, and cancel the read.
 (component

--- a/tests/misc_testsuite/component-model-async/future-cancel-write-closed.wast
+++ b/tests/misc_testsuite/component-model-async/future-cancel-write-closed.wast
@@ -1,0 +1,60 @@
+;;! component_model_async = true
+;;! reference_types = true
+;;! gc_types = true
+;;! multi_memory = true
+
+;; Create a future, start a write, close the read end, and cancel the write.
+(component
+  (type $f (future))
+  (core func $new (canon future.new $f))
+  (core module $libc (memory (export "mem") 1))
+  (core instance $libc (instantiate $libc))
+  (core func $write (canon future.write $f async (memory $libc "mem")))
+  (core func $cancel (canon future.cancel-write $f))
+  (core func $close-read (canon future.close-readable $f))
+  (core module $m
+    (import "" "new" (func $new (result i64)))
+    (import "" "write" (func $write (param i32 i32) (result i32)))
+    (import "" "cancel" (func $cancel (param i32) (result i32)))
+    (import "" "close-read" (func $close-read (param i32)))
+
+    (func (export "f") (result i32)
+      (local $read i32)
+      (local $write i32)
+      (local $new i64)
+
+      (local.set $new (call $new))
+      (local.set $read (i32.wrap_i64 (local.get $new)))
+      (local.set $write (i32.wrap_i64 (i64.shr_u (local.get $new) (i64.const 32))))
+
+      ;; start a write
+      local.get $write
+      i32.const 0
+      call $write
+      i32.const -1
+      i32.ne
+      if unreachable end
+
+      ;; close the read end
+      local.get $read
+      call $close-read
+
+      ;; cancel the write, returning the result
+      local.get $write
+      call $cancel
+    )
+  )
+
+  (core instance $i (instantiate $m
+    (with "" (instance
+      (export "new" (func $new))
+      (export "write" (func $write))
+      (export "cancel" (func $cancel))
+      (export "close-read" (func $close-read))
+    ))
+  ))
+
+  (func (export "f") (result u32) (canon lift (core func $i "f")))
+)
+
+(assert_return (invoke "f") (u32.const 1)) ;; expect CLOSED status (not CANCELLED)

--- a/tests/misc_testsuite/component-model-async/future-cancel-write-closed.wast
+++ b/tests/misc_testsuite/component-model-async/future-cancel-write-closed.wast
@@ -1,7 +1,4 @@
 ;;! component_model_async = true
-;;! reference_types = true
-;;! gc_types = true
-;;! multi_memory = true
 
 ;; Create a future, start a write, close the read end, and cancel the write.
 (component

--- a/tests/misc_testsuite/component-model-async/future-cancel-write-completed.wast
+++ b/tests/misc_testsuite/component-model-async/future-cancel-write-completed.wast
@@ -1,0 +1,99 @@
+;;! component_model_async = true
+;;! reference_types = true
+;;! gc_types = true
+;;! multi_memory = true
+
+;; Create a future, start a write, let it complete, and cancel the write prior
+;; to receiving the completion event.
+(component
+  (type $f (future))
+
+  (component $c
+    (type $f (future))
+
+    (core module $libc (memory (export "mem") 1))
+    (core instance $libc (instantiate $libc))
+    (core func $read (canon future.read $f async (memory $libc "mem")))
+    (core func $close-read (canon future.close-readable $f))
+    (core module $inner
+      (import "" "read" (func $read (param i32 i32) (result i32)))
+      (import "" "close-read" (func $close-read (param i32)))
+
+      (func (export "f") (param i32)
+        ;; start a read, asserting it completes with one item
+        local.get 0
+        i32.const 0
+        call $read
+        i32.const 0x10
+        i32.ne
+        if unreachable end
+
+        ;; close the read end
+        local.get 0
+        call $close-read
+      )
+    )
+
+    (core instance $i (instantiate $inner
+      (with "" (instance
+        (export "read" (func $read))
+        (export "close-read" (func $close-read))
+      ))
+    ))
+
+    (func (export "f") (param "x" $f) (canon lift (core func $i "f")))
+  )
+  (instance $c (instantiate $c))
+
+  (core func $new (canon future.new $f))
+  (core module $libc (memory (export "mem") 1))
+  (core instance $libc (instantiate $libc))
+  (core func $write (canon future.write $f async (memory $libc "mem")))
+  (core func $cancel (canon future.cancel-write $f))
+  (core func $drain (canon lower (func $c "f")))
+  (core module $m
+    (import "" "new" (func $new (result i64)))
+    (import "" "write" (func $write (param i32 i32) (result i32)))
+    (import "" "cancel" (func $cancel (param i32) (result i32)))
+    (import "" "drain" (func $drain (param i32)))
+
+    (func (export "f") (result i32)
+      (local $read i32)
+      (local $write i32)
+      (local $new i64)
+
+      (local.set $new (call $new))
+      (local.set $read (i32.wrap_i64 (local.get $new)))
+      (local.set $write (i32.wrap_i64 (i64.shr_u (local.get $new) (i64.const 32))))
+
+      ;; start a write
+      local.get $write
+      i32.const 0
+      call $write
+      i32.const -1
+      i32.ne
+      if unreachable end
+
+      ;; drain the read end
+      local.get $read
+      call $drain
+
+      ;; cancel the write, returning the result
+      local.get $write
+      call $cancel
+    )
+  )
+
+  (core instance $i (instantiate $m
+    (with "" (instance
+      (export "new" (func $new))
+      (export "write" (func $write))
+      (export "cancel" (func $cancel))
+      (export "drain" (func $drain))
+    ))
+  ))
+
+  (func (export "f") (result u32) (canon lift (core func $i "f")))
+)
+
+(assert_return (invoke "f") (u32.const 0x10))

--- a/tests/misc_testsuite/component-model-async/future-cancel-write-completed.wast
+++ b/tests/misc_testsuite/component-model-async/future-cancel-write-completed.wast
@@ -1,7 +1,4 @@
 ;;! component_model_async = true
-;;! reference_types = true
-;;! gc_types = true
-;;! multi_memory = true
 
 ;; Create a future, start a write, let it complete, and cancel the write prior
 ;; to receiving the completion event.


### PR DESCRIPTION
Fixes #137
Fixes #138

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
