### PR TITLE
remove unnecessary assertion from `subtask_cancel`

### DIFF
--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -2409,7 +2409,10 @@ impl ComponentInstance {
                 // Started, but not yet returned or cancelled; send the
                 // `CANCELLED` event
                 task.cancel_sent = true;
-                assert!(task.event.is_none());
+                // Note that this might overwrite an event that was set earlier
+                // (e.g. `Event::None` if the task is yielding, or
+                // `Event::Cancelled` if it was already cancelled), but that's
+                // okay -- this should supersede the previous state.
                 task.event = Some(Event::Cancelled);
                 if let Some(set) = task.waiting_on.take() {
                     let item = match self.get_mut(set)?.waiting.remove(&guest_task).unwrap() {


### PR DESCRIPTION
If the task to be cancelled is yielding or was cancelled earlier, then an event will already have been set for that task, which is normal and does not indicate a bug.

Fixes #146

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
