### PR TITLE
document more unsafe code

### DIFF
--- a/crates/wasmtime/src/runtime/component/instance.rs
+++ b/crates/wasmtime/src/runtime/component/instance.rs
@@ -916,8 +916,6 @@ impl<T> InstancePre<T> {
         );
         #[cfg(feature = "component-model-async")]
         {
-            // TODO: do we need to return the store here due to the possible
-            // invalidation of the reference we were passed?
             crate::component::concurrent::on_fiber(store, move |store| self.instantiate_impl(store))
                 .await?
         }
@@ -947,6 +945,9 @@ impl<T> InstancePre<T> {
         store.0.push_component_instance(instance);
         #[cfg(feature = "component-model-async")]
         {
+            // SAFETY: We have exclusive access to the store, which we means we
+            // have exclusive access to any `ComponentInstance` which resides in
+            // the store.
             let reference = unsafe { &mut *store.0[instance.0].as_ref().unwrap().instance_ptr() };
             reference.instance = Some(instance);
         }


### PR DESCRIPTION
This also adds an `unsafe` modifier to additional functions where appropriate, and removes redundant `StoreContextMut` parameters where the store can be derived from the `ComponentInstance`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
