### PR TITLE
Update wit-bindgen dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5201,7 +5201,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen"
 version = "0.41.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen#c9b4d1479a0175b6cf2fef58f3cbb66ebf09efe1"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#16ad2984059e9a895d0c51dfd65e00c20abd365f"
 dependencies = [
  "wit-bindgen-rt 0.41.0",
  "wit-bindgen-rust-macro",
@@ -5210,7 +5210,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-core"
 version = "0.41.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen#c9b4d1479a0175b6cf2fef58f3cbb66ebf09efe1"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#16ad2984059e9a895d0c51dfd65e00c20abd365f"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -5238,7 +5238,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-rt"
 version = "0.41.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen#c9b4d1479a0175b6cf2fef58f3cbb66ebf09efe1"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#16ad2984059e9a895d0c51dfd65e00c20abd365f"
 dependencies = [
  "bitflags 2.6.0",
  "futures",
@@ -5248,7 +5248,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-rust"
 version = "0.41.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen#c9b4d1479a0175b6cf2fef58f3cbb66ebf09efe1"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#16ad2984059e9a895d0c51dfd65e00c20abd365f"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -5263,7 +5263,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-rust-macro"
 version = "0.41.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen#c9b4d1479a0175b6cf2fef58f3cbb66ebf09efe1"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#16ad2984059e9a895d0c51dfd65e00c20abd365f"
 dependencies = [
  "anyhow",
  "prettyplease",


### PR DESCRIPTION
Pulling in some minor changes to the guest async runtime, also includes cancellation and usage of YIELD now too.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
