### PR TITLE
consolidate unsafe code in `concurrent.rs` and friends

### DIFF
--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -9,7 +9,7 @@ inputs:
   msrv_range:
     description: 'Versions later-than-latest-Rust the MSRV supports'
     required: false
-    default: '2'
+    default: '1'
 
 runs:
   using: composite

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,7 +176,7 @@ authors = ["The Wasmtime Project Developers"]
 edition = "2021"
 # Wasmtime's current policy is that this number can be no larger than the
 # current stable release of Rust minus 2.
-rust-version = "1.84.0"
+rust-version = "1.85.0"
 
 [workspace.lints.rust]
 # Turn on some lints which are otherwise allow-by-default in rustc.

--- a/benches/call.rs
+++ b/benches/call.rs
@@ -360,7 +360,7 @@ fn wasm_to_host(c: &mut Criterion) {
             return;
         }
 
-        let mut typed = Linker::new(&engine);
+        let mut typed = Linker::<()>::new(&engine);
         typed
             .func_wrap_async("", "nop", |caller, _: ()| {
                 Box::new(async {

--- a/ci/build-test-matrix.js
+++ b/ci/build-test-matrix.js
@@ -95,12 +95,14 @@ const FULL_MATRIX = [
     "name": "Test Windows MSVC x86_64",
     "filter": "windows-x64",
   },
-  {
-    "os": windows,
-    "target": "x86_64-pc-windows-gnu",
-    "name": "Test Windows MinGW x86_64",
-    "filter": "mingw-x64"
-  },
+  // FIXME: As of this writing, some of the GitHub images have a broken MinGW,
+  // leading CI to fail nondeterministically.
+  // {
+  //   "os": windows,
+  //   "target": "x86_64-pc-windows-gnu",
+  //   "name": "Test Windows MinGW x86_64",
+  //   "filter": "mingw-x64"
+  // },
   {
     "os": ubuntu + '-arm',
     "target": "aarch64-unknown-linux-gnu",

--- a/crates/component-macro/tests/expanded/char.rs
+++ b/crates/component-macro/tests/expanded/char.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -127,7 +127,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate`].
-        pub fn instantiate<_T>(
+        pub fn instantiate<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -300,7 +300,7 @@ pub mod exports {
                         arg0: char,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -318,7 +318,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<char>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/char_async.rs
+++ b/crates/component-macro/tests/expanded/char_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -130,7 +130,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -311,7 +311,7 @@ pub mod exports {
                         arg0: char,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -331,7 +331,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<char>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/char_concurrent.rs
+++ b/crates/component-macro/tests/expanded/char_concurrent.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -130,7 +130,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -316,7 +316,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -334,7 +334,7 @@ pub mod exports {
                         Output = wasmtime::Result<char>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/char_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/char_tracing_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -130,7 +130,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -340,7 +340,7 @@ pub mod exports {
                         arg0: char,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -369,7 +369,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<char>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(

--- a/crates/component-macro/tests/expanded/conventions.rs
+++ b/crates/component-macro/tests/expanded/conventions.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -129,7 +129,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate`].
-        pub fn instantiate<_T>(
+        pub fn instantiate<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -592,7 +592,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -610,7 +610,7 @@ pub mod exports {
                         arg0: LudicrousSpeed,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -627,7 +627,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -643,7 +643,7 @@ pub mod exports {
                         S: wasmtime::AsContextMut,
                     >(&self, mut store: S) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -660,7 +660,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -677,7 +677,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -694,7 +694,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -711,7 +711,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -733,7 +733,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -750,7 +750,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -767,7 +767,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -785,7 +785,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/conventions_async.rs
+++ b/crates/component-macro/tests/expanded/conventions_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -132,7 +132,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -623,7 +623,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -641,7 +641,7 @@ pub mod exports {
                         arg0: LudicrousSpeed,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -660,7 +660,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -676,7 +676,7 @@ pub mod exports {
                         S: wasmtime::AsContextMut,
                     >(&self, mut store: S) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -693,7 +693,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -710,7 +710,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -727,7 +727,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -744,7 +744,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -766,7 +766,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -783,7 +783,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -800,7 +800,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -818,7 +818,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/conventions_concurrent.rs
+++ b/crates/component-macro/tests/expanded/conventions_concurrent.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -132,7 +132,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -639,7 +639,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -657,7 +657,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -674,7 +674,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -693,7 +693,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -710,7 +710,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -727,7 +727,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -744,7 +744,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -761,7 +761,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -783,7 +783,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -800,7 +800,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -817,7 +817,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -835,7 +835,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/conventions_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/conventions_tracing_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -132,7 +132,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -783,7 +783,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -812,7 +812,7 @@ pub mod exports {
                         arg0: LudicrousSpeed,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -840,7 +840,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -867,7 +867,7 @@ pub mod exports {
                         S: wasmtime::AsContextMut,
                     >(&self, mut store: S) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -896,7 +896,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -924,7 +924,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -952,7 +952,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -980,7 +980,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -1013,7 +1013,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -1041,7 +1041,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -1069,7 +1069,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -1098,7 +1098,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(

--- a/crates/component-macro/tests/expanded/dead-code.rs
+++ b/crates/component-macro/tests/expanded/dead-code.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Imports`] as well.
-pub struct ImportsPre<T> {
+pub struct ImportsPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: ImportsIndices,
 }
-impl<T> Clone for ImportsPre<T> {
+impl<T: 'static> Clone for ImportsPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for ImportsPre<T> {
         }
     }
 }
-impl<_T> ImportsPre<_T> {
+impl<_T: 'static> ImportsPre<_T> {
     /// Creates a new copy of `ImportsPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -121,7 +121,7 @@ const _: () = {
     impl Imports {
         /// Convenience wrapper around [`ImportsPre::new`] and
         /// [`ImportsPre::instantiate`].
-        pub fn instantiate<_T>(
+        pub fn instantiate<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/dead-code_async.rs
+++ b/crates/component-macro/tests/expanded/dead-code_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Imports`] as well.
-pub struct ImportsPre<T> {
+pub struct ImportsPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: ImportsIndices,
 }
-impl<T> Clone for ImportsPre<T> {
+impl<T: 'static> Clone for ImportsPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for ImportsPre<T> {
         }
     }
 }
-impl<_T> ImportsPre<_T> {
+impl<_T: 'static> ImportsPre<_T> {
     /// Creates a new copy of `ImportsPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -124,7 +124,7 @@ const _: () = {
     impl Imports {
         /// Convenience wrapper around [`ImportsPre::new`] and
         /// [`ImportsPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/dead-code_concurrent.rs
+++ b/crates/component-macro/tests/expanded/dead-code_concurrent.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Imports`] as well.
-pub struct ImportsPre<T> {
+pub struct ImportsPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: ImportsIndices,
 }
-impl<T> Clone for ImportsPre<T> {
+impl<T: 'static> Clone for ImportsPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for ImportsPre<T> {
         }
     }
 }
-impl<_T> ImportsPre<_T> {
+impl<_T: 'static> ImportsPre<_T> {
     /// Creates a new copy of `ImportsPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -124,7 +124,7 @@ const _: () = {
     impl Imports {
         /// Convenience wrapper around [`ImportsPre::new`] and
         /// [`ImportsPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/dead-code_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/dead-code_tracing_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Imports`] as well.
-pub struct ImportsPre<T> {
+pub struct ImportsPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: ImportsIndices,
 }
-impl<T> Clone for ImportsPre<T> {
+impl<T: 'static> Clone for ImportsPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for ImportsPre<T> {
         }
     }
 }
-impl<_T> ImportsPre<_T> {
+impl<_T: 'static> ImportsPre<_T> {
     /// Creates a new copy of `ImportsPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -124,7 +124,7 @@ const _: () = {
     impl Imports {
         /// Convenience wrapper around [`ImportsPre::new`] and
         /// [`ImportsPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/direct-import.rs
+++ b/crates/component-macro/tests/expanded/direct-import.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Foo`] as well.
-pub struct FooPre<T> {
+pub struct FooPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: FooIndices,
 }
-impl<T> Clone for FooPre<T> {
+impl<T: 'static> Clone for FooPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for FooPre<T> {
         }
     }
 }
-impl<_T> FooPre<_T> {
+impl<_T: 'static> FooPre<_T> {
     /// Creates a new copy of `FooPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -129,7 +129,7 @@ const _: () = {
     impl Foo {
         /// Convenience wrapper around [`FooPre::new`] and
         /// [`FooPre::instantiate`].
-        pub fn instantiate<_T>(
+        pub fn instantiate<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/direct-import_async.rs
+++ b/crates/component-macro/tests/expanded/direct-import_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Foo`] as well.
-pub struct FooPre<T> {
+pub struct FooPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: FooIndices,
 }
-impl<T> Clone for FooPre<T> {
+impl<T: 'static> Clone for FooPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for FooPre<T> {
         }
     }
 }
-impl<_T> FooPre<_T> {
+impl<_T: 'static> FooPre<_T> {
     /// Creates a new copy of `FooPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -134,7 +134,7 @@ const _: () = {
     impl Foo {
         /// Convenience wrapper around [`FooPre::new`] and
         /// [`FooPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/direct-import_concurrent.rs
+++ b/crates/component-macro/tests/expanded/direct-import_concurrent.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Foo`] as well.
-pub struct FooPre<T> {
+pub struct FooPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: FooIndices,
 }
-impl<T> Clone for FooPre<T> {
+impl<T: 'static> Clone for FooPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for FooPre<T> {
         }
     }
 }
-impl<_T> FooPre<_T> {
+impl<_T: 'static> FooPre<_T> {
     /// Creates a new copy of `FooPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -136,7 +136,7 @@ const _: () = {
     impl Foo {
         /// Convenience wrapper around [`FooPre::new`] and
         /// [`FooPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/direct-import_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/direct-import_tracing_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Foo`] as well.
-pub struct FooPre<T> {
+pub struct FooPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: FooIndices,
 }
-impl<T> Clone for FooPre<T> {
+impl<T: 'static> Clone for FooPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for FooPre<T> {
         }
     }
 }
-impl<_T> FooPre<_T> {
+impl<_T: 'static> FooPre<_T> {
     /// Creates a new copy of `FooPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -134,7 +134,7 @@ const _: () = {
     impl Foo {
         /// Convenience wrapper around [`FooPre::new`] and
         /// [`FooPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/empty.rs
+++ b/crates/component-macro/tests/expanded/empty.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Empty`] as well.
-pub struct EmptyPre<T> {
+pub struct EmptyPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: EmptyIndices,
 }
-impl<T> Clone for EmptyPre<T> {
+impl<T: 'static> Clone for EmptyPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for EmptyPre<T> {
         }
     }
 }
-impl<_T> EmptyPre<_T> {
+impl<_T: 'static> EmptyPre<_T> {
     /// Creates a new copy of `EmptyPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -121,7 +121,7 @@ const _: () = {
     impl Empty {
         /// Convenience wrapper around [`EmptyPre::new`] and
         /// [`EmptyPre::instantiate`].
-        pub fn instantiate<_T>(
+        pub fn instantiate<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/empty_async.rs
+++ b/crates/component-macro/tests/expanded/empty_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Empty`] as well.
-pub struct EmptyPre<T> {
+pub struct EmptyPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: EmptyIndices,
 }
-impl<T> Clone for EmptyPre<T> {
+impl<T: 'static> Clone for EmptyPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for EmptyPre<T> {
         }
     }
 }
-impl<_T> EmptyPre<_T> {
+impl<_T: 'static> EmptyPre<_T> {
     /// Creates a new copy of `EmptyPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -124,7 +124,7 @@ const _: () = {
     impl Empty {
         /// Convenience wrapper around [`EmptyPre::new`] and
         /// [`EmptyPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/empty_concurrent.rs
+++ b/crates/component-macro/tests/expanded/empty_concurrent.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Empty`] as well.
-pub struct EmptyPre<T> {
+pub struct EmptyPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: EmptyIndices,
 }
-impl<T> Clone for EmptyPre<T> {
+impl<T: 'static> Clone for EmptyPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for EmptyPre<T> {
         }
     }
 }
-impl<_T> EmptyPre<_T> {
+impl<_T: 'static> EmptyPre<_T> {
     /// Creates a new copy of `EmptyPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -124,7 +124,7 @@ const _: () = {
     impl Empty {
         /// Convenience wrapper around [`EmptyPre::new`] and
         /// [`EmptyPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/empty_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/empty_tracing_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Empty`] as well.
-pub struct EmptyPre<T> {
+pub struct EmptyPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: EmptyIndices,
 }
-impl<T> Clone for EmptyPre<T> {
+impl<T: 'static> Clone for EmptyPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for EmptyPre<T> {
         }
     }
 }
-impl<_T> EmptyPre<_T> {
+impl<_T: 'static> EmptyPre<_T> {
     /// Creates a new copy of `EmptyPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -124,7 +124,7 @@ const _: () = {
     impl Empty {
         /// Convenience wrapper around [`EmptyPre::new`] and
         /// [`EmptyPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/flags.rs
+++ b/crates/component-macro/tests/expanded/flags.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheFlags`] as well.
-pub struct TheFlagsPre<T> {
+pub struct TheFlagsPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheFlagsIndices,
 }
-impl<T> Clone for TheFlagsPre<T> {
+impl<T: 'static> Clone for TheFlagsPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheFlagsPre<T> {
         }
     }
 }
-impl<_T> TheFlagsPre<_T> {
+impl<_T: 'static> TheFlagsPre<_T> {
     /// Creates a new copy of `TheFlagsPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -127,7 +127,7 @@ const _: () = {
     impl TheFlags {
         /// Convenience wrapper around [`TheFlagsPre::new`] and
         /// [`TheFlagsPre::instantiate`].
-        pub fn instantiate<_T>(
+        pub fn instantiate<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -697,7 +697,7 @@ pub mod exports {
                         arg0: Flag1,
                     ) -> wasmtime::Result<Flag1>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -715,7 +715,7 @@ pub mod exports {
                         arg0: Flag2,
                     ) -> wasmtime::Result<Flag2>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -733,7 +733,7 @@ pub mod exports {
                         arg0: Flag4,
                     ) -> wasmtime::Result<Flag4>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -751,7 +751,7 @@ pub mod exports {
                         arg0: Flag8,
                     ) -> wasmtime::Result<Flag8>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -769,7 +769,7 @@ pub mod exports {
                         arg0: Flag16,
                     ) -> wasmtime::Result<Flag16>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -787,7 +787,7 @@ pub mod exports {
                         arg0: Flag32,
                     ) -> wasmtime::Result<Flag32>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -805,7 +805,7 @@ pub mod exports {
                         arg0: Flag64,
                     ) -> wasmtime::Result<Flag64>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/flags_async.rs
+++ b/crates/component-macro/tests/expanded/flags_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheFlags`] as well.
-pub struct TheFlagsPre<T> {
+pub struct TheFlagsPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheFlagsIndices,
 }
-impl<T> Clone for TheFlagsPre<T> {
+impl<T: 'static> Clone for TheFlagsPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheFlagsPre<T> {
         }
     }
 }
-impl<_T> TheFlagsPre<_T> {
+impl<_T: 'static> TheFlagsPre<_T> {
     /// Creates a new copy of `TheFlagsPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -130,7 +130,7 @@ const _: () = {
     impl TheFlags {
         /// Convenience wrapper around [`TheFlagsPre::new`] and
         /// [`TheFlagsPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -718,7 +718,7 @@ pub mod exports {
                         arg0: Flag1,
                     ) -> wasmtime::Result<Flag1>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -738,7 +738,7 @@ pub mod exports {
                         arg0: Flag2,
                     ) -> wasmtime::Result<Flag2>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -758,7 +758,7 @@ pub mod exports {
                         arg0: Flag4,
                     ) -> wasmtime::Result<Flag4>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -778,7 +778,7 @@ pub mod exports {
                         arg0: Flag8,
                     ) -> wasmtime::Result<Flag8>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -798,7 +798,7 @@ pub mod exports {
                         arg0: Flag16,
                     ) -> wasmtime::Result<Flag16>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -818,7 +818,7 @@ pub mod exports {
                         arg0: Flag32,
                     ) -> wasmtime::Result<Flag32>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -838,7 +838,7 @@ pub mod exports {
                         arg0: Flag64,
                     ) -> wasmtime::Result<Flag64>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/flags_concurrent.rs
+++ b/crates/component-macro/tests/expanded/flags_concurrent.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheFlags`] as well.
-pub struct TheFlagsPre<T> {
+pub struct TheFlagsPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheFlagsIndices,
 }
-impl<T> Clone for TheFlagsPre<T> {
+impl<T: 'static> Clone for TheFlagsPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheFlagsPre<T> {
         }
     }
 }
-impl<_T> TheFlagsPre<_T> {
+impl<_T: 'static> TheFlagsPre<_T> {
     /// Creates a new copy of `TheFlagsPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -130,7 +130,7 @@ const _: () = {
     impl TheFlags {
         /// Convenience wrapper around [`TheFlagsPre::new`] and
         /// [`TheFlagsPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -763,7 +763,7 @@ pub mod exports {
                         Output = wasmtime::Result<Flag1>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -784,7 +784,7 @@ pub mod exports {
                         Output = wasmtime::Result<Flag2>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -805,7 +805,7 @@ pub mod exports {
                         Output = wasmtime::Result<Flag4>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -826,7 +826,7 @@ pub mod exports {
                         Output = wasmtime::Result<Flag8>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -847,7 +847,7 @@ pub mod exports {
                         Output = wasmtime::Result<Flag16>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -868,7 +868,7 @@ pub mod exports {
                         Output = wasmtime::Result<Flag32>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -889,7 +889,7 @@ pub mod exports {
                         Output = wasmtime::Result<Flag64>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/flags_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/flags_tracing_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheFlags`] as well.
-pub struct TheFlagsPre<T> {
+pub struct TheFlagsPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheFlagsIndices,
 }
-impl<T> Clone for TheFlagsPre<T> {
+impl<T: 'static> Clone for TheFlagsPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheFlagsPre<T> {
         }
     }
 }
-impl<_T> TheFlagsPre<_T> {
+impl<_T: 'static> TheFlagsPre<_T> {
     /// Creates a new copy of `TheFlagsPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -130,7 +130,7 @@ const _: () = {
     impl TheFlags {
         /// Convenience wrapper around [`TheFlagsPre::new`] and
         /// [`TheFlagsPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -830,7 +830,7 @@ pub mod exports {
                         arg0: Flag1,
                     ) -> wasmtime::Result<Flag1>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -859,7 +859,7 @@ pub mod exports {
                         arg0: Flag2,
                     ) -> wasmtime::Result<Flag2>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -888,7 +888,7 @@ pub mod exports {
                         arg0: Flag4,
                     ) -> wasmtime::Result<Flag4>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -917,7 +917,7 @@ pub mod exports {
                         arg0: Flag8,
                     ) -> wasmtime::Result<Flag8>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -946,7 +946,7 @@ pub mod exports {
                         arg0: Flag16,
                     ) -> wasmtime::Result<Flag16>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -975,7 +975,7 @@ pub mod exports {
                         arg0: Flag32,
                     ) -> wasmtime::Result<Flag32>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -1004,7 +1004,7 @@ pub mod exports {
                         arg0: Flag64,
                     ) -> wasmtime::Result<Flag64>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(

--- a/crates/component-macro/tests/expanded/floats.rs
+++ b/crates/component-macro/tests/expanded/floats.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -129,7 +129,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate`].
-        pub fn instantiate<_T>(
+        pub fn instantiate<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -334,7 +334,7 @@ pub mod exports {
                         arg0: f32,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -352,7 +352,7 @@ pub mod exports {
                         arg0: f64,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -369,7 +369,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<f32>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -386,7 +386,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<f64>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/floats_async.rs
+++ b/crates/component-macro/tests/expanded/floats_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -132,7 +132,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -349,7 +349,7 @@ pub mod exports {
                         arg0: f32,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -369,7 +369,7 @@ pub mod exports {
                         arg0: f64,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -388,7 +388,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<f32>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -407,7 +407,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<f64>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/floats_concurrent.rs
+++ b/crates/component-macro/tests/expanded/floats_concurrent.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -132,7 +132,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -366,7 +366,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -384,7 +384,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -401,7 +401,7 @@ pub mod exports {
                         Output = wasmtime::Result<f32>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -421,7 +421,7 @@ pub mod exports {
                         Output = wasmtime::Result<f64>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/floats_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/floats_tracing_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -132,7 +132,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -407,7 +407,7 @@ pub mod exports {
                         arg0: f32,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -436,7 +436,7 @@ pub mod exports {
                         arg0: f64,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -464,7 +464,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<f32>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -492,7 +492,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<f64>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(

--- a/crates/component-macro/tests/expanded/function-new.rs
+++ b/crates/component-macro/tests/expanded/function-new.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Foo`] as well.
-pub struct FooPre<T> {
+pub struct FooPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: FooIndices,
 }
-impl<T> Clone for FooPre<T> {
+impl<T: 'static> Clone for FooPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for FooPre<T> {
         }
     }
 }
-impl<_T> FooPre<_T> {
+impl<_T: 'static> FooPre<_T> {
     /// Creates a new copy of `FooPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -141,7 +141,7 @@ const _: () = {
     impl Foo {
         /// Convenience wrapper around [`FooPre::new`] and
         /// [`FooPre::instantiate`].
-        pub fn instantiate<_T>(
+        pub fn instantiate<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -163,7 +163,7 @@ const _: () = {
             mut store: S,
         ) -> wasmtime::Result<()>
         where
-            <S as wasmtime::AsContext>::Data: Send,
+            <S as wasmtime::AsContext>::Data: Send + 'static,
         {
             let callee = unsafe {
                 wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.new)

--- a/crates/component-macro/tests/expanded/function-new_async.rs
+++ b/crates/component-macro/tests/expanded/function-new_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Foo`] as well.
-pub struct FooPre<T> {
+pub struct FooPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: FooIndices,
 }
-impl<T> Clone for FooPre<T> {
+impl<T: 'static> Clone for FooPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for FooPre<T> {
         }
     }
 }
-impl<_T> FooPre<_T> {
+impl<_T: 'static> FooPre<_T> {
     /// Creates a new copy of `FooPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -144,7 +144,7 @@ const _: () = {
     impl Foo {
         /// Convenience wrapper around [`FooPre::new`] and
         /// [`FooPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -169,7 +169,7 @@ const _: () = {
             mut store: S,
         ) -> wasmtime::Result<()>
         where
-            <S as wasmtime::AsContext>::Data: Send,
+            <S as wasmtime::AsContext>::Data: Send + 'static,
         {
             let callee = unsafe {
                 wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.new)

--- a/crates/component-macro/tests/expanded/function-new_concurrent.rs
+++ b/crates/component-macro/tests/expanded/function-new_concurrent.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Foo`] as well.
-pub struct FooPre<T> {
+pub struct FooPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: FooIndices,
 }
-impl<T> Clone for FooPre<T> {
+impl<T: 'static> Clone for FooPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for FooPre<T> {
         }
     }
 }
-impl<_T> FooPre<_T> {
+impl<_T: 'static> FooPre<_T> {
     /// Creates a new copy of `FooPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -144,7 +144,7 @@ const _: () = {
     impl Foo {
         /// Convenience wrapper around [`FooPre::new`] and
         /// [`FooPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -171,7 +171,7 @@ const _: () = {
             Output = wasmtime::Result<()>,
         > + Send + 'static + use<S>
         where
-            <S as wasmtime::AsContext>::Data: Send,
+            <S as wasmtime::AsContext>::Data: Send + 'static,
         {
             let callee = unsafe {
                 wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.new)

--- a/crates/component-macro/tests/expanded/function-new_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/function-new_tracing_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Foo`] as well.
-pub struct FooPre<T> {
+pub struct FooPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: FooIndices,
 }
-impl<T> Clone for FooPre<T> {
+impl<T: 'static> Clone for FooPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for FooPre<T> {
         }
     }
 }
-impl<_T> FooPre<_T> {
+impl<_T: 'static> FooPre<_T> {
     /// Creates a new copy of `FooPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -144,7 +144,7 @@ const _: () = {
     impl Foo {
         /// Convenience wrapper around [`FooPre::new`] and
         /// [`FooPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -169,7 +169,7 @@ const _: () = {
             mut store: S,
         ) -> wasmtime::Result<()>
         where
-            <S as wasmtime::AsContext>::Data: Send,
+            <S as wasmtime::AsContext>::Data: Send + 'static,
         {
             use tracing::Instrument;
             let span = tracing::span!(

--- a/crates/component-macro/tests/expanded/host-world.rs
+++ b/crates/component-macro/tests/expanded/host-world.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Host_`] as well.
-pub struct Host_Pre<T> {
+pub struct Host_Pre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: Host_Indices,
 }
-impl<T> Clone for Host_Pre<T> {
+impl<T: 'static> Clone for Host_Pre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for Host_Pre<T> {
         }
     }
 }
-impl<_T> Host_Pre<_T> {
+impl<_T: 'static> Host_Pre<_T> {
     /// Creates a new copy of `Host_Pre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -129,7 +129,7 @@ const _: () = {
     impl Host_ {
         /// Convenience wrapper around [`Host_Pre::new`] and
         /// [`Host_Pre::instantiate`].
-        pub fn instantiate<_T>(
+        pub fn instantiate<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/host-world_async.rs
+++ b/crates/component-macro/tests/expanded/host-world_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Host_`] as well.
-pub struct Host_Pre<T> {
+pub struct Host_Pre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: Host_Indices,
 }
-impl<T> Clone for Host_Pre<T> {
+impl<T: 'static> Clone for Host_Pre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for Host_Pre<T> {
         }
     }
 }
-impl<_T> Host_Pre<_T> {
+impl<_T: 'static> Host_Pre<_T> {
     /// Creates a new copy of `Host_Pre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -134,7 +134,7 @@ const _: () = {
     impl Host_ {
         /// Convenience wrapper around [`Host_Pre::new`] and
         /// [`Host_Pre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/host-world_concurrent.rs
+++ b/crates/component-macro/tests/expanded/host-world_concurrent.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Host_`] as well.
-pub struct Host_Pre<T> {
+pub struct Host_Pre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: Host_Indices,
 }
-impl<T> Clone for Host_Pre<T> {
+impl<T: 'static> Clone for Host_Pre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for Host_Pre<T> {
         }
     }
 }
-impl<_T> Host_Pre<_T> {
+impl<_T: 'static> Host_Pre<_T> {
     /// Creates a new copy of `Host_Pre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -136,7 +136,7 @@ const _: () = {
     impl Host_ {
         /// Convenience wrapper around [`Host_Pre::new`] and
         /// [`Host_Pre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/host-world_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/host-world_tracing_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Host_`] as well.
-pub struct Host_Pre<T> {
+pub struct Host_Pre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: Host_Indices,
 }
-impl<T> Clone for Host_Pre<T> {
+impl<T: 'static> Clone for Host_Pre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for Host_Pre<T> {
         }
     }
 }
-impl<_T> Host_Pre<_T> {
+impl<_T: 'static> Host_Pre<_T> {
     /// Creates a new copy of `Host_Pre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -134,7 +134,7 @@ const _: () = {
     impl Host_ {
         /// Convenience wrapper around [`Host_Pre::new`] and
         /// [`Host_Pre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/integers.rs
+++ b/crates/component-macro/tests/expanded/integers.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -129,7 +129,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate`].
-        pub fn instantiate<_T>(
+        pub fn instantiate<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -662,7 +662,7 @@ pub mod exports {
                         arg0: u8,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -680,7 +680,7 @@ pub mod exports {
                         arg0: i8,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -698,7 +698,7 @@ pub mod exports {
                         arg0: u16,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -716,7 +716,7 @@ pub mod exports {
                         arg0: i16,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -734,7 +734,7 @@ pub mod exports {
                         arg0: u32,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -752,7 +752,7 @@ pub mod exports {
                         arg0: i32,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -770,7 +770,7 @@ pub mod exports {
                         arg0: u64,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -788,7 +788,7 @@ pub mod exports {
                         arg0: i64,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -813,7 +813,7 @@ pub mod exports {
                         arg7: i64,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -834,7 +834,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<u8>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -851,7 +851,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<i8>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -868,7 +868,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<u16>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -885,7 +885,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<i16>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -902,7 +902,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<u32>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -919,7 +919,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<i32>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -936,7 +936,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<u64>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -953,7 +953,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<i64>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -970,7 +970,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<(i64, u8)>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/integers_async.rs
+++ b/crates/component-macro/tests/expanded/integers_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -132,7 +132,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -706,7 +706,7 @@ pub mod exports {
                         arg0: u8,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -726,7 +726,7 @@ pub mod exports {
                         arg0: i8,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -746,7 +746,7 @@ pub mod exports {
                         arg0: u16,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -766,7 +766,7 @@ pub mod exports {
                         arg0: i16,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -786,7 +786,7 @@ pub mod exports {
                         arg0: u32,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -806,7 +806,7 @@ pub mod exports {
                         arg0: i32,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -826,7 +826,7 @@ pub mod exports {
                         arg0: u64,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -846,7 +846,7 @@ pub mod exports {
                         arg0: i64,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -873,7 +873,7 @@ pub mod exports {
                         arg7: i64,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -895,7 +895,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<u8>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -914,7 +914,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<i8>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -933,7 +933,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<u16>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -952,7 +952,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<i16>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -971,7 +971,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<u32>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -990,7 +990,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<i32>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1009,7 +1009,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<u64>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1028,7 +1028,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<i64>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1047,7 +1047,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<(i64, u8)>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/integers_concurrent.rs
+++ b/crates/component-macro/tests/expanded/integers_concurrent.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -132,7 +132,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -741,7 +741,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -759,7 +759,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -777,7 +777,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -795,7 +795,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -813,7 +813,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -831,7 +831,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -849,7 +849,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -867,7 +867,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -892,7 +892,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -913,7 +913,7 @@ pub mod exports {
                         Output = wasmtime::Result<u8>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -933,7 +933,7 @@ pub mod exports {
                         Output = wasmtime::Result<i8>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -953,7 +953,7 @@ pub mod exports {
                         Output = wasmtime::Result<u16>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -973,7 +973,7 @@ pub mod exports {
                         Output = wasmtime::Result<i16>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -993,7 +993,7 @@ pub mod exports {
                         Output = wasmtime::Result<u32>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1013,7 +1013,7 @@ pub mod exports {
                         Output = wasmtime::Result<i32>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1033,7 +1033,7 @@ pub mod exports {
                         Output = wasmtime::Result<u64>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1053,7 +1053,7 @@ pub mod exports {
                         Output = wasmtime::Result<i64>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1073,7 +1073,7 @@ pub mod exports {
                         Output = wasmtime::Result<(i64, u8)>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/integers_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/integers_tracing_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -132,7 +132,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -971,7 +971,7 @@ pub mod exports {
                         arg0: u8,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -1000,7 +1000,7 @@ pub mod exports {
                         arg0: i8,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -1029,7 +1029,7 @@ pub mod exports {
                         arg0: u16,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -1058,7 +1058,7 @@ pub mod exports {
                         arg0: i16,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -1087,7 +1087,7 @@ pub mod exports {
                         arg0: u32,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -1116,7 +1116,7 @@ pub mod exports {
                         arg0: i32,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -1145,7 +1145,7 @@ pub mod exports {
                         arg0: u64,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -1174,7 +1174,7 @@ pub mod exports {
                         arg0: i64,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -1210,7 +1210,7 @@ pub mod exports {
                         arg7: i64,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -1241,7 +1241,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<u8>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -1269,7 +1269,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<i8>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -1297,7 +1297,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<u16>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -1325,7 +1325,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<i16>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -1353,7 +1353,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<u32>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -1381,7 +1381,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<i32>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -1409,7 +1409,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<u64>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -1437,7 +1437,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<i64>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -1465,7 +1465,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<(i64, u8)>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(

--- a/crates/component-macro/tests/expanded/lists.rs
+++ b/crates/component-macro/tests/expanded/lists.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheLists`] as well.
-pub struct TheListsPre<T> {
+pub struct TheListsPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheListsIndices,
 }
-impl<T> Clone for TheListsPre<T> {
+impl<T: 'static> Clone for TheListsPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheListsPre<T> {
         }
     }
 }
-impl<_T> TheListsPre<_T> {
+impl<_T: 'static> TheListsPre<_T> {
     /// Creates a new copy of `TheListsPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -127,7 +127,7 @@ const _: () = {
     impl TheLists {
         /// Convenience wrapper around [`TheListsPre::new`] and
         /// [`TheListsPre::instantiate`].
-        pub fn instantiate<_T>(
+        pub fn instantiate<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -1519,7 +1519,7 @@ pub mod exports {
                         arg0: &[u8],
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1537,7 +1537,7 @@ pub mod exports {
                         arg0: &[u16],
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1555,7 +1555,7 @@ pub mod exports {
                         arg0: &[u32],
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1573,7 +1573,7 @@ pub mod exports {
                         arg0: &[u64],
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1591,7 +1591,7 @@ pub mod exports {
                         arg0: &[i8],
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1609,7 +1609,7 @@ pub mod exports {
                         arg0: &[i16],
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1627,7 +1627,7 @@ pub mod exports {
                         arg0: &[i32],
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1645,7 +1645,7 @@ pub mod exports {
                         arg0: &[i64],
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1663,7 +1663,7 @@ pub mod exports {
                         arg0: &[f32],
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1681,7 +1681,7 @@ pub mod exports {
                         arg0: &[f64],
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1698,7 +1698,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::__internal::Vec<u8>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1715,7 +1715,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::__internal::Vec<u16>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1732,7 +1732,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::__internal::Vec<u32>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1749,7 +1749,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::__internal::Vec<u64>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1766,7 +1766,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::__internal::Vec<i8>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1783,7 +1783,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::__internal::Vec<i16>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1800,7 +1800,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::__internal::Vec<i32>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1817,7 +1817,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::__internal::Vec<i64>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1834,7 +1834,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::__internal::Vec<f32>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1851,7 +1851,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::__internal::Vec<f64>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1871,7 +1871,7 @@ pub mod exports {
                         wasmtime::component::__internal::Vec<(i64, u32)>,
                     >
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1889,7 +1889,7 @@ pub mod exports {
                         arg0: &[wasmtime::component::__internal::String],
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1910,7 +1910,7 @@ pub mod exports {
                         >,
                     >
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1936,7 +1936,7 @@ pub mod exports {
                         >,
                     >
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1962,7 +1962,7 @@ pub mod exports {
                         >,
                     >
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1986,7 +1986,7 @@ pub mod exports {
                         wasmtime::component::__internal::Vec<OtherRecord>,
                     >
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -2006,7 +2006,7 @@ pub mod exports {
                         wasmtime::component::__internal::Vec<SomeRecord>,
                     >
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -2026,7 +2026,7 @@ pub mod exports {
                         wasmtime::component::__internal::Vec<OtherVariant>,
                     >
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -2044,7 +2044,7 @@ pub mod exports {
                         arg0: &LoadStoreAllSizes,
                     ) -> wasmtime::Result<LoadStoreAllSizes>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/lists_async.rs
+++ b/crates/component-macro/tests/expanded/lists_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheLists`] as well.
-pub struct TheListsPre<T> {
+pub struct TheListsPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheListsIndices,
 }
-impl<T> Clone for TheListsPre<T> {
+impl<T: 'static> Clone for TheListsPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheListsPre<T> {
         }
     }
 }
-impl<_T> TheListsPre<_T> {
+impl<_T: 'static> TheListsPre<_T> {
     /// Creates a new copy of `TheListsPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -130,7 +130,7 @@ const _: () = {
     impl TheLists {
         /// Convenience wrapper around [`TheListsPre::new`] and
         /// [`TheListsPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -1624,7 +1624,7 @@ pub mod exports {
                         arg0: &[u8],
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1644,7 +1644,7 @@ pub mod exports {
                         arg0: &[u16],
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1664,7 +1664,7 @@ pub mod exports {
                         arg0: &[u32],
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1684,7 +1684,7 @@ pub mod exports {
                         arg0: &[u64],
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1704,7 +1704,7 @@ pub mod exports {
                         arg0: &[i8],
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1724,7 +1724,7 @@ pub mod exports {
                         arg0: &[i16],
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1744,7 +1744,7 @@ pub mod exports {
                         arg0: &[i32],
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1764,7 +1764,7 @@ pub mod exports {
                         arg0: &[i64],
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1784,7 +1784,7 @@ pub mod exports {
                         arg0: &[f32],
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1804,7 +1804,7 @@ pub mod exports {
                         arg0: &[f64],
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1823,7 +1823,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::__internal::Vec<u8>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1842,7 +1842,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::__internal::Vec<u16>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1861,7 +1861,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::__internal::Vec<u32>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1880,7 +1880,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::__internal::Vec<u64>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1899,7 +1899,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::__internal::Vec<i8>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1918,7 +1918,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::__internal::Vec<i16>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1937,7 +1937,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::__internal::Vec<i32>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1956,7 +1956,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::__internal::Vec<i64>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1975,7 +1975,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::__internal::Vec<f32>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1994,7 +1994,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::__internal::Vec<f64>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -2016,7 +2016,7 @@ pub mod exports {
                         wasmtime::component::__internal::Vec<(i64, u32)>,
                     >
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -2036,7 +2036,7 @@ pub mod exports {
                         arg0: &[wasmtime::component::__internal::String],
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -2059,7 +2059,7 @@ pub mod exports {
                         >,
                     >
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -2087,7 +2087,7 @@ pub mod exports {
                         >,
                     >
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -2115,7 +2115,7 @@ pub mod exports {
                         >,
                     >
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -2141,7 +2141,7 @@ pub mod exports {
                         wasmtime::component::__internal::Vec<OtherRecord>,
                     >
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -2163,7 +2163,7 @@ pub mod exports {
                         wasmtime::component::__internal::Vec<SomeRecord>,
                     >
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -2185,7 +2185,7 @@ pub mod exports {
                         wasmtime::component::__internal::Vec<OtherVariant>,
                     >
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -2205,7 +2205,7 @@ pub mod exports {
                         arg0: &LoadStoreAllSizes,
                     ) -> wasmtime::Result<LoadStoreAllSizes>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/lists_concurrent.rs
+++ b/crates/component-macro/tests/expanded/lists_concurrent.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheLists`] as well.
-pub struct TheListsPre<T> {
+pub struct TheListsPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheListsIndices,
 }
-impl<T> Clone for TheListsPre<T> {
+impl<T: 'static> Clone for TheListsPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheListsPre<T> {
         }
     }
 }
-impl<_T> TheListsPre<_T> {
+impl<_T: 'static> TheListsPre<_T> {
     /// Creates a new copy of `TheListsPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -130,7 +130,7 @@ const _: () = {
     impl TheLists {
         /// Convenience wrapper around [`TheListsPre::new`] and
         /// [`TheListsPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -1575,7 +1575,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1593,7 +1593,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1611,7 +1611,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1629,7 +1629,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1647,7 +1647,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1665,7 +1665,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1683,7 +1683,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1701,7 +1701,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1719,7 +1719,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1737,7 +1737,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1756,7 +1756,7 @@ pub mod exports {
                         >,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1778,7 +1778,7 @@ pub mod exports {
                         >,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1800,7 +1800,7 @@ pub mod exports {
                         >,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1822,7 +1822,7 @@ pub mod exports {
                         >,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1844,7 +1844,7 @@ pub mod exports {
                         >,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1866,7 +1866,7 @@ pub mod exports {
                         >,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1888,7 +1888,7 @@ pub mod exports {
                         >,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1910,7 +1910,7 @@ pub mod exports {
                         >,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1932,7 +1932,7 @@ pub mod exports {
                         >,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1954,7 +1954,7 @@ pub mod exports {
                         >,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1977,7 +1977,7 @@ pub mod exports {
                         >,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -2000,7 +2000,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -2025,7 +2025,7 @@ pub mod exports {
                         >,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -2056,7 +2056,7 @@ pub mod exports {
                         >,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -2091,7 +2091,7 @@ pub mod exports {
                         >,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -2122,7 +2122,7 @@ pub mod exports {
                         >,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -2145,7 +2145,7 @@ pub mod exports {
                         >,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -2168,7 +2168,7 @@ pub mod exports {
                         >,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -2189,7 +2189,7 @@ pub mod exports {
                         Output = wasmtime::Result<LoadStoreAllSizes>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/lists_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/lists_tracing_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheLists`] as well.
-pub struct TheListsPre<T> {
+pub struct TheListsPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheListsIndices,
 }
-impl<T> Clone for TheListsPre<T> {
+impl<T: 'static> Clone for TheListsPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheListsPre<T> {
         }
     }
 }
-impl<_T> TheListsPre<_T> {
+impl<_T: 'static> TheListsPre<_T> {
     /// Creates a new copy of `TheListsPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -130,7 +130,7 @@ const _: () = {
     impl TheLists {
         /// Convenience wrapper around [`TheListsPre::new`] and
         /// [`TheListsPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -2055,7 +2055,7 @@ pub mod exports {
                         arg0: &[u8],
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -2084,7 +2084,7 @@ pub mod exports {
                         arg0: &[u16],
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -2113,7 +2113,7 @@ pub mod exports {
                         arg0: &[u32],
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -2142,7 +2142,7 @@ pub mod exports {
                         arg0: &[u64],
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -2171,7 +2171,7 @@ pub mod exports {
                         arg0: &[i8],
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -2200,7 +2200,7 @@ pub mod exports {
                         arg0: &[i16],
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -2229,7 +2229,7 @@ pub mod exports {
                         arg0: &[i32],
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -2258,7 +2258,7 @@ pub mod exports {
                         arg0: &[i64],
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -2287,7 +2287,7 @@ pub mod exports {
                         arg0: &[f32],
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -2316,7 +2316,7 @@ pub mod exports {
                         arg0: &[f64],
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -2344,7 +2344,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::__internal::Vec<u8>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -2372,7 +2372,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::__internal::Vec<u16>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -2400,7 +2400,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::__internal::Vec<u32>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -2428,7 +2428,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::__internal::Vec<u64>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -2456,7 +2456,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::__internal::Vec<i8>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -2484,7 +2484,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::__internal::Vec<i16>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -2512,7 +2512,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::__internal::Vec<i32>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -2540,7 +2540,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::__internal::Vec<i64>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -2568,7 +2568,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::__internal::Vec<f32>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -2596,7 +2596,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::__internal::Vec<f64>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -2627,7 +2627,7 @@ pub mod exports {
                         wasmtime::component::__internal::Vec<(i64, u32)>,
                     >
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -2656,7 +2656,7 @@ pub mod exports {
                         arg0: &[wasmtime::component::__internal::String],
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -2688,7 +2688,7 @@ pub mod exports {
                         >,
                     >
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -2725,7 +2725,7 @@ pub mod exports {
                         >,
                     >
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -2762,7 +2762,7 @@ pub mod exports {
                         >,
                     >
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -2797,7 +2797,7 @@ pub mod exports {
                         wasmtime::component::__internal::Vec<OtherRecord>,
                     >
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -2828,7 +2828,7 @@ pub mod exports {
                         wasmtime::component::__internal::Vec<SomeRecord>,
                     >
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -2859,7 +2859,7 @@ pub mod exports {
                         wasmtime::component::__internal::Vec<OtherVariant>,
                     >
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -2888,7 +2888,7 @@ pub mod exports {
                         arg0: &LoadStoreAllSizes,
                     ) -> wasmtime::Result<LoadStoreAllSizes>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(

--- a/crates/component-macro/tests/expanded/many-arguments.rs
+++ b/crates/component-macro/tests/expanded/many-arguments.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -129,7 +129,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate`].
-        pub fn instantiate<_T>(
+        pub fn instantiate<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -607,7 +607,7 @@ pub mod exports {
                         arg15: u64,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -663,7 +663,7 @@ pub mod exports {
                         arg0: &BigStruct,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/many-arguments_async.rs
+++ b/crates/component-macro/tests/expanded/many-arguments_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -132,7 +132,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -620,7 +620,7 @@ pub mod exports {
                         arg15: u64,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -677,7 +677,7 @@ pub mod exports {
                         arg0: &BigStruct,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/many-arguments_concurrent.rs
+++ b/crates/component-macro/tests/expanded/many-arguments_concurrent.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -132,7 +132,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -588,7 +588,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -644,7 +644,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/many-arguments_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/many-arguments_tracing_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -132,7 +132,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -663,7 +663,7 @@ pub mod exports {
                         arg15: u64,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -729,7 +729,7 @@ pub mod exports {
                         arg0: &BigStruct,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(

--- a/crates/component-macro/tests/expanded/multiversion.rs
+++ b/crates/component-macro/tests/expanded/multiversion.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Foo`] as well.
-pub struct FooPre<T> {
+pub struct FooPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: FooIndices,
 }
-impl<T> Clone for FooPre<T> {
+impl<T: 'static> Clone for FooPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for FooPre<T> {
         }
     }
 }
-impl<_T> FooPre<_T> {
+impl<_T: 'static> FooPre<_T> {
     /// Creates a new copy of `FooPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -134,7 +134,7 @@ const _: () = {
     impl Foo {
         /// Convenience wrapper around [`FooPre::new`] and
         /// [`FooPre::instantiate`].
-        pub fn instantiate<_T>(
+        pub fn instantiate<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -313,7 +313,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -395,7 +395,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/multiversion_async.rs
+++ b/crates/component-macro/tests/expanded/multiversion_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Foo`] as well.
-pub struct FooPre<T> {
+pub struct FooPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: FooIndices,
 }
-impl<T> Clone for FooPre<T> {
+impl<T: 'static> Clone for FooPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for FooPre<T> {
         }
     }
 }
-impl<_T> FooPre<_T> {
+impl<_T: 'static> FooPre<_T> {
     /// Creates a new copy of `FooPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -137,7 +137,7 @@ const _: () = {
     impl Foo {
         /// Convenience wrapper around [`FooPre::new`] and
         /// [`FooPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -325,7 +325,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -407,7 +407,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/multiversion_concurrent.rs
+++ b/crates/component-macro/tests/expanded/multiversion_concurrent.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Foo`] as well.
-pub struct FooPre<T> {
+pub struct FooPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: FooIndices,
 }
-impl<T> Clone for FooPre<T> {
+impl<T: 'static> Clone for FooPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for FooPre<T> {
         }
     }
 }
-impl<_T> FooPre<_T> {
+impl<_T: 'static> FooPre<_T> {
     /// Creates a new copy of `FooPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -137,7 +137,7 @@ const _: () = {
     impl Foo {
         /// Convenience wrapper around [`FooPre::new`] and
         /// [`FooPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -331,7 +331,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -413,7 +413,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/multiversion_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/multiversion_tracing_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Foo`] as well.
-pub struct FooPre<T> {
+pub struct FooPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: FooIndices,
 }
-impl<T> Clone for FooPre<T> {
+impl<T: 'static> Clone for FooPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for FooPre<T> {
         }
     }
 }
-impl<_T> FooPre<_T> {
+impl<_T: 'static> FooPre<_T> {
     /// Creates a new copy of `FooPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -137,7 +137,7 @@ const _: () = {
     impl Foo {
         /// Convenience wrapper around [`FooPre::new`] and
         /// [`FooPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -351,7 +351,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -444,7 +444,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(

--- a/crates/component-macro/tests/expanded/path1.rs
+++ b/crates/component-macro/tests/expanded/path1.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Path1`] as well.
-pub struct Path1Pre<T> {
+pub struct Path1Pre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: Path1Indices,
 }
-impl<T> Clone for Path1Pre<T> {
+impl<T: 'static> Clone for Path1Pre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for Path1Pre<T> {
         }
     }
 }
-impl<_T> Path1Pre<_T> {
+impl<_T: 'static> Path1Pre<_T> {
     /// Creates a new copy of `Path1Pre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -121,7 +121,7 @@ const _: () = {
     impl Path1 {
         /// Convenience wrapper around [`Path1Pre::new`] and
         /// [`Path1Pre::instantiate`].
-        pub fn instantiate<_T>(
+        pub fn instantiate<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/path1_async.rs
+++ b/crates/component-macro/tests/expanded/path1_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Path1`] as well.
-pub struct Path1Pre<T> {
+pub struct Path1Pre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: Path1Indices,
 }
-impl<T> Clone for Path1Pre<T> {
+impl<T: 'static> Clone for Path1Pre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for Path1Pre<T> {
         }
     }
 }
-impl<_T> Path1Pre<_T> {
+impl<_T: 'static> Path1Pre<_T> {
     /// Creates a new copy of `Path1Pre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -124,7 +124,7 @@ const _: () = {
     impl Path1 {
         /// Convenience wrapper around [`Path1Pre::new`] and
         /// [`Path1Pre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/path1_concurrent.rs
+++ b/crates/component-macro/tests/expanded/path1_concurrent.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Path1`] as well.
-pub struct Path1Pre<T> {
+pub struct Path1Pre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: Path1Indices,
 }
-impl<T> Clone for Path1Pre<T> {
+impl<T: 'static> Clone for Path1Pre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for Path1Pre<T> {
         }
     }
 }
-impl<_T> Path1Pre<_T> {
+impl<_T: 'static> Path1Pre<_T> {
     /// Creates a new copy of `Path1Pre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -124,7 +124,7 @@ const _: () = {
     impl Path1 {
         /// Convenience wrapper around [`Path1Pre::new`] and
         /// [`Path1Pre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/path1_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/path1_tracing_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Path1`] as well.
-pub struct Path1Pre<T> {
+pub struct Path1Pre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: Path1Indices,
 }
-impl<T> Clone for Path1Pre<T> {
+impl<T: 'static> Clone for Path1Pre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for Path1Pre<T> {
         }
     }
 }
-impl<_T> Path1Pre<_T> {
+impl<_T: 'static> Path1Pre<_T> {
     /// Creates a new copy of `Path1Pre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -124,7 +124,7 @@ const _: () = {
     impl Path1 {
         /// Convenience wrapper around [`Path1Pre::new`] and
         /// [`Path1Pre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/path2.rs
+++ b/crates/component-macro/tests/expanded/path2.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Path2`] as well.
-pub struct Path2Pre<T> {
+pub struct Path2Pre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: Path2Indices,
 }
-impl<T> Clone for Path2Pre<T> {
+impl<T: 'static> Clone for Path2Pre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for Path2Pre<T> {
         }
     }
 }
-impl<_T> Path2Pre<_T> {
+impl<_T: 'static> Path2Pre<_T> {
     /// Creates a new copy of `Path2Pre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -121,7 +121,7 @@ const _: () = {
     impl Path2 {
         /// Convenience wrapper around [`Path2Pre::new`] and
         /// [`Path2Pre::instantiate`].
-        pub fn instantiate<_T>(
+        pub fn instantiate<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/path2_async.rs
+++ b/crates/component-macro/tests/expanded/path2_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Path2`] as well.
-pub struct Path2Pre<T> {
+pub struct Path2Pre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: Path2Indices,
 }
-impl<T> Clone for Path2Pre<T> {
+impl<T: 'static> Clone for Path2Pre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for Path2Pre<T> {
         }
     }
 }
-impl<_T> Path2Pre<_T> {
+impl<_T: 'static> Path2Pre<_T> {
     /// Creates a new copy of `Path2Pre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -124,7 +124,7 @@ const _: () = {
     impl Path2 {
         /// Convenience wrapper around [`Path2Pre::new`] and
         /// [`Path2Pre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/path2_concurrent.rs
+++ b/crates/component-macro/tests/expanded/path2_concurrent.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Path2`] as well.
-pub struct Path2Pre<T> {
+pub struct Path2Pre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: Path2Indices,
 }
-impl<T> Clone for Path2Pre<T> {
+impl<T: 'static> Clone for Path2Pre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for Path2Pre<T> {
         }
     }
 }
-impl<_T> Path2Pre<_T> {
+impl<_T: 'static> Path2Pre<_T> {
     /// Creates a new copy of `Path2Pre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -124,7 +124,7 @@ const _: () = {
     impl Path2 {
         /// Convenience wrapper around [`Path2Pre::new`] and
         /// [`Path2Pre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/path2_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/path2_tracing_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Path2`] as well.
-pub struct Path2Pre<T> {
+pub struct Path2Pre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: Path2Indices,
 }
-impl<T> Clone for Path2Pre<T> {
+impl<T: 'static> Clone for Path2Pre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for Path2Pre<T> {
         }
     }
 }
-impl<_T> Path2Pre<_T> {
+impl<_T: 'static> Path2Pre<_T> {
     /// Creates a new copy of `Path2Pre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -124,7 +124,7 @@ const _: () = {
     impl Path2 {
         /// Convenience wrapper around [`Path2Pre::new`] and
         /// [`Path2Pre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/records.rs
+++ b/crates/component-macro/tests/expanded/records.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -129,7 +129,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate`].
-        pub fn instantiate<_T>(
+        pub fn instantiate<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -861,7 +861,7 @@ pub mod exports {
                         arg0: (char, u32),
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -878,7 +878,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<(char, u32)>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -896,7 +896,7 @@ pub mod exports {
                         arg0: Empty,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -913,7 +913,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<Empty>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -931,7 +931,7 @@ pub mod exports {
                         arg0: Scalars,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -948,7 +948,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<Scalars>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -966,7 +966,7 @@ pub mod exports {
                         arg0: ReallyFlags,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -983,7 +983,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<ReallyFlags>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1001,7 +1001,7 @@ pub mod exports {
                         arg0: &Aggregates,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1018,7 +1018,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<Aggregates>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1036,7 +1036,7 @@ pub mod exports {
                         arg0: TupleTypedef2,
                     ) -> wasmtime::Result<i32>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/records_async.rs
+++ b/crates/component-macro/tests/expanded/records_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -132,7 +132,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -890,7 +890,7 @@ pub mod exports {
                         arg0: (char, u32),
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -909,7 +909,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<(char, u32)>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -929,7 +929,7 @@ pub mod exports {
                         arg0: Empty,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -948,7 +948,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<Empty>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -968,7 +968,7 @@ pub mod exports {
                         arg0: Scalars,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -987,7 +987,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<Scalars>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1007,7 +1007,7 @@ pub mod exports {
                         arg0: ReallyFlags,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1026,7 +1026,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<ReallyFlags>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1046,7 +1046,7 @@ pub mod exports {
                         arg0: &Aggregates,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1065,7 +1065,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<Aggregates>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1085,7 +1085,7 @@ pub mod exports {
                         arg0: TupleTypedef2,
                     ) -> wasmtime::Result<i32>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/records_concurrent.rs
+++ b/crates/component-macro/tests/expanded/records_concurrent.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -132,7 +132,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -917,7 +917,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -934,7 +934,7 @@ pub mod exports {
                         Output = wasmtime::Result<(char, u32)>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -955,7 +955,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -972,7 +972,7 @@ pub mod exports {
                         Output = wasmtime::Result<Empty>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -993,7 +993,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1010,7 +1010,7 @@ pub mod exports {
                         Output = wasmtime::Result<Scalars>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1031,7 +1031,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1048,7 +1048,7 @@ pub mod exports {
                         Output = wasmtime::Result<ReallyFlags>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1069,7 +1069,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1086,7 +1086,7 @@ pub mod exports {
                         Output = wasmtime::Result<Aggregates>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1107,7 +1107,7 @@ pub mod exports {
                         Output = wasmtime::Result<i32>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/records_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/records_tracing_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -132,7 +132,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -1051,7 +1051,7 @@ pub mod exports {
                         arg0: (char, u32),
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -1079,7 +1079,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<(char, u32)>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -1108,7 +1108,7 @@ pub mod exports {
                         arg0: Empty,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -1136,7 +1136,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<Empty>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -1165,7 +1165,7 @@ pub mod exports {
                         arg0: Scalars,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -1193,7 +1193,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<Scalars>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -1222,7 +1222,7 @@ pub mod exports {
                         arg0: ReallyFlags,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -1250,7 +1250,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<ReallyFlags>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -1279,7 +1279,7 @@ pub mod exports {
                         arg0: &Aggregates,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -1307,7 +1307,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<Aggregates>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -1336,7 +1336,7 @@ pub mod exports {
                         arg0: TupleTypedef2,
                     ) -> wasmtime::Result<i32>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(

--- a/crates/component-macro/tests/expanded/rename.rs
+++ b/crates/component-macro/tests/expanded/rename.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Neptune`] as well.
-pub struct NeptunePre<T> {
+pub struct NeptunePre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: NeptuneIndices,
 }
-impl<T> Clone for NeptunePre<T> {
+impl<T: 'static> Clone for NeptunePre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for NeptunePre<T> {
         }
     }
 }
-impl<_T> NeptunePre<_T> {
+impl<_T: 'static> NeptunePre<_T> {
     /// Creates a new copy of `NeptunePre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -121,7 +121,7 @@ const _: () = {
     impl Neptune {
         /// Convenience wrapper around [`NeptunePre::new`] and
         /// [`NeptunePre::instantiate`].
-        pub fn instantiate<_T>(
+        pub fn instantiate<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/rename_async.rs
+++ b/crates/component-macro/tests/expanded/rename_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Neptune`] as well.
-pub struct NeptunePre<T> {
+pub struct NeptunePre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: NeptuneIndices,
 }
-impl<T> Clone for NeptunePre<T> {
+impl<T: 'static> Clone for NeptunePre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for NeptunePre<T> {
         }
     }
 }
-impl<_T> NeptunePre<_T> {
+impl<_T: 'static> NeptunePre<_T> {
     /// Creates a new copy of `NeptunePre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -124,7 +124,7 @@ const _: () = {
     impl Neptune {
         /// Convenience wrapper around [`NeptunePre::new`] and
         /// [`NeptunePre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/rename_concurrent.rs
+++ b/crates/component-macro/tests/expanded/rename_concurrent.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Neptune`] as well.
-pub struct NeptunePre<T> {
+pub struct NeptunePre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: NeptuneIndices,
 }
-impl<T> Clone for NeptunePre<T> {
+impl<T: 'static> Clone for NeptunePre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for NeptunePre<T> {
         }
     }
 }
-impl<_T> NeptunePre<_T> {
+impl<_T: 'static> NeptunePre<_T> {
     /// Creates a new copy of `NeptunePre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -124,7 +124,7 @@ const _: () = {
     impl Neptune {
         /// Convenience wrapper around [`NeptunePre::new`] and
         /// [`NeptunePre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/rename_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/rename_tracing_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Neptune`] as well.
-pub struct NeptunePre<T> {
+pub struct NeptunePre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: NeptuneIndices,
 }
-impl<T> Clone for NeptunePre<T> {
+impl<T: 'static> Clone for NeptunePre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for NeptunePre<T> {
         }
     }
 }
-impl<_T> NeptunePre<_T> {
+impl<_T: 'static> NeptunePre<_T> {
     /// Creates a new copy of `NeptunePre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -124,7 +124,7 @@ const _: () = {
     impl Neptune {
         /// Convenience wrapper around [`NeptunePre::new`] and
         /// [`NeptunePre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/resources-export.rs
+++ b/crates/component-macro/tests/expanded/resources-export.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`W`] as well.
-pub struct WPre<T> {
+pub struct WPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: WIndices,
 }
-impl<T> Clone for WPre<T> {
+impl<T: 'static> Clone for WPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for WPre<T> {
         }
     }
 }
-impl<_T> WPre<_T> {
+impl<_T: 'static> WPre<_T> {
     /// Creates a new copy of `WPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -157,7 +157,7 @@ const _: () = {
     impl W {
         /// Convenience wrapper around [`WPre::new`] and
         /// [`WPre::instantiate`].
-        pub fn instantiate<_T>(
+        pub fn instantiate<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -361,7 +361,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::ResourceAny>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -378,7 +378,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<u32>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -396,7 +396,7 @@ pub mod exports {
                         arg0: wasmtime::component::ResourceAny,
                     ) -> wasmtime::Result<u32>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -519,7 +519,7 @@ pub mod exports {
                         arg0: wasmtime::component::Resource<Y>,
                     ) -> wasmtime::Result<wasmtime::component::ResourceAny>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -536,7 +536,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::Resource<Y>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -555,7 +555,7 @@ pub mod exports {
                         arg1: wasmtime::component::Resource<Y>,
                     ) -> wasmtime::Result<wasmtime::component::Resource<Y>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -652,7 +652,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::ResourceAny>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -748,7 +748,7 @@ pub mod exports {
                         arg0: wasmtime::component::ResourceAny,
                     ) -> wasmtime::Result<wasmtime::component::ResourceAny>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/resources-export_async.rs
+++ b/crates/component-macro/tests/expanded/resources-export_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`W`] as well.
-pub struct WPre<T> {
+pub struct WPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: WIndices,
 }
-impl<T> Clone for WPre<T> {
+impl<T: 'static> Clone for WPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for WPre<T> {
         }
     }
 }
-impl<_T> WPre<_T> {
+impl<_T: 'static> WPre<_T> {
     /// Creates a new copy of `WPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -160,7 +160,7 @@ const _: () = {
     impl W {
         /// Convenience wrapper around [`WPre::new`] and
         /// [`WPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -372,7 +372,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::ResourceAny>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -391,7 +391,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<u32>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -411,7 +411,7 @@ pub mod exports {
                         arg0: wasmtime::component::ResourceAny,
                     ) -> wasmtime::Result<u32>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -536,7 +536,7 @@ pub mod exports {
                         arg0: wasmtime::component::Resource<Y>,
                     ) -> wasmtime::Result<wasmtime::component::ResourceAny>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -555,7 +555,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::Resource<Y>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -576,7 +576,7 @@ pub mod exports {
                         arg1: wasmtime::component::Resource<Y>,
                     ) -> wasmtime::Result<wasmtime::component::Resource<Y>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -675,7 +675,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::ResourceAny>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -773,7 +773,7 @@ pub mod exports {
                         arg0: wasmtime::component::ResourceAny,
                     ) -> wasmtime::Result<wasmtime::component::ResourceAny>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/resources-export_concurrent.rs
+++ b/crates/component-macro/tests/expanded/resources-export_concurrent.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`W`] as well.
-pub struct WPre<T> {
+pub struct WPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: WIndices,
 }
-impl<T> Clone for WPre<T> {
+impl<T: 'static> Clone for WPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for WPre<T> {
         }
     }
 }
-impl<_T> WPre<_T> {
+impl<_T: 'static> WPre<_T> {
     /// Creates a new copy of `WPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -160,7 +160,7 @@ const _: () = {
     impl W {
         /// Convenience wrapper around [`WPre::new`] and
         /// [`WPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -374,7 +374,7 @@ pub mod exports {
                         Output = wasmtime::Result<wasmtime::component::ResourceAny>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -394,7 +394,7 @@ pub mod exports {
                         Output = wasmtime::Result<u32>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -415,7 +415,7 @@ pub mod exports {
                         Output = wasmtime::Result<u32>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -541,7 +541,7 @@ pub mod exports {
                         Output = wasmtime::Result<wasmtime::component::ResourceAny>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -561,7 +561,7 @@ pub mod exports {
                         Output = wasmtime::Result<wasmtime::component::Resource<Y>>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -583,7 +583,7 @@ pub mod exports {
                         Output = wasmtime::Result<wasmtime::component::Resource<Y>>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -683,7 +683,7 @@ pub mod exports {
                         Output = wasmtime::Result<wasmtime::component::ResourceAny>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -782,7 +782,7 @@ pub mod exports {
                         Output = wasmtime::Result<wasmtime::component::ResourceAny>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/resources-export_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/resources-export_tracing_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`W`] as well.
-pub struct WPre<T> {
+pub struct WPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: WIndices,
 }
-impl<T> Clone for WPre<T> {
+impl<T: 'static> Clone for WPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for WPre<T> {
         }
     }
 }
-impl<_T> WPre<_T> {
+impl<_T: 'static> WPre<_T> {
     /// Creates a new copy of `WPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -160,7 +160,7 @@ const _: () = {
     impl W {
         /// Convenience wrapper around [`WPre::new`] and
         /// [`WPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -372,7 +372,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::ResourceAny>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -400,7 +400,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<u32>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -429,7 +429,7 @@ pub mod exports {
                         arg0: wasmtime::component::ResourceAny,
                     ) -> wasmtime::Result<u32>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -563,7 +563,7 @@ pub mod exports {
                         arg0: wasmtime::component::Resource<Y>,
                     ) -> wasmtime::Result<wasmtime::component::ResourceAny>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -591,7 +591,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::Resource<Y>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -622,7 +622,7 @@ pub mod exports {
                         arg1: wasmtime::component::Resource<Y>,
                     ) -> wasmtime::Result<wasmtime::component::Resource<Y>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -731,7 +731,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::ResourceAny>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -838,7 +838,7 @@ pub mod exports {
                         arg0: wasmtime::component::ResourceAny,
                     ) -> wasmtime::Result<wasmtime::component::ResourceAny>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(

--- a/crates/component-macro/tests/expanded/resources-import.rs
+++ b/crates/component-macro/tests/expanded/resources-import.rs
@@ -33,11 +33,11 @@ impl<_T: HostWorldResource> HostWorldResource for &mut _T {
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -45,7 +45,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -205,7 +205,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate`].
-        pub fn instantiate<_T>(
+        pub fn instantiate<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -315,7 +315,7 @@ const _: () = {
             mut store: S,
         ) -> wasmtime::Result<wasmtime::component::Resource<WorldResource>>
         where
-            <S as wasmtime::AsContext>::Data: Send,
+            <S as wasmtime::AsContext>::Data: Send + 'static,
         {
             let callee = unsafe {
                 wasmtime::component::TypedFunc::<
@@ -1075,7 +1075,7 @@ pub mod exports {
                         arg0: wasmtime::component::Resource<Foo>,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/resources-import_async.rs
+++ b/crates/component-macro/tests/expanded/resources-import_async.rs
@@ -34,11 +34,11 @@ impl<_T: HostWorldResource + Send> HostWorldResource for &mut _T {
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -46,7 +46,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -211,7 +211,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -336,7 +336,7 @@ const _: () = {
             mut store: S,
         ) -> wasmtime::Result<wasmtime::component::Resource<WorldResource>>
         where
-            <S as wasmtime::AsContext>::Data: Send,
+            <S as wasmtime::AsContext>::Data: Send + 'static,
         {
             let callee = unsafe {
                 wasmtime::component::TypedFunc::<
@@ -1173,7 +1173,7 @@ pub mod exports {
                         arg0: wasmtime::component::Resource<Foo>,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/resources-import_concurrent.rs
+++ b/crates/component-macro/tests/expanded/resources-import_concurrent.rs
@@ -43,11 +43,11 @@ impl<_T: HostWorldResource + Send> HostWorldResource for &mut _T {
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -55,7 +55,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -224,7 +224,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -364,7 +364,7 @@ const _: () = {
             Output = wasmtime::Result<wasmtime::component::Resource<WorldResource>>,
         > + Send + 'static + use<S>
         where
-            <S as wasmtime::AsContext>::Data: Send,
+            <S as wasmtime::AsContext>::Data: Send + 'static,
         {
             let callee = unsafe {
                 wasmtime::component::TypedFunc::<
@@ -1204,7 +1204,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/resources-import_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/resources-import_tracing_async.rs
@@ -34,11 +34,11 @@ impl<_T: HostWorldResource + Send> HostWorldResource for &mut _T {
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -46,7 +46,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -211,7 +211,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -391,7 +391,7 @@ const _: () = {
             mut store: S,
         ) -> wasmtime::Result<wasmtime::component::Resource<WorldResource>>
         where
-            <S as wasmtime::AsContext>::Data: Send,
+            <S as wasmtime::AsContext>::Data: Send + 'static,
         {
             use tracing::Instrument;
             let span = tracing::span!(
@@ -1577,7 +1577,7 @@ pub mod exports {
                         arg0: wasmtime::component::Resource<Foo>,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(

--- a/crates/component-macro/tests/expanded/share-types.rs
+++ b/crates/component-macro/tests/expanded/share-types.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`HttpInterface`] as well.
-pub struct HttpInterfacePre<T> {
+pub struct HttpInterfacePre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: HttpInterfaceIndices,
 }
-impl<T> Clone for HttpInterfacePre<T> {
+impl<T: 'static> Clone for HttpInterfacePre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for HttpInterfacePre<T> {
         }
     }
 }
-impl<_T> HttpInterfacePre<_T> {
+impl<_T: 'static> HttpInterfacePre<_T> {
     /// Creates a new copy of `HttpInterfacePre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -127,7 +127,7 @@ const _: () = {
     impl HttpInterface {
         /// Convenience wrapper around [`HttpInterfacePre::new`] and
         /// [`HttpInterfacePre::instantiate`].
-        pub fn instantiate<_T>(
+        pub fn instantiate<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -345,7 +345,7 @@ pub mod exports {
                 arg0: &Request,
             ) -> wasmtime::Result<Response>
             where
-                <S as wasmtime::AsContext>::Data: Send,
+                <S as wasmtime::AsContext>::Data: Send + 'static,
             {
                 let callee = unsafe {
                     wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/share-types_async.rs
+++ b/crates/component-macro/tests/expanded/share-types_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`HttpInterface`] as well.
-pub struct HttpInterfacePre<T> {
+pub struct HttpInterfacePre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: HttpInterfaceIndices,
 }
-impl<T> Clone for HttpInterfacePre<T> {
+impl<T: 'static> Clone for HttpInterfacePre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for HttpInterfacePre<T> {
         }
     }
 }
-impl<_T> HttpInterfacePre<_T> {
+impl<_T: 'static> HttpInterfacePre<_T> {
     /// Creates a new copy of `HttpInterfacePre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -130,7 +130,7 @@ const _: () = {
     impl HttpInterface {
         /// Convenience wrapper around [`HttpInterfacePre::new`] and
         /// [`HttpInterfacePre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -355,7 +355,7 @@ pub mod exports {
                 arg0: &Request,
             ) -> wasmtime::Result<Response>
             where
-                <S as wasmtime::AsContext>::Data: Send,
+                <S as wasmtime::AsContext>::Data: Send + 'static,
             {
                 let callee = unsafe {
                     wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/share-types_concurrent.rs
+++ b/crates/component-macro/tests/expanded/share-types_concurrent.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`HttpInterface`] as well.
-pub struct HttpInterfacePre<T> {
+pub struct HttpInterfacePre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: HttpInterfaceIndices,
 }
-impl<T> Clone for HttpInterfacePre<T> {
+impl<T: 'static> Clone for HttpInterfacePre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for HttpInterfacePre<T> {
         }
     }
 }
-impl<_T> HttpInterfacePre<_T> {
+impl<_T: 'static> HttpInterfacePre<_T> {
     /// Creates a new copy of `HttpInterfacePre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -130,7 +130,7 @@ const _: () = {
     impl HttpInterface {
         /// Convenience wrapper around [`HttpInterfacePre::new`] and
         /// [`HttpInterfacePre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -360,7 +360,7 @@ pub mod exports {
                 Output = wasmtime::Result<Response>,
             > + Send + 'static + use<S>
             where
-                <S as wasmtime::AsContext>::Data: Send,
+                <S as wasmtime::AsContext>::Data: Send + 'static,
             {
                 let callee = unsafe {
                     wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/share-types_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/share-types_tracing_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`HttpInterface`] as well.
-pub struct HttpInterfacePre<T> {
+pub struct HttpInterfacePre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: HttpInterfaceIndices,
 }
-impl<T> Clone for HttpInterfacePre<T> {
+impl<T: 'static> Clone for HttpInterfacePre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for HttpInterfacePre<T> {
         }
     }
 }
-impl<_T> HttpInterfacePre<_T> {
+impl<_T: 'static> HttpInterfacePre<_T> {
     /// Creates a new copy of `HttpInterfacePre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -130,7 +130,7 @@ const _: () = {
     impl HttpInterface {
         /// Convenience wrapper around [`HttpInterfacePre::new`] and
         /// [`HttpInterfacePre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -371,7 +371,7 @@ pub mod exports {
                 arg0: &Request,
             ) -> wasmtime::Result<Response>
             where
-                <S as wasmtime::AsContext>::Data: Send,
+                <S as wasmtime::AsContext>::Data: Send + 'static,
             {
                 use tracing::Instrument;
                 let span = tracing::span!(

--- a/crates/component-macro/tests/expanded/simple-functions.rs
+++ b/crates/component-macro/tests/expanded/simple-functions.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -129,7 +129,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate`].
-        pub fn instantiate<_T>(
+        pub fn instantiate<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -375,7 +375,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -393,7 +393,7 @@ pub mod exports {
                         arg0: u32,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -412,7 +412,7 @@ pub mod exports {
                         arg1: u32,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -429,7 +429,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<u32>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -446,7 +446,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<(u32, u32)>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -466,7 +466,7 @@ pub mod exports {
                         arg2: u32,
                     ) -> wasmtime::Result<(u32, u32, u32)>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/simple-functions_async.rs
+++ b/crates/component-macro/tests/expanded/simple-functions_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -132,7 +132,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -394,7 +394,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -412,7 +412,7 @@ pub mod exports {
                         arg0: u32,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -433,7 +433,7 @@ pub mod exports {
                         arg1: u32,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -452,7 +452,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<u32>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -471,7 +471,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<(u32, u32)>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -493,7 +493,7 @@ pub mod exports {
                         arg2: u32,
                     ) -> wasmtime::Result<(u32, u32, u32)>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/simple-functions_concurrent.rs
+++ b/crates/component-macro/tests/expanded/simple-functions_concurrent.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -132,7 +132,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -414,7 +414,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -432,7 +432,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -451,7 +451,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -468,7 +468,7 @@ pub mod exports {
                         Output = wasmtime::Result<u32>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -488,7 +488,7 @@ pub mod exports {
                         Output = wasmtime::Result<(u32, u32)>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -511,7 +511,7 @@ pub mod exports {
                         Output = wasmtime::Result<(u32, u32, u32)>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/simple-functions_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/simple-functions_tracing_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -132,7 +132,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -482,7 +482,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -511,7 +511,7 @@ pub mod exports {
                         arg0: u32,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -541,7 +541,7 @@ pub mod exports {
                         arg1: u32,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -569,7 +569,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<u32>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -597,7 +597,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<(u32, u32)>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -628,7 +628,7 @@ pub mod exports {
                         arg2: u32,
                     ) -> wasmtime::Result<(u32, u32, u32)>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(

--- a/crates/component-macro/tests/expanded/simple-lists.rs
+++ b/crates/component-macro/tests/expanded/simple-lists.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`MyWorld`] as well.
-pub struct MyWorldPre<T> {
+pub struct MyWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: MyWorldIndices,
 }
-impl<T> Clone for MyWorldPre<T> {
+impl<T: 'static> Clone for MyWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for MyWorldPre<T> {
         }
     }
 }
-impl<_T> MyWorldPre<_T> {
+impl<_T: 'static> MyWorldPre<_T> {
     /// Creates a new copy of `MyWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -129,7 +129,7 @@ const _: () = {
     impl MyWorld {
         /// Convenience wrapper around [`MyWorldPre::new`] and
         /// [`MyWorldPre::instantiate`].
-        pub fn instantiate<_T>(
+        pub fn instantiate<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -410,7 +410,7 @@ pub mod exports {
                         arg0: &[u32],
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -427,7 +427,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::__internal::Vec<u32>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -451,7 +451,7 @@ pub mod exports {
                         ),
                     >
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -478,7 +478,7 @@ pub mod exports {
                         >,
                     >
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/simple-lists_async.rs
+++ b/crates/component-macro/tests/expanded/simple-lists_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`MyWorld`] as well.
-pub struct MyWorldPre<T> {
+pub struct MyWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: MyWorldIndices,
 }
-impl<T> Clone for MyWorldPre<T> {
+impl<T: 'static> Clone for MyWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for MyWorldPre<T> {
         }
     }
 }
-impl<_T> MyWorldPre<_T> {
+impl<_T: 'static> MyWorldPre<_T> {
     /// Creates a new copy of `MyWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -132,7 +132,7 @@ const _: () = {
     impl MyWorld {
         /// Convenience wrapper around [`MyWorldPre::new`] and
         /// [`MyWorldPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -429,7 +429,7 @@ pub mod exports {
                         arg0: &[u32],
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -448,7 +448,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::__internal::Vec<u32>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -474,7 +474,7 @@ pub mod exports {
                         ),
                     >
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -503,7 +503,7 @@ pub mod exports {
                         >,
                     >
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/simple-lists_concurrent.rs
+++ b/crates/component-macro/tests/expanded/simple-lists_concurrent.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`MyWorld`] as well.
-pub struct MyWorldPre<T> {
+pub struct MyWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: MyWorldIndices,
 }
-impl<T> Clone for MyWorldPre<T> {
+impl<T: 'static> Clone for MyWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for MyWorldPre<T> {
         }
     }
 }
-impl<_T> MyWorldPre<_T> {
+impl<_T: 'static> MyWorldPre<_T> {
     /// Creates a new copy of `MyWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -132,7 +132,7 @@ const _: () = {
     impl MyWorld {
         /// Convenience wrapper around [`MyWorldPre::new`] and
         /// [`MyWorldPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -422,7 +422,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -441,7 +441,7 @@ pub mod exports {
                         >,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -468,7 +468,7 @@ pub mod exports {
                         >,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -503,7 +503,7 @@ pub mod exports {
                         >,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/simple-lists_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/simple-lists_tracing_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`MyWorld`] as well.
-pub struct MyWorldPre<T> {
+pub struct MyWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: MyWorldIndices,
 }
-impl<T> Clone for MyWorldPre<T> {
+impl<T: 'static> Clone for MyWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for MyWorldPre<T> {
         }
     }
 }
-impl<_T> MyWorldPre<_T> {
+impl<_T: 'static> MyWorldPre<_T> {
     /// Creates a new copy of `MyWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -132,7 +132,7 @@ const _: () = {
     impl MyWorld {
         /// Convenience wrapper around [`MyWorldPre::new`] and
         /// [`MyWorldPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -490,7 +490,7 @@ pub mod exports {
                         arg0: &[u32],
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -518,7 +518,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::__internal::Vec<u32>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -553,7 +553,7 @@ pub mod exports {
                         ),
                     >
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -591,7 +591,7 @@ pub mod exports {
                         >,
                     >
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(

--- a/crates/component-macro/tests/expanded/simple-wasi.rs
+++ b/crates/component-macro/tests/expanded/simple-wasi.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Wasi`] as well.
-pub struct WasiPre<T> {
+pub struct WasiPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: WasiIndices,
 }
-impl<T> Clone for WasiPre<T> {
+impl<T: 'static> Clone for WasiPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for WasiPre<T> {
         }
     }
 }
-impl<_T> WasiPre<_T> {
+impl<_T: 'static> WasiPre<_T> {
     /// Creates a new copy of `WasiPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -121,7 +121,7 @@ const _: () = {
     impl Wasi {
         /// Convenience wrapper around [`WasiPre::new`] and
         /// [`WasiPre::instantiate`].
-        pub fn instantiate<_T>(
+        pub fn instantiate<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/simple-wasi_async.rs
+++ b/crates/component-macro/tests/expanded/simple-wasi_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Wasi`] as well.
-pub struct WasiPre<T> {
+pub struct WasiPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: WasiIndices,
 }
-impl<T> Clone for WasiPre<T> {
+impl<T: 'static> Clone for WasiPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for WasiPre<T> {
         }
     }
 }
-impl<_T> WasiPre<_T> {
+impl<_T: 'static> WasiPre<_T> {
     /// Creates a new copy of `WasiPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -124,7 +124,7 @@ const _: () = {
     impl Wasi {
         /// Convenience wrapper around [`WasiPre::new`] and
         /// [`WasiPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/simple-wasi_concurrent.rs
+++ b/crates/component-macro/tests/expanded/simple-wasi_concurrent.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Wasi`] as well.
-pub struct WasiPre<T> {
+pub struct WasiPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: WasiIndices,
 }
-impl<T> Clone for WasiPre<T> {
+impl<T: 'static> Clone for WasiPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for WasiPre<T> {
         }
     }
 }
-impl<_T> WasiPre<_T> {
+impl<_T: 'static> WasiPre<_T> {
     /// Creates a new copy of `WasiPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -124,7 +124,7 @@ const _: () = {
     impl Wasi {
         /// Convenience wrapper around [`WasiPre::new`] and
         /// [`WasiPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/simple-wasi_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/simple-wasi_tracing_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Wasi`] as well.
-pub struct WasiPre<T> {
+pub struct WasiPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: WasiIndices,
 }
-impl<T> Clone for WasiPre<T> {
+impl<T: 'static> Clone for WasiPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for WasiPre<T> {
         }
     }
 }
-impl<_T> WasiPre<_T> {
+impl<_T: 'static> WasiPre<_T> {
     /// Creates a new copy of `WasiPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -124,7 +124,7 @@ const _: () = {
     impl Wasi {
         /// Convenience wrapper around [`WasiPre::new`] and
         /// [`WasiPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/small-anonymous.rs
+++ b/crates/component-macro/tests/expanded/small-anonymous.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -127,7 +127,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate`].
-        pub fn instantiate<_T>(
+        pub fn instantiate<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -379,7 +379,7 @@ pub mod exports {
                         Result<Option<wasmtime::component::__internal::String>, Error>,
                     >
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/small-anonymous_async.rs
+++ b/crates/component-macro/tests/expanded/small-anonymous_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -130,7 +130,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -388,7 +388,7 @@ pub mod exports {
                         Result<Option<wasmtime::component::__internal::String>, Error>,
                     >
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/small-anonymous_concurrent.rs
+++ b/crates/component-macro/tests/expanded/small-anonymous_concurrent.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -130,7 +130,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -396,7 +396,7 @@ pub mod exports {
                         >,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/small-anonymous_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/small-anonymous_tracing_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -130,7 +130,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -401,7 +401,7 @@ pub mod exports {
                         Result<Option<wasmtime::component::__internal::String>, Error>,
                     >
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(

--- a/crates/component-macro/tests/expanded/smoke-default.rs
+++ b/crates/component-macro/tests/expanded/smoke-default.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -141,7 +141,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate`].
-        pub fn instantiate<_T>(
+        pub fn instantiate<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -163,7 +163,7 @@ const _: () = {
             mut store: S,
         ) -> wasmtime::Result<()>
         where
-            <S as wasmtime::AsContext>::Data: Send,
+            <S as wasmtime::AsContext>::Data: Send + 'static,
         {
             let callee = unsafe {
                 wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.y)

--- a/crates/component-macro/tests/expanded/smoke-default_async.rs
+++ b/crates/component-macro/tests/expanded/smoke-default_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -144,7 +144,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -169,7 +169,7 @@ const _: () = {
             mut store: S,
         ) -> wasmtime::Result<()>
         where
-            <S as wasmtime::AsContext>::Data: Send,
+            <S as wasmtime::AsContext>::Data: Send + 'static,
         {
             let callee = unsafe {
                 wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.y)

--- a/crates/component-macro/tests/expanded/smoke-default_concurrent.rs
+++ b/crates/component-macro/tests/expanded/smoke-default_concurrent.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -144,7 +144,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -171,7 +171,7 @@ const _: () = {
             Output = wasmtime::Result<()>,
         > + Send + 'static + use<S>
         where
-            <S as wasmtime::AsContext>::Data: Send,
+            <S as wasmtime::AsContext>::Data: Send + 'static,
         {
             let callee = unsafe {
                 wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.y)

--- a/crates/component-macro/tests/expanded/smoke-default_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/smoke-default_tracing_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -144,7 +144,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -169,7 +169,7 @@ const _: () = {
             mut store: S,
         ) -> wasmtime::Result<()>
         where
-            <S as wasmtime::AsContext>::Data: Send,
+            <S as wasmtime::AsContext>::Data: Send + 'static,
         {
             use tracing::Instrument;
             let span = tracing::span!(

--- a/crates/component-macro/tests/expanded/smoke-export.rs
+++ b/crates/component-macro/tests/expanded/smoke-export.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -127,7 +127,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate`].
-        pub fn instantiate<_T>(
+        pub fn instantiate<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -212,7 +212,7 @@ pub mod exports {
                 mut store: S,
             ) -> wasmtime::Result<()>
             where
-                <S as wasmtime::AsContext>::Data: Send,
+                <S as wasmtime::AsContext>::Data: Send + 'static,
             {
                 let callee = unsafe {
                     wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.y)

--- a/crates/component-macro/tests/expanded/smoke-export_async.rs
+++ b/crates/component-macro/tests/expanded/smoke-export_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -130,7 +130,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -218,7 +218,7 @@ pub mod exports {
                 mut store: S,
             ) -> wasmtime::Result<()>
             where
-                <S as wasmtime::AsContext>::Data: Send,
+                <S as wasmtime::AsContext>::Data: Send + 'static,
             {
                 let callee = unsafe {
                     wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.y)

--- a/crates/component-macro/tests/expanded/smoke-export_concurrent.rs
+++ b/crates/component-macro/tests/expanded/smoke-export_concurrent.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -130,7 +130,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -220,7 +220,7 @@ pub mod exports {
                 Output = wasmtime::Result<()>,
             > + Send + 'static + use<S>
             where
-                <S as wasmtime::AsContext>::Data: Send,
+                <S as wasmtime::AsContext>::Data: Send + 'static,
             {
                 let callee = unsafe {
                     wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.y)

--- a/crates/component-macro/tests/expanded/smoke-export_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/smoke-export_tracing_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -130,7 +130,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -218,7 +218,7 @@ pub mod exports {
                 mut store: S,
             ) -> wasmtime::Result<()>
             where
-                <S as wasmtime::AsContext>::Data: Send,
+                <S as wasmtime::AsContext>::Data: Send + 'static,
             {
                 use tracing::Instrument;
                 let span = tracing::span!(

--- a/crates/component-macro/tests/expanded/smoke.rs
+++ b/crates/component-macro/tests/expanded/smoke.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -121,7 +121,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate`].
-        pub fn instantiate<_T>(
+        pub fn instantiate<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/smoke_async.rs
+++ b/crates/component-macro/tests/expanded/smoke_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -124,7 +124,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/smoke_concurrent.rs
+++ b/crates/component-macro/tests/expanded/smoke_concurrent.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -124,7 +124,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/smoke_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/smoke_tracing_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -124,7 +124,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/strings.rs
+++ b/crates/component-macro/tests/expanded/strings.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -129,7 +129,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate`].
-        pub fn instantiate<_T>(
+        pub fn instantiate<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -332,7 +332,7 @@ pub mod exports {
                         arg0: &str,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -349,7 +349,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::__internal::String>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -368,7 +368,7 @@ pub mod exports {
                         arg1: &str,
                     ) -> wasmtime::Result<wasmtime::component::__internal::String>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/strings_async.rs
+++ b/crates/component-macro/tests/expanded/strings_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -132,7 +132,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -345,7 +345,7 @@ pub mod exports {
                         arg0: &str,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -364,7 +364,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::__internal::String>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -385,7 +385,7 @@ pub mod exports {
                         arg1: &str,
                     ) -> wasmtime::Result<wasmtime::component::__internal::String>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/strings_concurrent.rs
+++ b/crates/component-macro/tests/expanded/strings_concurrent.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -132,7 +132,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -350,7 +350,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -369,7 +369,7 @@ pub mod exports {
                         >,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -393,7 +393,7 @@ pub mod exports {
                         >,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/strings_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/strings_tracing_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -132,7 +132,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -390,7 +390,7 @@ pub mod exports {
                         arg0: &str,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -418,7 +418,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::__internal::String>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -448,7 +448,7 @@ pub mod exports {
                         arg1: &str,
                     ) -> wasmtime::Result<wasmtime::component::__internal::String>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(

--- a/crates/component-macro/tests/expanded/unstable-features.rs
+++ b/crates/component-macro/tests/expanded/unstable-features.rs
@@ -99,11 +99,11 @@ impl<_T: HostBaz> HostBaz for &mut _T {
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -111,7 +111,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -222,7 +222,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate`].
-        pub fn instantiate<_T>(
+        pub fn instantiate<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/unstable-features_async.rs
+++ b/crates/component-macro/tests/expanded/unstable-features_async.rs
@@ -106,11 +106,11 @@ impl<_T: HostBaz + Send> HostBaz for &mut _T {
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -118,7 +118,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -234,7 +234,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/unstable-features_concurrent.rs
+++ b/crates/component-macro/tests/expanded/unstable-features_concurrent.rs
@@ -111,11 +111,11 @@ impl<_T: HostBaz + Send> HostBaz for &mut _T {
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -123,7 +123,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -241,7 +241,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/unstable-features_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/unstable-features_tracing_async.rs
@@ -106,11 +106,11 @@ impl<_T: HostBaz + Send> HostBaz for &mut _T {
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T> {
+pub struct TheWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: TheWorldIndices,
 }
-impl<T> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -118,7 +118,7 @@ impl<T> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T> TheWorldPre<_T> {
+impl<_T: 'static> TheWorldPre<_T> {
     /// Creates a new copy of `TheWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -234,7 +234,7 @@ const _: () = {
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
         /// [`TheWorldPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/unversioned-foo.rs
+++ b/crates/component-macro/tests/expanded/unversioned-foo.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Nope`] as well.
-pub struct NopePre<T> {
+pub struct NopePre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: NopeIndices,
 }
-impl<T> Clone for NopePre<T> {
+impl<T: 'static> Clone for NopePre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for NopePre<T> {
         }
     }
 }
-impl<_T> NopePre<_T> {
+impl<_T: 'static> NopePre<_T> {
     /// Creates a new copy of `NopePre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -121,7 +121,7 @@ const _: () = {
     impl Nope {
         /// Convenience wrapper around [`NopePre::new`] and
         /// [`NopePre::instantiate`].
-        pub fn instantiate<_T>(
+        pub fn instantiate<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/unversioned-foo_async.rs
+++ b/crates/component-macro/tests/expanded/unversioned-foo_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Nope`] as well.
-pub struct NopePre<T> {
+pub struct NopePre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: NopeIndices,
 }
-impl<T> Clone for NopePre<T> {
+impl<T: 'static> Clone for NopePre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for NopePre<T> {
         }
     }
 }
-impl<_T> NopePre<_T> {
+impl<_T: 'static> NopePre<_T> {
     /// Creates a new copy of `NopePre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -124,7 +124,7 @@ const _: () = {
     impl Nope {
         /// Convenience wrapper around [`NopePre::new`] and
         /// [`NopePre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/unversioned-foo_concurrent.rs
+++ b/crates/component-macro/tests/expanded/unversioned-foo_concurrent.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Nope`] as well.
-pub struct NopePre<T> {
+pub struct NopePre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: NopeIndices,
 }
-impl<T> Clone for NopePre<T> {
+impl<T: 'static> Clone for NopePre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for NopePre<T> {
         }
     }
 }
-impl<_T> NopePre<_T> {
+impl<_T: 'static> NopePre<_T> {
     /// Creates a new copy of `NopePre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -124,7 +124,7 @@ const _: () = {
     impl Nope {
         /// Convenience wrapper around [`NopePre::new`] and
         /// [`NopePre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/unversioned-foo_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/unversioned-foo_tracing_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Nope`] as well.
-pub struct NopePre<T> {
+pub struct NopePre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: NopeIndices,
 }
-impl<T> Clone for NopePre<T> {
+impl<T: 'static> Clone for NopePre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for NopePre<T> {
         }
     }
 }
-impl<_T> NopePre<_T> {
+impl<_T: 'static> NopePre<_T> {
     /// Creates a new copy of `NopePre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -124,7 +124,7 @@ const _: () = {
     impl Nope {
         /// Convenience wrapper around [`NopePre::new`] and
         /// [`NopePre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/use-paths.rs
+++ b/crates/component-macro/tests/expanded/use-paths.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`D`] as well.
-pub struct DPre<T> {
+pub struct DPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: DIndices,
 }
-impl<T> Clone for DPre<T> {
+impl<T: 'static> Clone for DPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for DPre<T> {
         }
     }
 }
-impl<_T> DPre<_T> {
+impl<_T: 'static> DPre<_T> {
     /// Creates a new copy of `DPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -121,7 +121,7 @@ const _: () = {
     impl D {
         /// Convenience wrapper around [`DPre::new`] and
         /// [`DPre::instantiate`].
-        pub fn instantiate<_T>(
+        pub fn instantiate<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/use-paths_async.rs
+++ b/crates/component-macro/tests/expanded/use-paths_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`D`] as well.
-pub struct DPre<T> {
+pub struct DPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: DIndices,
 }
-impl<T> Clone for DPre<T> {
+impl<T: 'static> Clone for DPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for DPre<T> {
         }
     }
 }
-impl<_T> DPre<_T> {
+impl<_T: 'static> DPre<_T> {
     /// Creates a new copy of `DPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -124,7 +124,7 @@ const _: () = {
     impl D {
         /// Convenience wrapper around [`DPre::new`] and
         /// [`DPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/use-paths_concurrent.rs
+++ b/crates/component-macro/tests/expanded/use-paths_concurrent.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`D`] as well.
-pub struct DPre<T> {
+pub struct DPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: DIndices,
 }
-impl<T> Clone for DPre<T> {
+impl<T: 'static> Clone for DPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for DPre<T> {
         }
     }
 }
-impl<_T> DPre<_T> {
+impl<_T: 'static> DPre<_T> {
     /// Creates a new copy of `DPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -124,7 +124,7 @@ const _: () = {
     impl D {
         /// Convenience wrapper around [`DPre::new`] and
         /// [`DPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/use-paths_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/use-paths_tracing_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`D`] as well.
-pub struct DPre<T> {
+pub struct DPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: DIndices,
 }
-impl<T> Clone for DPre<T> {
+impl<T: 'static> Clone for DPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for DPre<T> {
         }
     }
 }
-impl<_T> DPre<_T> {
+impl<_T: 'static> DPre<_T> {
     /// Creates a new copy of `DPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -124,7 +124,7 @@ const _: () = {
     impl D {
         /// Convenience wrapper around [`DPre::new`] and
         /// [`DPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/variants.rs
+++ b/crates/component-macro/tests/expanded/variants.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`MyWorld`] as well.
-pub struct MyWorldPre<T> {
+pub struct MyWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: MyWorldIndices,
 }
-impl<T> Clone for MyWorldPre<T> {
+impl<T: 'static> Clone for MyWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for MyWorldPre<T> {
         }
     }
 }
-impl<_T> MyWorldPre<_T> {
+impl<_T: 'static> MyWorldPre<_T> {
     /// Creates a new copy of `MyWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -129,7 +129,7 @@ const _: () = {
     impl MyWorld {
         /// Convenience wrapper around [`MyWorldPre::new`] and
         /// [`MyWorldPre::instantiate`].
-        pub fn instantiate<_T>(
+        pub fn instantiate<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -1515,7 +1515,7 @@ pub mod exports {
                         arg0: E1,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1532,7 +1532,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<E1>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1550,7 +1550,7 @@ pub mod exports {
                         arg0: &V1,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1567,7 +1567,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<V1>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1585,7 +1585,7 @@ pub mod exports {
                         arg0: bool,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1602,7 +1602,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<bool>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1625,7 +1625,7 @@ pub mod exports {
                         arg5: Option<Option<bool>>,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1662,7 +1662,7 @@ pub mod exports {
                         ),
                     >
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1696,7 +1696,7 @@ pub mod exports {
                         (Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),
                     >
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1723,7 +1723,7 @@ pub mod exports {
                         arg5: Result<&str, &[u8]>,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1763,7 +1763,7 @@ pub mod exports {
                         ),
                     >
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1792,7 +1792,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<Result<i32, MyErrno>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1809,7 +1809,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<Result<(), MyErrno>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1826,7 +1826,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<Result<MyErrno, MyErrno>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1843,7 +1843,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<Result<(i32, u32), MyErrno>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1860,7 +1860,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<Option<i32>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1877,7 +1877,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<Option<MyErrno>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1894,7 +1894,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<Result<u32, i32>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1912,7 +1912,7 @@ pub mod exports {
                         arg0: &IsClone,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1929,7 +1929,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<IsClone>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/variants_async.rs
+++ b/crates/component-macro/tests/expanded/variants_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`MyWorld`] as well.
-pub struct MyWorldPre<T> {
+pub struct MyWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: MyWorldIndices,
 }
-impl<T> Clone for MyWorldPre<T> {
+impl<T: 'static> Clone for MyWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for MyWorldPre<T> {
         }
     }
 }
-impl<_T> MyWorldPre<_T> {
+impl<_T: 'static> MyWorldPre<_T> {
     /// Creates a new copy of `MyWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -132,7 +132,7 @@ const _: () = {
     impl MyWorld {
         /// Convenience wrapper around [`MyWorldPre::new`] and
         /// [`MyWorldPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -1565,7 +1565,7 @@ pub mod exports {
                         arg0: E1,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1584,7 +1584,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<E1>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1604,7 +1604,7 @@ pub mod exports {
                         arg0: &V1,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1623,7 +1623,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<V1>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1643,7 +1643,7 @@ pub mod exports {
                         arg0: bool,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1662,7 +1662,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<bool>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1687,7 +1687,7 @@ pub mod exports {
                         arg5: Option<Option<bool>>,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1725,7 +1725,7 @@ pub mod exports {
                         ),
                     >
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1761,7 +1761,7 @@ pub mod exports {
                         (Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),
                     >
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1789,7 +1789,7 @@ pub mod exports {
                         arg5: Result<&str, &[u8]>,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1830,7 +1830,7 @@ pub mod exports {
                         ),
                     >
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1861,7 +1861,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<Result<i32, MyErrno>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1880,7 +1880,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<Result<(), MyErrno>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1899,7 +1899,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<Result<MyErrno, MyErrno>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1918,7 +1918,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<Result<(i32, u32), MyErrno>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1937,7 +1937,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<Option<i32>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1956,7 +1956,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<Option<MyErrno>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1975,7 +1975,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<Result<u32, i32>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1995,7 +1995,7 @@ pub mod exports {
                         arg0: &IsClone,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -2014,7 +2014,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<IsClone>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/variants_concurrent.rs
+++ b/crates/component-macro/tests/expanded/variants_concurrent.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`MyWorld`] as well.
-pub struct MyWorldPre<T> {
+pub struct MyWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: MyWorldIndices,
 }
-impl<T> Clone for MyWorldPre<T> {
+impl<T: 'static> Clone for MyWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for MyWorldPre<T> {
         }
     }
 }
-impl<_T> MyWorldPre<_T> {
+impl<_T: 'static> MyWorldPre<_T> {
     /// Creates a new copy of `MyWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -132,7 +132,7 @@ const _: () = {
     impl MyWorld {
         /// Convenience wrapper around [`MyWorldPre::new`] and
         /// [`MyWorldPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -1561,7 +1561,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1578,7 +1578,7 @@ pub mod exports {
                         Output = wasmtime::Result<E1>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1599,7 +1599,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1616,7 +1616,7 @@ pub mod exports {
                         Output = wasmtime::Result<V1>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1637,7 +1637,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1654,7 +1654,7 @@ pub mod exports {
                         Output = wasmtime::Result<bool>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1680,7 +1680,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1717,7 +1717,7 @@ pub mod exports {
                         >,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1754,7 +1754,7 @@ pub mod exports {
                         >,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1787,7 +1787,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1830,7 +1830,7 @@ pub mod exports {
                         >,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1862,7 +1862,7 @@ pub mod exports {
                         Output = wasmtime::Result<Result<i32, MyErrno>>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1882,7 +1882,7 @@ pub mod exports {
                         Output = wasmtime::Result<Result<(), MyErrno>>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1902,7 +1902,7 @@ pub mod exports {
                         Output = wasmtime::Result<Result<MyErrno, MyErrno>>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1922,7 +1922,7 @@ pub mod exports {
                         Output = wasmtime::Result<Result<(i32, u32), MyErrno>>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1942,7 +1942,7 @@ pub mod exports {
                         Output = wasmtime::Result<Option<i32>>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1962,7 +1962,7 @@ pub mod exports {
                         Output = wasmtime::Result<Option<MyErrno>>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1982,7 +1982,7 @@ pub mod exports {
                         Output = wasmtime::Result<Result<u32, i32>>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -2003,7 +2003,7 @@ pub mod exports {
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -2020,7 +2020,7 @@ pub mod exports {
                         Output = wasmtime::Result<IsClone>,
                     > + Send + 'static + use<S>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<

--- a/crates/component-macro/tests/expanded/variants_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/variants_tracing_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`MyWorld`] as well.
-pub struct MyWorldPre<T> {
+pub struct MyWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: MyWorldIndices,
 }
-impl<T> Clone for MyWorldPre<T> {
+impl<T: 'static> Clone for MyWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for MyWorldPre<T> {
         }
     }
 }
-impl<_T> MyWorldPre<_T> {
+impl<_T: 'static> MyWorldPre<_T> {
     /// Creates a new copy of `MyWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -132,7 +132,7 @@ const _: () = {
     impl MyWorld {
         /// Convenience wrapper around [`MyWorldPre::new`] and
         /// [`MyWorldPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -1863,7 +1863,7 @@ pub mod exports {
                         arg0: E1,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -1891,7 +1891,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<E1>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -1920,7 +1920,7 @@ pub mod exports {
                         arg0: &V1,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -1948,7 +1948,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<V1>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -1977,7 +1977,7 @@ pub mod exports {
                         arg0: bool,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -2005,7 +2005,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<bool>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -2039,7 +2039,7 @@ pub mod exports {
                         arg5: Option<Option<bool>>,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -2086,7 +2086,7 @@ pub mod exports {
                         ),
                     >
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -2131,7 +2131,7 @@ pub mod exports {
                         (Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),
                     >
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -2168,7 +2168,7 @@ pub mod exports {
                         arg5: Result<&str, &[u8]>,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -2218,7 +2218,7 @@ pub mod exports {
                         ),
                     >
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -2258,7 +2258,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<Result<i32, MyErrno>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -2286,7 +2286,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<Result<(), MyErrno>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -2314,7 +2314,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<Result<MyErrno, MyErrno>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -2342,7 +2342,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<Result<(i32, u32), MyErrno>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -2370,7 +2370,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<Option<i32>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -2398,7 +2398,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<Option<MyErrno>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -2426,7 +2426,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<Result<u32, i32>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -2455,7 +2455,7 @@ pub mod exports {
                         arg0: &IsClone,
                     ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(
@@ -2483,7 +2483,7 @@ pub mod exports {
                         mut store: S,
                     ) -> wasmtime::Result<IsClone>
                     where
-                        <S as wasmtime::AsContext>::Data: Send,
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
                         use tracing::Instrument;
                         let span = tracing::span!(

--- a/crates/component-macro/tests/expanded/wat.rs
+++ b/crates/component-macro/tests/expanded/wat.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Example`] as well.
-pub struct ExamplePre<T> {
+pub struct ExamplePre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: ExampleIndices,
 }
-impl<T> Clone for ExamplePre<T> {
+impl<T: 'static> Clone for ExamplePre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for ExamplePre<T> {
         }
     }
 }
-impl<_T> ExamplePre<_T> {
+impl<_T: 'static> ExamplePre<_T> {
     /// Creates a new copy of `ExamplePre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -129,7 +129,7 @@ const _: () = {
     impl Example {
         /// Convenience wrapper around [`ExamplePre::new`] and
         /// [`ExamplePre::instantiate`].
-        pub fn instantiate<_T>(
+        pub fn instantiate<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/wat_async.rs
+++ b/crates/component-macro/tests/expanded/wat_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Example`] as well.
-pub struct ExamplePre<T> {
+pub struct ExamplePre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: ExampleIndices,
 }
-impl<T> Clone for ExamplePre<T> {
+impl<T: 'static> Clone for ExamplePre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for ExamplePre<T> {
         }
     }
 }
-impl<_T> ExamplePre<_T> {
+impl<_T: 'static> ExamplePre<_T> {
     /// Creates a new copy of `ExamplePre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -132,7 +132,7 @@ const _: () = {
     impl Example {
         /// Convenience wrapper around [`ExamplePre::new`] and
         /// [`ExamplePre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/wat_concurrent.rs
+++ b/crates/component-macro/tests/expanded/wat_concurrent.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Example`] as well.
-pub struct ExamplePre<T> {
+pub struct ExamplePre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: ExampleIndices,
 }
-impl<T> Clone for ExamplePre<T> {
+impl<T: 'static> Clone for ExamplePre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for ExamplePre<T> {
         }
     }
 }
-impl<_T> ExamplePre<_T> {
+impl<_T: 'static> ExamplePre<_T> {
     /// Creates a new copy of `ExamplePre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -132,7 +132,7 @@ const _: () = {
     impl Example {
         /// Convenience wrapper around [`ExamplePre::new`] and
         /// [`ExamplePre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/wat_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/wat_tracing_async.rs
@@ -6,11 +6,11 @@
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Example`] as well.
-pub struct ExamplePre<T> {
+pub struct ExamplePre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: ExampleIndices,
 }
-impl<T> Clone for ExamplePre<T> {
+impl<T: 'static> Clone for ExamplePre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,7 +18,7 @@ impl<T> Clone for ExamplePre<T> {
         }
     }
 }
-impl<_T> ExamplePre<_T> {
+impl<_T: 'static> ExamplePre<_T> {
     /// Creates a new copy of `ExamplePre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -132,7 +132,7 @@ const _: () = {
     impl Example {
         /// Convenience wrapper around [`ExamplePre::new`] and
         /// [`ExamplePre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,

--- a/crates/component-macro/tests/expanded/worlds-with-types.rs
+++ b/crates/component-macro/tests/expanded/worlds-with-types.rs
@@ -31,11 +31,11 @@ const _: () = {
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Foo`] as well.
-pub struct FooPre<T> {
+pub struct FooPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: FooIndices,
 }
-impl<T> Clone for FooPre<T> {
+impl<T: 'static> Clone for FooPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -43,7 +43,7 @@ impl<T> Clone for FooPre<T> {
         }
     }
 }
-impl<_T> FooPre<_T> {
+impl<_T: 'static> FooPre<_T> {
     /// Creates a new copy of `FooPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -168,7 +168,7 @@ const _: () = {
     impl Foo {
         /// Convenience wrapper around [`FooPre::new`] and
         /// [`FooPre::instantiate`].
-        pub fn instantiate<_T>(
+        pub fn instantiate<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -202,7 +202,7 @@ const _: () = {
             mut store: S,
         ) -> wasmtime::Result<(T, U, R)>
         where
-            <S as wasmtime::AsContext>::Data: Send,
+            <S as wasmtime::AsContext>::Data: Send + 'static,
         {
             let callee = unsafe {
                 wasmtime::component::TypedFunc::<(), ((T, U, R),)>::new_unchecked(self.f)

--- a/crates/component-macro/tests/expanded/worlds-with-types_async.rs
+++ b/crates/component-macro/tests/expanded/worlds-with-types_async.rs
@@ -31,11 +31,11 @@ const _: () = {
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Foo`] as well.
-pub struct FooPre<T> {
+pub struct FooPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: FooIndices,
 }
-impl<T> Clone for FooPre<T> {
+impl<T: 'static> Clone for FooPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -43,7 +43,7 @@ impl<T> Clone for FooPre<T> {
         }
     }
 }
-impl<_T> FooPre<_T> {
+impl<_T: 'static> FooPre<_T> {
     /// Creates a new copy of `FooPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -171,7 +171,7 @@ const _: () = {
     impl Foo {
         /// Convenience wrapper around [`FooPre::new`] and
         /// [`FooPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -208,7 +208,7 @@ const _: () = {
             mut store: S,
         ) -> wasmtime::Result<(T, U, R)>
         where
-            <S as wasmtime::AsContext>::Data: Send,
+            <S as wasmtime::AsContext>::Data: Send + 'static,
         {
             let callee = unsafe {
                 wasmtime::component::TypedFunc::<(), ((T, U, R),)>::new_unchecked(self.f)

--- a/crates/component-macro/tests/expanded/worlds-with-types_concurrent.rs
+++ b/crates/component-macro/tests/expanded/worlds-with-types_concurrent.rs
@@ -31,11 +31,11 @@ const _: () = {
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Foo`] as well.
-pub struct FooPre<T> {
+pub struct FooPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: FooIndices,
 }
-impl<T> Clone for FooPre<T> {
+impl<T: 'static> Clone for FooPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -43,7 +43,7 @@ impl<T> Clone for FooPre<T> {
         }
     }
 }
-impl<_T> FooPre<_T> {
+impl<_T: 'static> FooPre<_T> {
     /// Creates a new copy of `FooPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -171,7 +171,7 @@ const _: () = {
     impl Foo {
         /// Convenience wrapper around [`FooPre::new`] and
         /// [`FooPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -210,7 +210,7 @@ const _: () = {
             Output = wasmtime::Result<(T, U, R)>,
         > + Send + 'static + use<S>
         where
-            <S as wasmtime::AsContext>::Data: Send,
+            <S as wasmtime::AsContext>::Data: Send + 'static,
         {
             let callee = unsafe {
                 wasmtime::component::TypedFunc::<(), ((T, U, R),)>::new_unchecked(self.f)

--- a/crates/component-macro/tests/expanded/worlds-with-types_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/worlds-with-types_tracing_async.rs
@@ -31,11 +31,11 @@ const _: () = {
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
 /// For more information see [`Foo`] as well.
-pub struct FooPre<T> {
+pub struct FooPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
     indices: FooIndices,
 }
-impl<T> Clone for FooPre<T> {
+impl<T: 'static> Clone for FooPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -43,7 +43,7 @@ impl<T> Clone for FooPre<T> {
         }
     }
 }
-impl<_T> FooPre<_T> {
+impl<_T: 'static> FooPre<_T> {
     /// Creates a new copy of `FooPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -171,7 +171,7 @@ const _: () = {
     impl Foo {
         /// Convenience wrapper around [`FooPre::new`] and
         /// [`FooPre::instantiate_async`].
-        pub async fn instantiate_async<_T>(
+        pub async fn instantiate_async<_T: 'static>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
@@ -208,7 +208,7 @@ const _: () = {
             mut store: S,
         ) -> wasmtime::Result<(T, U, R)>
         where
-            <S as wasmtime::AsContext>::Data: Send,
+            <S as wasmtime::AsContext>::Data: Send + 'static,
         {
             use tracing::Instrument;
             let span = tracing::span!(

--- a/crates/fuzzing/src/oracles/dummy.rs
+++ b/crates/fuzzing/src/oracles/dummy.rs
@@ -4,7 +4,7 @@ use anyhow::Context;
 use wasmtime::*;
 
 /// Create a set of dummy functions/globals/etc for the given imports.
-pub fn dummy_linker<T>(store: &mut Store<T>, module: &Module) -> Result<Linker<T>> {
+pub fn dummy_linker<T: 'static>(store: &mut Store<T>, module: &Module) -> Result<Linker<T>> {
     let mut linker = Linker::new(store.engine());
     linker.allow_shadowing(true);
     for import in module.imports() {

--- a/crates/misc/component-async-tests/http/src/lib.rs
+++ b/crates/misc/component-async-tests/http/src/lib.rs
@@ -217,7 +217,7 @@ impl<T: WasiHttpView> wasi::http::types::HostFields for WasiHttpImpl<T> {
 }
 
 impl<C: WasiHttpViewConcurrent> wasi::http::types::HostBodyConcurrent for WasiHttp<C> {
-    async fn new<T>(
+    async fn new<T: 'static>(
         accessor: &mut Accessor<T, Self>,
         stream: HostStream<u8>,
     ) -> wasmtime::Result<Resource<Body>> {
@@ -230,7 +230,7 @@ impl<C: WasiHttpViewConcurrent> wasi::http::types::HostBodyConcurrent for WasiHt
         })
     }
 
-    async fn new_with_trailers<T>(
+    async fn new_with_trailers<T: 'static>(
         accessor: &mut Accessor<T, Self>,
         stream: HostStream<u8>,
         trailers: HostFuture<Resource<Fields>>,
@@ -246,7 +246,7 @@ impl<C: WasiHttpViewConcurrent> wasi::http::types::HostBodyConcurrent for WasiHt
 
     // TODO: once access to the store is possible in a non-async context (similar to Accessor pattern)
     // we should convert this to a sync function that works w/ &mut self.
-    async fn finish<T>(
+    async fn finish<T: 'static>(
         accessor: &mut Accessor<T, Self>,
         this: Resource<Body>,
     ) -> wasmtime::Result<HostFuture<Resource<Fields>>> {

--- a/crates/wasi-common/src/lib.rs
+++ b/crates/wasi-common/src/lib.rs
@@ -117,6 +117,7 @@ macro_rules! define_wasi {
         where U: Send
                 + crate::snapshots::preview_0::wasi_unstable::WasiUnstable
                 + crate::snapshots::preview_1::wasi_snapshot_preview1::WasiSnapshotPreview1,
+              T: 'static,
             $($bounds)*
     {
         snapshots::preview_1::add_wasi_snapshot_preview1_to_linker(linker, get_cx)?;

--- a/crates/wasi-common/tests/all/async_.rs
+++ b/crates/wasi-common/tests/all/async_.rs
@@ -1,6 +1,7 @@
 use super::*;
 use test_programs_artifacts::*;
 use wasi_common::tokio::{add_to_linker, WasiCtxBuilder};
+use wasi_common::WasiCtx;
 
 foreach_preview1!(assert_test_exists);
 
@@ -20,7 +21,7 @@ async fn run(path: &str, inherit_stdio: bool) -> Result<()> {
         let engine = test_programs_artifacts::engine(|config| {
             config.async_support(true);
         });
-        let mut linker = Linker::new(&engine);
+        let mut linker = Linker::<WasiCtx>::new(&engine);
         add_to_linker(&mut linker, |cx| cx)?;
 
         // Create our wasi context.

--- a/crates/wasi-http/src/p3/host/types.rs
+++ b/crates/wasi-http/src/p3/host/types.rs
@@ -739,7 +739,7 @@ impl<T> HostRequestConcurrent for WasiHttp<T>
 where
     T: WasiHttpView + 'static,
 {
-    async fn new<U>(
+    async fn new<U: 'static>(
         store: &mut Accessor<U, Self>,
         headers: Resource<WithChildren<http::HeaderMap>>,
         contents: Option<HostStream<u8>>,
@@ -1066,7 +1066,7 @@ impl<T> HostResponseConcurrent for WasiHttp<T>
 where
     T: WasiHttpView + 'static,
 {
-    async fn new<U>(
+    async fn new<U: 'static>(
         store: &mut Accessor<U, Self>,
         headers: Resource<WithChildren<http::HeaderMap>>,
         contents: Option<HostStream<u8>>,

--- a/crates/wasi-http/src/p3/proxy.rs
+++ b/crates/wasi-http/src/p3/proxy.rs
@@ -12,7 +12,7 @@ use crate::p3::{Request, Response};
 
 impl Proxy {
     /// Call `handle` on [Proxy] getting a [Future] back.
-    pub fn handle<T, S: AsContextMut<Data = T>, R: Into<Request>>(
+    pub fn handle<T: 'static, S: AsContextMut<Data = T>, R: Into<Request>>(
         &self,
         mut store: S,
         req: R,

--- a/crates/wasi/src/p3/filesystem/host.rs
+++ b/crates/wasi/src/p3/filesystem/host.rs
@@ -142,7 +142,7 @@ where
         })
     }
 
-    async fn write_via_stream<U>(
+    async fn write_via_stream<U: 'static>(
         store: &mut Accessor<U, Self>,
         fd: Resource<Descriptor>,
         data: HostStream<u8>,
@@ -191,7 +191,7 @@ where
         }
     }
 
-    async fn append_via_stream<U>(
+    async fn append_via_stream<U: 'static>(
         store: &mut Accessor<U, Self>,
         fd: Resource<Descriptor>,
         data: HostStream<u8>,

--- a/crates/wasi/src/p3/sockets/host/types/tcp.rs
+++ b/crates/wasi/src/p3/sockets/host/types/tcp.rs
@@ -372,7 +372,7 @@ where
         }
     }
 
-    async fn send<U>(
+    async fn send<U: 'static>(
         store: &mut Accessor<U, Self>,
         socket: Resource<TcpSocket>,
         data: HostStream<u8>,

--- a/crates/wasi/src/preview0.rs
+++ b/crates/wasi/src/preview0.rs
@@ -9,14 +9,14 @@ use crate::preview1::wasi_snapshot_preview1::WasiSnapshotPreview1 as Snapshot1;
 use crate::preview1::WasiP1Ctx;
 use wiggle::{GuestError, GuestMemory, GuestPtr};
 
-pub fn add_to_linker_async<T: Send>(
+pub fn add_to_linker_async<T: Send + 'static>(
     linker: &mut wasmtime::Linker<T>,
     f: impl Fn(&mut T) -> &mut WasiP1Ctx + Copy + Send + Sync + 'static,
 ) -> anyhow::Result<()> {
     wasi_unstable::add_to_linker(linker, f)
 }
 
-pub fn add_to_linker_sync<T: Send>(
+pub fn add_to_linker_sync<T: Send + 'static>(
     linker: &mut wasmtime::Linker<T>,
     f: impl Fn(&mut T) -> &mut WasiP1Ctx + Copy + Send + Sync + 'static,
 ) -> anyhow::Result<()> {

--- a/crates/wasi/src/preview1.rs
+++ b/crates/wasi/src/preview1.rs
@@ -739,7 +739,7 @@ enum FdWrite {
 ///     Ok(())
 /// }
 /// ```
-pub fn add_to_linker_async<T: Send>(
+pub fn add_to_linker_async<T: Send + 'static>(
     linker: &mut wasmtime::Linker<T>,
     f: impl Fn(&mut T) -> &mut WasiP1Ctx + Copy + Send + Sync + 'static,
 ) -> anyhow::Result<()> {
@@ -813,7 +813,7 @@ pub fn add_to_linker_async<T: Send>(
 ///     Ok(())
 /// }
 /// ```
-pub fn add_to_linker_sync<T: Send>(
+pub fn add_to_linker_sync<T: Send + 'static>(
     linker: &mut wasmtime::Linker<T>,
     f: impl Fn(&mut T) -> &mut WasiP1Ctx + Copy + Send + Sync + 'static,
 ) -> anyhow::Result<()> {

--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -2616,6 +2616,9 @@ impl ComponentInstance {
             }
             _ => bail!("invalid task handle: {task_id}"),
         };
+        // Since waitables can neither be passed between instances nor forged,
+        // this should never fail unless there's a bug in Wasmtime, but we check
+        // here to be sure:
         assert_eq!(expected_caller_instance, caller_instance);
         log::trace!("subtask_drop {waitable:?} (handle {task_id})");
         Ok(())
@@ -2644,6 +2647,9 @@ impl ComponentInstance {
             }
             _ => bail!("invalid task handle: {task_id}"),
         };
+        // Since waitables can neither be passed between instances nor forged,
+        // this should never fail unless there's a bug in Wasmtime, but we check
+        // here to be sure:
         assert_eq!(expected_caller_instance, caller_instance);
 
         log::trace!("subtask_cancel {waitable:?} (handle {task_id})");

--- a/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams/buffers.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams/buffers.rs
@@ -204,7 +204,11 @@ impl WriteBuffer<u8> for Cursor<Bytes> {
     }
 
     fn skip(&mut self, count: usize) {
-        assert!(count <= self.remaining().len());
+        assert!(
+            count <= self.remaining().len(),
+            "tried to skip {count} with {} remaining",
+            self.remaining().len()
+        );
         self.set_position(
             self.position()
                 .checked_add(u64::try_from(count).unwrap())

--- a/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams/buffers.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams/buffers.rs
@@ -1,6 +1,7 @@
 use {
     bytes::{Bytes, BytesMut},
     std::{
+        any::TypeId,
         io::Cursor,
         mem::{self, MaybeUninit},
         ptr, slice,
@@ -8,15 +9,27 @@ use {
     },
 };
 
+/// Trait representing a buffer from which items may be moved (i.e. ownership
+/// transferred).
+///
+/// SAFETY: `Self::take` must verify the requested number of items are
+/// available, must pass a `TypeId` corresponding to the type of items being
+/// taken, and must `mem::forget` those items after the call to `fun` returns.
+pub unsafe trait TakeBuffer {
+    /// Take ownership of the specified number of items.
+    ///
+    /// The items are passed to `fun` as a raw pointer which may be cast to the
+    /// type indicated by the specified `TypeId`.
+    fn take(&mut self, count: usize, fun: &mut dyn FnMut(TypeId, *const u8));
+}
+
 /// Trait representing a buffer which may be written to a `StreamWriter`.
 #[doc(hidden)]
-pub trait WriteBuffer<T>: Send + Sync + 'static {
+pub trait WriteBuffer<T>: TakeBuffer + Send + Sync + 'static {
     /// Slice of items remaining to be read.
     fn remaining(&self) -> &[T];
     /// Skip and drop the specified number of items.
     fn skip(&mut self, count: usize);
-    /// Skip and forget (i.e. do _not_ drop) the specified number of items.
-    fn forget(&mut self, count: usize);
 }
 
 /// Trait representing a buffer which may be used to read from a `StreamReader`.
@@ -28,10 +41,8 @@ pub trait ReadBuffer<T>: Send + Sync + 'static {
     fn remaining_capacity(&self) -> usize;
     /// Move (i.e. take ownership of) the specified items into this buffer.
     ///
-    /// SAFETY: `input` must be a valid `*const T` array of `count` items on
-    /// entry.  Those items will be invalidated on exit and must be forgotten
-    /// using e.g. `mem::forget` to avoid unsoundness.
-    unsafe fn copy_from(&mut self, input: *const T, count: usize);
+    /// This will panic if the specified `input` item type does not match `T`.
+    fn move_from(&mut self, input: &mut dyn TakeBuffer, count: usize);
 }
 
 pub(super) struct Extender<'a, B>(pub(super) &'a mut B);
@@ -39,6 +50,20 @@ pub(super) struct Extender<'a, B>(pub(super) &'a mut B);
 impl<T, B: ReadBuffer<T>> Extend<T> for Extender<'_, B> {
     fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
         self.0.extend(iter)
+    }
+}
+
+unsafe impl<T: Send + Sync + 'static> TakeBuffer for Option<T> {
+    fn take(&mut self, count: usize, fun: &mut dyn FnMut(TypeId, *const u8)) {
+        match count {
+            0 => fun(TypeId::of::<T>(), ptr::null_mut()),
+            1 => {
+                assert!(self.is_some());
+                fun(TypeId::of::<T>(), self.remaining().as_ptr().cast());
+                mem::forget(self.take());
+            }
+            _ => panic!("cannot forget more than {} item(s)", self.remaining().len()),
+        }
     }
 }
 
@@ -63,17 +88,6 @@ impl<T: Send + Sync + 'static> WriteBuffer<T> for Option<T> {
             _ => panic!("cannot skip more than {} item(s)", self.remaining().len()),
         }
     }
-
-    fn forget(&mut self, count: usize) {
-        match count {
-            0 => {}
-            1 => {
-                assert!(self.is_some());
-                mem::forget(self.take());
-            }
-            _ => panic!("cannot forget more than {} item(s)", self.remaining().len()),
-        }
-    }
 }
 
 impl<T: Send + Sync + 'static> ReadBuffer<T> for Option<T> {
@@ -93,13 +107,18 @@ impl<T: Send + Sync + 'static> ReadBuffer<T> for Option<T> {
         }
     }
 
-    /// SAFETY: See trait docs.
-    unsafe fn copy_from(&mut self, input: *const T, count: usize) {
+    fn move_from(&mut self, input: &mut dyn TakeBuffer, count: usize) {
         match count {
             0 => {}
             1 => {
                 assert!(self.is_none());
-                *self = Some(input.read());
+                input.take(1, &mut |id, ptr| {
+                    assert_eq!(TypeId::of::<T>(), id);
+                    // SAFETY: Per the `TakeBuffer` implementation contract and
+                    // the above assertion, the types match and we have been
+                    // given ownership of the item.
+                    unsafe { *self = Some(ptr.cast::<T>().read()) };
+                });
             }
             _ => panic!(
                 "cannot take more than {} item(s)",
@@ -149,6 +168,14 @@ impl<T> VecBuffer<T> {
     }
 }
 
+unsafe impl<T: Send + Sync + 'static> TakeBuffer for VecBuffer<T> {
+    fn take(&mut self, count: usize, fun: &mut dyn FnMut(TypeId, *const u8)) {
+        assert!(count <= self.remaining().len());
+        fun(TypeId::of::<T>(), self.remaining().as_ptr().cast());
+        self.offset = self.offset.checked_add(count).unwrap();
+    }
+}
+
 impl<T: Send + Sync + 'static> WriteBuffer<T> for VecBuffer<T> {
     fn remaining(&self) -> &[T] {
         self.remaining_()
@@ -156,11 +183,6 @@ impl<T: Send + Sync + 'static> WriteBuffer<T> for VecBuffer<T> {
 
     fn skip(&mut self, count: usize) {
         self.skip_(count)
-    }
-
-    fn forget(&mut self, count: usize) {
-        assert!(count <= self.remaining().len());
-        self.offset = self.offset.checked_add(count).unwrap();
     }
 }
 
@@ -190,11 +212,26 @@ impl<T: Send + Sync + 'static> ReadBuffer<T> for Vec<T> {
         self.capacity().checked_sub(self.len()).unwrap()
     }
 
-    /// SAFETY: See trait docs.
-    unsafe fn copy_from(&mut self, input: *const T, count: usize) {
+    fn move_from(&mut self, input: &mut dyn TakeBuffer, count: usize) {
         assert!(count <= self.remaining_capacity());
-        ptr::copy(input, self.as_mut_ptr().add(self.len()), count);
-        self.set_len(self.len() + count);
+        input.take(count, &mut |id, ptr| {
+            assert_eq!(TypeId::of::<T>(), id);
+            // SAFETY: Per the `TakeBuffer` implementation contract and the
+            // above assertion, the types match and we have been given ownership
+            // of the items.
+            unsafe {
+                ptr::copy(ptr.cast::<T>(), self.as_mut_ptr().add(self.len()), count);
+                self.set_len(self.len() + count);
+            }
+        });
+    }
+}
+
+unsafe impl TakeBuffer for Cursor<Bytes> {
+    fn take(&mut self, count: usize, fun: &mut dyn FnMut(TypeId, *const u8)) {
+        assert!(count <= self.remaining().len());
+        fun(TypeId::of::<u8>(), self.remaining().as_ptr().cast());
+        self.skip(count);
     }
 }
 
@@ -215,9 +252,13 @@ impl WriteBuffer<u8> for Cursor<Bytes> {
                 .unwrap(),
         );
     }
+}
 
-    fn forget(&mut self, count: usize) {
-        self.skip(count)
+unsafe impl TakeBuffer for Cursor<BytesMut> {
+    fn take(&mut self, count: usize, fun: &mut dyn FnMut(TypeId, *const u8)) {
+        assert!(count <= self.remaining().len());
+        fun(TypeId::of::<u8>(), self.remaining().as_ptr().cast());
+        self.skip(count);
     }
 }
 
@@ -234,10 +275,6 @@ impl WriteBuffer<u8> for Cursor<BytesMut> {
                 .unwrap(),
         );
     }
-
-    fn forget(&mut self, count: usize) {
-        self.skip(count)
-    }
 }
 
 impl ReadBuffer<u8> for BytesMut {
@@ -249,10 +286,16 @@ impl ReadBuffer<u8> for BytesMut {
         self.capacity().checked_sub(self.len()).unwrap()
     }
 
-    /// SAFETY: See trait docs.
-    unsafe fn copy_from(&mut self, input: *const u8, count: usize) {
+    fn move_from(&mut self, input: &mut dyn TakeBuffer, count: usize) {
         assert!(count <= self.remaining_capacity());
-        ptr::copy(input, self.as_mut_ptr().add(self.len()), count);
-        self.set_len(self.len() + count);
+        input.take(count, &mut |id, ptr| {
+            assert_eq!(TypeId::of::<u8>(), id);
+            // SAFETY: Per the `TakeBuffer` implementation contract and the
+            // above assertion, the types match.
+            unsafe {
+                ptr::copy(ptr, self.as_mut_ptr().add(self.len()), count);
+                self.set_len(self.len() + count);
+            }
+        });
     }
 }

--- a/crates/wasmtime/src/runtime/component/func/typed.rs
+++ b/crates/wasmtime/src/runtime/component/func/typed.rs
@@ -464,9 +464,7 @@ where
     /// Equivalent to `lower_stack_args`, but with a monomorphic signature
     /// suitable for use with `concurrent::prepare_call`.
     ///
-    /// SAFETY: `store` must be a valid pointer to a store with data type
-    /// parameter `T`, and the caller must confer exclusive access to that
-    /// store.  Also, `params_in` must be a valid pointer to a `Self::Params`.
+    /// SAFETY: `params_in` must be a valid pointer to a `Self::Params`.
     #[cfg(feature = "component-model-async")]
     unsafe fn lower_stack_args_fn<T>(
         func: Func,
@@ -527,9 +525,7 @@ where
     /// Equivalent to `lower_heap_args`, but with a monomorphic signature
     /// suitable for use with `concurrent::prepare_call`.
     ///
-    /// SAFETY: `store` must be a valid pointer to a store with data type
-    /// parameter `T`, and the caller must confer exclusive access to that
-    /// store.  Also, `params_in` must be a valid pointer to a `Self::Params`.
+    /// SAFETY: `params_in` must be a valid pointer to a `Self::Params`.
     #[cfg(feature = "component-model-async")]
     unsafe fn lower_heap_args_fn<T>(
         func: Func,
@@ -590,10 +586,6 @@ where
 
     /// Equivalent to `lift_stack_result`, but with a monomorphic signature
     /// suitable for use with `concurrent::prepare_call`.
-    ///
-    /// SAFETY: `store` must be a valid pointer to a store with data type
-    /// parameter `T`, and the caller must confer exclusive access to that
-    /// store.
     #[cfg(feature = "component-model-async")]
     fn lift_stack_result_fn<T>(
         func: Func,
@@ -642,10 +634,6 @@ where
 
     /// Equivalent to `lift_heap_result`, but with a monomorphic signature
     /// suitable for use with `concurrent::prepare_call`.
-    ///
-    /// SAFETY: `store` must be a valid pointer to a store with data type
-    /// parameter `T`, and the caller must confer exclusive access to that
-    /// store.
     #[cfg(feature = "component-model-async")]
     fn lift_heap_result_fn<T>(
         func: Func,

--- a/crates/wasmtime/src/runtime/component/linker.rs
+++ b/crates/wasmtime/src/runtime/component/linker.rs
@@ -109,7 +109,7 @@ pub(crate) enum Definition {
     Resource(ResourceType, Arc<crate::func::HostFunc>),
 }
 
-impl<T> Linker<T> {
+impl<T: 'static> Linker<T> {
     /// Creates a new linker for the [`Engine`] specified with no items defined
     /// within it.
     pub fn new(engine: &Engine) -> Linker<T> {
@@ -319,7 +319,7 @@ impl<T> Linker<T> {
         use wasmtime_environ::component::ComponentTypes;
         use wasmtime_environ::component::TypeDef;
         // Recursively stub out all imports of the component with a function that traps.
-        fn stub_item<T>(
+        fn stub_item<T: 'static>(
             linker: &mut LinkerInstance<T>,
             item_name: &str,
             item_def: &TypeDef,
@@ -379,7 +379,7 @@ impl<T> Linker<T> {
     }
 }
 
-impl<T> LinkerInstance<'_, T> {
+impl<T: 'static> LinkerInstance<'_, T> {
     fn as_mut(&mut self) -> LinkerInstance<'_, T> {
         LinkerInstance {
             engine: self.engine,

--- a/crates/wasmtime/src/runtime/externals/table.rs
+++ b/crates/wasmtime/src/runtime/externals/table.rs
@@ -262,7 +262,12 @@ impl Table {
     /// (see also: [`Store::limiter_async`](`crate::Store::limiter_async`)).
     /// When using an async resource limiter, use [`Table::grow_async`]
     /// instead.
-    pub fn grow(&self, mut store: impl AsContextMut, delta: u64, init: Ref) -> Result<u64> {
+    pub fn grow<T: 'static>(
+        &self,
+        mut store: impl AsContextMut<Data = T>,
+        delta: u64,
+        init: Ref,
+    ) -> Result<u64> {
         let store = store.as_context_mut().0;
         let ty = self.ty(&store);
         let init = init.into_table_element(store, ty.element())?;
@@ -296,7 +301,7 @@ impl Table {
         init: Ref,
     ) -> Result<u64>
     where
-        T: Send,
+        T: Send + 'static,
     {
         let store = store.as_context_mut();
         assert!(

--- a/crates/wasmtime/src/runtime/memory.rs
+++ b/crates/wasmtime/src/runtime/memory.rs
@@ -590,7 +590,11 @@ impl Memory {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn grow(&self, mut store: impl AsContextMut, delta: u64) -> Result<u64> {
+    pub fn grow<T: 'static>(
+        &self,
+        mut store: impl AsContextMut<Data = T>,
+        delta: u64,
+    ) -> Result<u64> {
         let store = store.as_context_mut().0;
         let mem = self.wasmtime_memory(store);
         unsafe {
@@ -620,7 +624,7 @@ impl Memory {
         delta: u64,
     ) -> Result<u64>
     where
-        T: Send,
+        T: Send + 'static,
     {
         let store = store.as_context_mut();
         assert!(

--- a/crates/wasmtime/src/runtime/store/data.rs
+++ b/crates/wasmtime/src/runtime/store/data.rs
@@ -296,7 +296,7 @@ impl<T> Stored<T> {
         self.store_id.assert_belongs_to(store)
     }
 
-    fn index(&self) -> usize {
+    pub(crate) fn index(&self) -> usize {
         self.index
     }
 }

--- a/crates/wasmtime/src/runtime/store/token.rs
+++ b/crates/wasmtime/src/runtime/store/token.rs
@@ -1,0 +1,35 @@
+use crate::{store::StoreId, StoreContextMut, VMStore};
+use core::marker::PhantomData;
+
+pub struct StoreToken<T> {
+    id: StoreId,
+    _phantom: PhantomData<fn() -> T>,
+}
+
+impl<T> Clone for StoreToken<T> {
+    fn clone(&self) -> Self {
+        Self {
+            id: self.id,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T> Copy for StoreToken<T> {}
+
+impl<T> StoreToken<T> {
+    pub fn new(store: StoreContextMut<T>) -> Self {
+        Self {
+            id: store.0.id(),
+            _phantom: PhantomData,
+        }
+    }
+
+    pub fn as_context_mut<'a>(&self, store: &'a mut dyn VMStore) -> StoreContextMut<'a, T> {
+        assert_eq!(store.store_opaque().id(), self.id);
+        // We know the store with this ID has data type parameter `T` because
+        // we witnessed that in `Self::new`, which is the only way `self` could
+        // have been safely created:
+        unsafe { StoreContextMut::<T>(&mut *(store as *mut dyn VMStore).cast()) }
+    }
+}

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -172,7 +172,7 @@ cfg_if::cfg_if! {
 /// be respected by embedders (e.g. the `wasmtime::Store` structure). The theory
 /// is that `wasmtime::Store` handles all this correctly.
 #[doc(hidden)]
-pub unsafe trait VMStore {
+pub unsafe trait VMStore: 'static {
     /// Get a shared borrow of this store's `StoreOpaque`.
     fn store_opaque(&self) -> &StoreOpaque;
 

--- a/crates/wasmtime/src/runtime/vm/component.rs
+++ b/crates/wasmtime/src/runtime/vm/component.rs
@@ -6,7 +6,7 @@
 //! Eventually it's intended that module-to-module calls, which would be
 //! cranelift-compiled adapters, will use this `VMComponentContext` as well.
 
-use crate::component::ResourceType;
+use crate::component::{Instance, InstanceData, ResourceType};
 use crate::prelude::*;
 use crate::runtime::vm::{
     SendSyncPtr, VMArrayCallFunction, VMContext, VMFuncRef, VMGlobalDefinition, VMMemoryDefinition,
@@ -40,8 +40,6 @@ pub use self::resources::{
 pub use self::resources::CallContext;
 #[cfg(feature = "component-model-async")]
 use crate::component::concurrent;
-#[cfg(feature = "component-model-async")]
-use crate::component::Instance;
 
 /// Runtime representation of a component instance and all state necessary for
 /// the instance itself.
@@ -76,10 +74,11 @@ pub struct ComponentInstance {
     resource_types: Arc<PrimaryMap<ResourceIndex, ResourceType>>,
 
     /// Self-pointer back to `Store<T>` and its functions.
-    store: VMStoreRawPtr,
+    store: Option<VMStoreRawPtr>,
 
-    #[cfg(feature = "component-model-async")]
     pub(crate) instance: Option<Instance>,
+
+    pub(crate) data: Option<Box<InstanceData>>,
 
     /// A zero-sized field which represents the end of the struct for the actual
     /// `VMComponentContext` to be allocated behind.
@@ -182,12 +181,26 @@ impl ComponentInstance {
     /// mutable reference at this time to the instance from `vmctx`.
     pub unsafe fn from_vmctx<R>(
         vmctx: NonNull<VMComponentContext>,
-        f: impl FnOnce(&mut ComponentInstance) -> R,
+        f: impl FnOnce(&mut dyn VMStore, &mut ComponentInstance) -> R,
     ) -> R {
         let mut ptr = vmctx
             .byte_sub(mem::size_of::<ComponentInstance>())
             .cast::<ComponentInstance>();
-        f(ptr.as_mut())
+        let reference = ptr.as_mut();
+        let store = &mut *reference.store();
+        if let Some(instance) = reference.instance {
+            assert!(reference.data.is_none());
+            reference.data = Some(store[instance.0].take().unwrap());
+        }
+        reference.set_store(None);
+        let result = f(store, reference);
+        reference.set_store(Some(VMStoreRawPtr(store.traitobj())));
+        if let Some(instance) = reference.instance {
+            if store[instance.0].is_none() {
+                store[instance.0] = reference.data.take();
+            }
+        }
+        result
     }
 
     /// Returns the layout corresponding to what would be an allocation of a
@@ -248,11 +261,11 @@ impl ComponentInstance {
                 instance_resource_tables,
                 runtime_info,
                 resource_types,
-                store: VMStoreRawPtr(store),
+                store: Some(VMStoreRawPtr(store)),
                 vmctx: VMComponentContext {
                     _marker: marker::PhantomPinned,
                 },
-                #[cfg(feature = "component-model-async")]
+                data: None,
                 instance: None,
                 #[cfg(feature = "component-model-async")]
                 concurrent_state,
@@ -295,8 +308,14 @@ impl ComponentInstance {
     }
 
     /// Returns the store that this component was created with.
+    ///
+    /// This will panic if this instance has been removed from its store.
     pub fn store(&self) -> *mut dyn VMStore {
-        self.store.0.as_ptr()
+        self.store.unwrap().0.as_ptr()
+    }
+
+    pub(crate) fn set_store(&mut self, store: Option<VMStoreRawPtr>) {
+        self.store = store;
     }
 
     /// Returns the runtime memory definition corresponding to the index of the
@@ -546,7 +565,7 @@ impl ComponentInstance {
         *self.vmctx_plus_offset_mut(self.offsets.builtins()) =
             VmPtr::from(NonNull::from(&libcalls::VMComponentBuiltins::INIT));
         *self.vmctx_plus_offset_mut(self.offsets.vm_store_context()) =
-            VmPtr::from(self.store.0.as_ref().vm_store_context_ptr());
+            VmPtr::from(self.store.unwrap().0.as_ref().vm_store_context_ptr());
 
         for i in 0..self.offsets.num_runtime_component_instances {
             let i = RuntimeComponentInstanceIndex::from_u32(i);
@@ -642,21 +661,36 @@ impl ComponentInstance {
 
     /// Implementation of the `resource.new` intrinsic for `i32`
     /// representations.
-    pub fn resource_new32(&mut self, ty: TypeResourceTableIndex, rep: u32) -> Result<u32> {
-        self.resource_tables()
+    pub fn resource_new32(
+        &mut self,
+        store: &mut dyn VMStore,
+        ty: TypeResourceTableIndex,
+        rep: u32,
+    ) -> Result<u32> {
+        self.resource_tables(store)
             .resource_new(TypedResource::Component { ty, rep })
     }
 
     /// Implementation of the `resource.rep` intrinsic for `i32`
     /// representations.
-    pub fn resource_rep32(&mut self, ty: TypeResourceTableIndex, index: u32) -> Result<u32> {
-        self.resource_tables()
+    pub fn resource_rep32(
+        &mut self,
+        store: &mut dyn VMStore,
+        ty: TypeResourceTableIndex,
+        index: u32,
+    ) -> Result<u32> {
+        self.resource_tables(store)
             .resource_rep(TypedResourceIndex::Component { ty, index })
     }
 
     /// Implementation of the `resource.drop` intrinsic.
-    pub fn resource_drop(&mut self, ty: TypeResourceTableIndex, index: u32) -> Result<Option<u32>> {
-        self.resource_tables()
+    pub fn resource_drop(
+        &mut self,
+        store: &mut dyn VMStore,
+        ty: TypeResourceTableIndex,
+        index: u32,
+    ) -> Result<Option<u32>> {
+        self.resource_tables(store)
             .resource_drop(TypedResourceIndex::Component { ty, index })
     }
 
@@ -667,10 +701,10 @@ impl ComponentInstance {
     ///
     /// If necessary though it's possible to enhance the `Store` trait to thread
     /// through the relevant information and get `host_table` to be `Some` here.
-    fn resource_tables(&mut self) -> ResourceTables<'_> {
+    fn resource_tables<'a>(&'a mut self, store: &'a mut dyn VMStore) -> ResourceTables<'a> {
         ResourceTables {
             host_table: None,
-            calls: unsafe { (&mut *self.store()).component_calls() },
+            calls: store.component_calls(),
             guest: Some((
                 &mut self.instance_resource_tables,
                 self.runtime_info.component_types(),
@@ -713,23 +747,25 @@ impl ComponentInstance {
 
     pub(crate) fn resource_transfer_own(
         &mut self,
+        store: &mut dyn VMStore,
         index: u32,
         src: TypeResourceTableIndex,
         dst: TypeResourceTableIndex,
     ) -> Result<u32> {
-        let mut tables = self.resource_tables();
+        let mut tables = self.resource_tables(store);
         let rep = tables.resource_lift_own(TypedResourceIndex::Component { ty: src, index })?;
         tables.resource_lower_own(TypedResource::Component { ty: dst, rep })
     }
 
     pub(crate) fn resource_transfer_borrow(
         &mut self,
+        store: &mut dyn VMStore,
         index: u32,
         src: TypeResourceTableIndex,
         dst: TypeResourceTableIndex,
     ) -> Result<u32> {
         let dst_owns_resource = self.resource_owned_by_own_instance(dst);
-        let mut tables = self.resource_tables();
+        let mut tables = self.resource_tables(store);
         let rep = tables.resource_lift_borrow(TypedResourceIndex::Component { ty: src, index })?;
         // Implement `lower_borrow`'s special case here where if a borrow's
         // resource type is owned by `dst` then the destination receives the
@@ -745,12 +781,12 @@ impl ComponentInstance {
         tables.resource_lower_borrow(TypedResource::Component { ty: dst, rep })
     }
 
-    pub(crate) fn resource_enter_call(&mut self) {
-        self.resource_tables().enter_call()
+    pub(crate) fn resource_enter_call(&mut self, store: &mut dyn VMStore) {
+        self.resource_tables(store).enter_call()
     }
 
-    pub(crate) fn resource_exit_call(&mut self) -> Result<()> {
-        self.resource_tables().exit_call()
+    pub(crate) fn resource_exit_call(&mut self, store: &mut dyn VMStore) -> Result<()> {
+        self.resource_tables(store).exit_call()
     }
 }
 

--- a/crates/wast/src/spectest.rs
+++ b/crates/wast/src/spectest.rs
@@ -88,7 +88,7 @@ pub fn link_spectest<T>(
 }
 
 #[cfg(feature = "component-model")]
-pub fn link_component_spectest<T>(linker: &mut component::Linker<T>) -> Result<()> {
+pub fn link_component_spectest<T: 'static>(linker: &mut component::Linker<T>) -> Result<()> {
     use std::sync::atomic::{AtomicU32, Ordering::SeqCst};
     use std::sync::Arc;
     use wasmtime::component::{Resource, ResourceType};

--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -14,7 +14,7 @@ use wast::{QuoteWat, Wast, WastArg, WastDirective, WastExecute, WastInvoke, Wast
 
 /// The wast test script language allows modules to be defined and actions
 /// to be performed on them.
-pub struct WastContext<T> {
+pub struct WastContext<T: 'static> {
     /// Wast files have a concept of a "current" module, which is the most
     /// recently defined.
     current: Option<InstanceKind>,

--- a/crates/wiggle/generate/src/wasmtime.rs
+++ b/crates/wiggle/generate/src/wasmtime.rs
@@ -58,6 +58,7 @@ pub fn link_module(
             get_cx: impl Fn(&mut T) -> #u + Send + Sync + Copy + 'static,
         ) -> wiggle::anyhow::Result<()>
             where
+                T: 'static,
                 U: #ctx_bound #send_bound
         {
             #(#bodies)*

--- a/crates/wiggle/tests/wasmtime_async.rs
+++ b/crates/wiggle/tests/wasmtime_async.rs
@@ -41,7 +41,7 @@ impl atoms::Atoms for Ctx {
 #[tokio::test]
 async fn test_sync_host_func() {
     let mut store = async_store();
-    let mut linker = Linker::new(store.engine());
+    let mut linker = Linker::<Ctx>::new(store.engine());
     atoms::add_to_linker(&mut linker, |cx| cx).unwrap();
     let shim_mod = shim_module(linker.engine());
     let shim_inst = linker
@@ -67,7 +67,7 @@ async fn test_sync_host_func() {
 #[tokio::test]
 async fn test_async_host_func() {
     let mut store = async_store();
-    let mut linker = Linker::new(store.engine());
+    let mut linker = Linker::<Ctx>::new(store.engine());
     atoms::add_to_linker(&mut linker, |cx| cx).unwrap();
 
     let shim_mod = shim_module(linker.engine());

--- a/crates/wit-bindgen/src/lib.rs
+++ b/crates/wit-bindgen/src/lib.rs
@@ -854,12 +854,12 @@ pub fn new<_T>(
 /// has been created through a [`Linker`]({wt}::component::Linker).
 ///
 /// For more information see [`{camel}`] as well.
-pub struct {camel}Pre<T> {{
+pub struct {camel}Pre<T: 'static> {{
     instance_pre: {wt}::component::InstancePre<T>,
     indices: {camel}Indices,
 }}
 
-impl<T> Clone for {camel}Pre<T> {{
+impl<T: 'static> Clone for {camel}Pre<T> {{
     fn clone(&self) -> Self {{
         Self {{
             instance_pre: self.instance_pre.clone(),
@@ -868,7 +868,7 @@ impl<T> Clone for {camel}Pre<T> {{
     }}
 }}
 
-impl<_T> {camel}Pre<_T> {{
+impl<_T: 'static> {camel}Pre<_T> {{
     /// Creates a new copy of `{camel}Pre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
@@ -1028,7 +1028,7 @@ impl<_T> {camel}Pre<_T> {{
             "impl {camel} {{
                 /// Convenience wrapper around [`{camel}Pre::new`] and
                 /// [`{camel}Pre::instantiate{async__}`].
-                pub {async_} fn instantiate{async__}<_T>(
+                pub {async_} fn instantiate{async__}<_T: 'static>(
                     store: impl {wt}::AsContextMut<Data = _T>,
                     component: &{wt}::component::Component,
                     linker: &{wt}::component::Linker<_T>,
@@ -2771,14 +2771,23 @@ impl<'a> InterfaceGenerator<'a> {
 
         match style {
             CallStyle::Concurrent => {
-                uwrite!(self.src, " where <S as {wt}::AsContext>::Data: Send",);
+                uwrite!(
+                    self.src,
+                    " where <S as {wt}::AsContext>::Data: Send + 'static",
+                );
             }
             CallStyle::Async => {
-                uwrite!(self.src, " where <S as {wt}::AsContext>::Data: Send");
+                uwrite!(
+                    self.src,
+                    " where <S as {wt}::AsContext>::Data: Send + 'static"
+                );
             }
             CallStyle::Sync => {
                 // TODO: should not require `Send` or 'static here.
-                uwrite!(self.src, " where <S as {wt}::AsContext>::Data: Send");
+                uwrite!(
+                    self.src,
+                    " where <S as {wt}::AsContext>::Data: Send + 'static"
+                );
             }
         }
         uwrite!(self.src, "{{\n");

--- a/tests/all/async_functions.rs
+++ b/tests/all/async_functions.rs
@@ -847,7 +847,7 @@ async fn non_stacky_async_activations() -> Result<()> {
 
             let module2 = module2.clone();
             let mut store2 = Store::new(caller.engine(), ());
-            let mut linker2 = Linker::new(caller.engine());
+            let mut linker2 = Linker::<()>::new(caller.engine());
             linker2
                 .func_wrap_async("", "yield", {
                     let stacks = stacks.clone();
@@ -876,7 +876,7 @@ async fn non_stacky_async_activations() -> Result<()> {
                             .await?;
 
                         capture_stack(&stacks, &store2);
-                        Ok(())
+                        anyhow::Ok(())
                     }
                 }) as _)
                 .await
@@ -1042,7 +1042,7 @@ async fn async_gc_with_func_new_and_func_wrap() -> Result<()> {
         "#,
     )?;
 
-    let mut linker = Linker::new(&engine);
+    let mut linker = Linker::<()>::new(&engine);
     linker.func_wrap_async("", "a", |mut cx: Caller<'_, _>, ()| {
         Box::new(async move {
             let externref = ExternRef::new_async(&mut cx, 100).await?;

--- a/tests/all/epoch_interruption.rs
+++ b/tests/all/epoch_interruption.rs
@@ -13,7 +13,7 @@ fn build_engine(config: &mut Config) -> Arc<Engine> {
     Arc::new(Engine::new(&config).unwrap())
 }
 
-fn make_env<T>(engine: &Engine) -> Linker<T> {
+fn make_env<T: 'static>(engine: &Engine) -> Linker<T> {
     let mut linker = Linker::new(engine);
     let engine = engine.clone();
 
@@ -53,7 +53,7 @@ async fn run_and_count_yields_or_trap<F: Fn(Arc<Engine>)>(
     setup_func: F,
 ) -> Option<(usize, usize)> {
     let engine = build_engine(config);
-    let linker = make_env(&engine);
+    let linker = make_env::<usize>(&engine);
     let module = Module::new(&engine, wasm).unwrap();
     let mut store = Store::new(&engine, 0);
     store.set_epoch_deadline(initial);
@@ -446,7 +446,7 @@ async fn drop_future_on_epoch_yield(config: &mut Config) {
     ";
 
     let engine = build_engine(config);
-    let mut linker = make_env(&engine);
+    let mut linker = make_env::<()>(&engine);
 
     // Create a few helpers for the Wasm to call.
     let alive_flag = Arc::new(AtomicBool::new(false));

--- a/tests/all/limits.rs
+++ b/tests/all/limits.rs
@@ -868,7 +868,7 @@ async fn custom_limiter_async_detect_grow_failure() -> Result<()> {
     config.async_support(true);
     config.allocation_strategy(InstanceAllocationStrategy::Pooling(pool));
     let engine = Engine::new(&config).unwrap();
-    let linker = Linker::new(&engine);
+    let linker = Linker::<FailureDetector>::new(&engine);
 
     let module = Module::new(
         &engine,
@@ -1049,7 +1049,7 @@ async fn panic_in_async_memory_limiter() {
     let mut config = Config::new();
     config.async_support(true);
     let engine = Engine::new(&config).unwrap();
-    let linker = Linker::new(&engine);
+    let linker = Linker::<Panic>::new(&engine);
 
     let module = Module::new(&engine, r#"(module (memory (export "m") 0))"#).unwrap();
 
@@ -1071,7 +1071,7 @@ async fn panic_in_async_memory_limiter_wasm_stack() {
     let mut config = Config::new();
     config.async_support(true);
     let engine = Engine::new(&config).unwrap();
-    let linker = Linker::new(&engine);
+    let linker = Linker::<Panic>::new(&engine);
 
     let module = Module::new(
         &engine,
@@ -1101,7 +1101,7 @@ async fn panic_in_async_table_limiter() {
     let mut config = Config::new();
     config.async_support(true);
     let engine = Engine::new(&config).unwrap();
-    let linker = Linker::new(&engine);
+    let linker = Linker::<Panic>::new(&engine);
 
     let module = Module::new(&engine, r#"(module (table (export "t") 0 funcref))"#).unwrap();
 


### PR DESCRIPTION
This adds a few abstractions to reduce the amount of unsafe code and make what remains easier to reason about locally (i.e. without relying as much on functions only being called in certain contexts, or on non-local safe code upholding invariants).

This introduces a `StoreToken` abstraction for witnessing the data type parameter `T` for a `StoreContextMut<T>` and later safely casting from a `&mut dyn VMStore` to a `&mut StoreInner<T>` within a closure by asserting that the `StoreId`s match.

This also eliminates various transmutes and other unsafe shenanigans to avoid a `T: 'static` bound since we've finally decided avoiding such a bound is impractical.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
