### PR TITLE
add `async_intertask_communication` test

### DIFF
--- a/crates/misc/component-async-tests/tests/scenario/transmit.rs
+++ b/crates/misc/component-async-tests/tests/scenario/transmit.rs
@@ -16,7 +16,7 @@ use wasmtime::{AsContextMut, Engine, Store};
 use wasmtime_wasi::p2::WasiCtxBuilder;
 
 use component_async_tests::transmit::bindings::exports::local::local::transmit::Control;
-use component_async_tests::util::{annotate, compose, config, test_run};
+use component_async_tests::util::{annotate, compose, config, test_run, test_run_with_count};
 use component_async_tests::{sleep, transmit, Ctx};
 
 use cancel::exports::local::local::cancel::Mode;
@@ -120,6 +120,15 @@ async fn test_cancel(mode: Mode) -> Result<()> {
     instance.run(&mut store, run).await??;
 
     Ok(())
+}
+
+#[tokio::test]
+pub async fn async_intertask_communication() -> Result<()> {
+    test_run_with_count(
+        &fs::read(test_programs_artifacts::ASYNC_INTERTASK_COMMUNICATION_COMPONENT).await?,
+        2,
+    )
+    .await
 }
 
 #[tokio::test]

--- a/crates/misc/component-async-tests/tests/test_all.rs
+++ b/crates/misc/component-async-tests/tests/test_all.rs
@@ -30,8 +30,8 @@ use scenario::round_trip_many::{
 };
 use scenario::streams::async_closed_streams;
 use scenario::transmit::{
-    async_cancel_callee, async_cancel_caller, async_poll_stackless, async_poll_synchronous,
-    async_transmit_callee, async_transmit_caller,
+    async_cancel_callee, async_cancel_caller, async_intertask_communication, async_poll_stackless,
+    async_poll_synchronous, async_transmit_callee, async_transmit_caller,
 };
 use scenario::unit_stream::{async_unit_stream_callee, async_unit_stream_caller};
 use scenario::yield_::{

--- a/crates/misc/component-async-tests/wit/test.wit
+++ b/crates/misc/component-async-tests/wit/test.wit
@@ -162,6 +162,10 @@ interface cancel {
   run: func(mode: mode);
 }
 
+interface intertask {
+  foo: func(fut: future);
+}
+
 world yield-caller {
   import continue;
   import ready;
@@ -308,4 +312,9 @@ world cancel-callee {
 
 world cancel-host {
   export cancel;
+}
+
+world intertask-communication {
+  import intertask;
+  export run;
 }

--- a/crates/test-programs/src/async_.rs
+++ b/crates/test-programs/src/async_.rs
@@ -133,6 +133,10 @@ pub const STATUS_RETURN_CANCELLED: u32 = 4;
 
 pub const EVENT_NONE: u32 = 0;
 pub const EVENT_SUBTASK: u32 = 1;
+pub const EVENT_STREAM_READ: u32 = 2;
+pub const EVENT_STREAM_WRITE: u32 = 3;
+pub const EVENT_FUTURE_READ: u32 = 4;
+pub const EVENT_FUTURE_WRITE: u32 = 5;
 pub const EVENT_CANCELLED: u32 = 6;
 
 pub const CALLBACK_CODE_EXIT: u32 = 0;

--- a/crates/test-programs/src/bin/async_intertask_communication.rs
+++ b/crates/test-programs/src/bin/async_intertask_communication.rs
@@ -1,0 +1,199 @@
+mod bindings {
+    wit_bindgen::generate!({
+        path: "../misc/component-async-tests/wit",
+        world: "intertask-communication",
+    });
+}
+
+use {
+    std::sync::atomic::{AtomicU32, Ordering::Relaxed},
+    test_programs::async_::{
+        context_get, context_set, waitable_join, waitable_set_drop, waitable_set_new, BLOCKED,
+        CALLBACK_CODE_EXIT, CALLBACK_CODE_WAIT, EVENT_FUTURE_WRITE, EVENT_NONE,
+    },
+};
+
+#[cfg(target_arch = "wasm32")]
+#[link(wasm_import_module = "[export]local:local/run")]
+unsafe extern "C" {
+    #[link_name = "[task-return][async]run"]
+    fn task_return_run();
+}
+#[cfg(not(target_arch = "wasm32"))]
+unsafe extern "C" fn task_return_run() {
+    unreachable!()
+}
+
+fn future_new() -> (u32, u32) {
+    #[cfg(target_arch = "wasm32")]
+    #[link(wasm_import_module = "local:local/intertask")]
+    unsafe extern "C" {
+        #[link_name = "[future-new-0]foo"]
+        fn future_new() -> u64;
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    unsafe extern "C" fn future_new() -> u64 {
+        unreachable!()
+    }
+
+    let pair = unsafe { future_new() };
+    (
+        (pair >> 32).try_into().unwrap(),
+        (pair & 0xFFFFFFFF_u64).try_into().unwrap(),
+    )
+}
+
+fn future_write(writer: u32) -> u32 {
+    #[cfg(target_arch = "wasm32")]
+    #[link(wasm_import_module = "local:local/intertask")]
+    unsafe extern "C" {
+        #[link_name = "[async-lower][future-write-0]foo"]
+        fn future_write(_: u32, _: u32) -> u32;
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    unsafe extern "C" fn future_write(_: u32, _: u32) -> u32 {
+        unreachable!()
+    }
+
+    unsafe { future_write(writer, 0) }
+}
+
+fn future_read(reader: u32) -> u32 {
+    #[cfg(target_arch = "wasm32")]
+    #[link(wasm_import_module = "local:local/intertask")]
+    unsafe extern "C" {
+        #[link_name = "[async-lower][future-read-0]foo"]
+        fn future_read(_: u32, _: u32) -> u32;
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    unsafe extern "C" fn future_read(_: u32, _: u32) -> u32 {
+        unreachable!()
+    }
+
+    unsafe { future_read(reader, 0) }
+}
+
+fn future_close_readable(reader: u32) {
+    #[cfg(target_arch = "wasm32")]
+    #[link(wasm_import_module = "local:local/intertask")]
+    unsafe extern "C" {
+        #[link_name = "[future-close-readable-0]foo"]
+        fn future_close_readable(_: u32);
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    unsafe extern "C" fn future_close_readable(_: u32) {
+        unreachable!()
+    }
+
+    unsafe { future_close_readable(reader) }
+}
+
+fn future_close_writable(writer: u32) {
+    #[cfg(target_arch = "wasm32")]
+    #[link(wasm_import_module = "local:local/intertask")]
+    unsafe extern "C" {
+        #[link_name = "[future-close-writable-0]foo"]
+        fn future_close_writable(_: u32);
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    unsafe extern "C" fn future_close_writable(_: u32) {
+        unreachable!()
+    }
+
+    unsafe { future_close_writable(writer) }
+}
+
+static TASK_NUMBER: AtomicU32 = AtomicU32::new(0);
+static SET: AtomicU32 = AtomicU32::new(0);
+
+enum State {
+    S0 { number: u32 },
+    S1 { set: u32 },
+}
+
+#[unsafe(export_name = "[async-lift]local:local/run#[async]run")]
+unsafe extern "C" fn export_run() -> u32 {
+    unsafe {
+        context_set(
+            u32::try_from(Box::into_raw(Box::new(State::S0 {
+                number: TASK_NUMBER.fetch_add(1, Relaxed),
+            })) as usize)
+            .unwrap(),
+        );
+        callback_run(EVENT_NONE, 0, 0)
+    }
+}
+
+#[unsafe(export_name = "[callback][async-lift]local:local/run#[async]run")]
+unsafe extern "C" fn callback_run(event0: u32, event1: u32, event2: u32) -> u32 {
+    unsafe {
+        let state = &mut *(usize::try_from(context_get()).unwrap() as *mut State);
+        match state {
+            State::S0 { number } => {
+                assert_eq!(event0, EVENT_NONE);
+
+                match *number {
+                    0 => {
+                        // Create a new waitable-set, store it for the other task to
+                        // find, then return `CALLBACK_CODE_WAIT` to wait on it.
+                        // This would lead to an infinite wait, except that the
+                        // other task will add to the waitable-set after this one
+                        // has started waiting and then trigger an event to wake it
+                        // up.
+                        let set = waitable_set_new();
+
+                        let old = SET.swap(set, Relaxed);
+                        assert_eq!(old, 0);
+
+                        *state = State::S1 { set };
+
+                        CALLBACK_CODE_WAIT | (set << 4)
+                    }
+                    1 => {
+                        // Retrieve the waitable-set our peer task is waiting on,
+                        // create a future, write to write end, add the write end to
+                        // the waitable-set, then read from the read end.  The read
+                        // should trigger an event on the write end, waking up the
+                        // peer task.
+                        let set = SET.swap(0, Relaxed);
+                        assert_ne!(set, 0);
+
+                        let (tx, rx) = future_new();
+                        let status = future_write(tx);
+                        assert_eq!(status, BLOCKED);
+
+                        waitable_join(tx, set);
+
+                        let status = future_read(rx);
+                        assert_eq!(status, 1 << 4); // i.e. one element was read
+
+                        future_close_readable(rx);
+
+                        task_return_run();
+                        CALLBACK_CODE_EXIT
+                    }
+                    _ => {
+                        unreachable!()
+                    }
+                }
+            }
+
+            State::S1 { set } => {
+                assert_eq!(event0, EVENT_FUTURE_WRITE);
+                assert_eq!(event2, 1 << 4); // i.e. one element was written
+
+                waitable_join(event1, 0);
+                waitable_set_drop(*set);
+                future_close_writable(event1);
+
+                TASK_NUMBER.store(0, Relaxed);
+
+                task_return_run();
+                CALLBACK_CODE_EXIT
+            }
+        }
+    }
+}
+
+// Unused function; required since this file is built as a `bin`:
+fn main() {}


### PR DESCRIPTION
In this test, the guest task returns `CALLBACK_CODE_WAIT` with an empty waitable set from its callback, relying on a second task to add a waitable to that set, trigger an event on it, and thereby wake up the first task.

Closes #142

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
