### PR TITLE
Refactor access and accessor

### DIFF
--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -3430,17 +3430,6 @@ impl Instance {
             Poll::Pending => unreachable!(),
         }
     }
-
-    #[doc(hidden)]
-    pub fn spawn_raw(
-        &self,
-        mut store: impl AsContextMut,
-        task: impl std::future::Future<Output = Result<()>> + Send + 'static,
-    ) {
-        store
-            .as_context_mut()
-            .with_detached_instance(self, |_, instance| instance.spawn(task))
-    }
 }
 
 /// Trait representing component model ABI async intrinsics and fused adapter

--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -661,7 +661,7 @@ fn poll_with_state<T: 'static, F: Future + ?Sized>(
                 if let AbortWrapper::Unpolled(mut future)
                 | AbortWrapper::Polled { mut future, .. } = inner
                 {
-                    let result = poll_with_state::<T, _>(token, cx, future.as_mut());
+                    let result = poll_with_state(token, cx, future.as_mut());
                     *spawned = AbortWrapper::Polled {
                         future,
                         waker: cx.waker().clone(),
@@ -3390,7 +3390,7 @@ impl Instance {
                 let mut future = Box::pin(async move { fun(&mut accessor).await });
                 let token = StoreToken::new(store);
                 Box::pin(future::poll_fn(move |cx| {
-                    poll_with_state::<U, _>(token, cx, future.as_mut())
+                    poll_with_state(token, cx, future.as_mut())
                 }))
             })
     }

--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -320,8 +320,7 @@ where
     /// intended scope.  If it returns, the caller must be granted exclusive
     /// access to that store until the call to `Future::poll` for the current
     /// host task returns.
-    #[doc(hidden)]
-    pub unsafe fn new(
+    unsafe fn new(
         get: fn() -> *mut dyn VMStore,
         get_data: fn(&mut T) -> D::Data<'_>,
         spawn: fn(Spawned),

--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -289,7 +289,6 @@ where
     get_data: fn(&mut T) -> D::Data<'_>,
     spawn: fn(Spawned),
     instance: Option<Instance>,
-    _phantom: PhantomData<fn() -> *mut StoreInner<T>>,
 }
 
 impl<T> Accessor<T> {
@@ -316,7 +315,6 @@ impl<T> Accessor<T> {
             get_data: |x| x,
             spawn: spawn_task,
             instance,
-            _phantom: PhantomData,
         }
     }
 }
@@ -365,7 +363,6 @@ where
             get_data,
             spawn: self.spawn,
             instance: self.instance,
-            _phantom: PhantomData,
         }
     }
 
@@ -387,7 +384,6 @@ where
             get_data: self.get_data,
             spawn: self.spawn,
             instance: self.instance,
-            _phantom: PhantomData,
         };
         let future = Arc::new(Mutex::new(AbortWrapper::Unpolled(Box::pin(async move {
             task.run(&mut accessor).await

--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -292,7 +292,7 @@ pub struct Accessor<T: 'static, D = HasSelf<T>>
 where
     D: HasData,
 {
-    get: Arc<dyn Fn() -> *mut (dyn VMStore) + Send + Sync>,
+    get: fn() -> *mut dyn VMStore,
     get_data: fn(&mut T) -> D::Data<'_>,
     spawn: fn(Spawned),
     instance: Option<Instance>,
@@ -328,7 +328,7 @@ where
         instance: Option<Instance>,
     ) -> Self {
         Self {
-            get: Arc::new(get),
+            get,
             get_data,
             spawn,
             instance,
@@ -354,7 +354,7 @@ where
         get_data: fn(&mut T) -> D2::Data<'_>,
     ) -> Accessor<T, D2> {
         Accessor {
-            get: self.get.clone(),
+            get: self.get,
             get_data,
             spawn: self.spawn,
             instance: self.instance,
@@ -376,7 +376,7 @@ where
         T: 'static,
     {
         let mut accessor = Self {
-            get: self.get.clone(),
+            get: self.get,
             get_data: self.get_data,
             spawn: self.spawn,
             instance: self.instance,


### PR DESCRIPTION
This PR is a series of commits of small refactors aimed at improving the safety of `Access` and `Accessor`, ideally removing the unsafety entirely. While `Access` is now 100% safe there's still work to do on `Accessor`. This works its way up to the final refactor to make `Accessor` 100% safe but stops short of other necessary refactors due to how load bearing `Accessor` and its internals are.