### PR TITLE
Remove no-longer-needed helper method

### DIFF
--- a/cranelift/entity/src/primary.rs
+++ b/cranelift/entity/src/primary.rs
@@ -72,17 +72,6 @@ where
         self.elems.get_mut(k.index())
     }
 
-    /// Get the element at `k` if it exists, mutable version.
-    pub fn get_mut_or_insert_with(&mut self, k: K, f: impl FnOnce() -> V) -> &mut V {
-        if self.elems.get(k.index()).is_none() {
-            self.elems.insert(k.index(), f());
-        }
-
-        self.elems
-            .get_mut(k.index())
-            .expect("missing existing element")
-    }
-
     /// Is this map completely empty?
     pub fn is_empty(&self) -> bool {
         self.elems.is_empty()

--- a/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
@@ -3143,9 +3143,7 @@ impl ComponentInstance {
         // Here we reflect the newly created global concurrent error context state into the
         // component instance's locally tracked count, along with the appropriate key into the global
         // ref tracking data structures to enable later lookup
-        let local_tbl = self
-            .error_context_tables()
-            .get_mut_or_insert_with(ty, || StateTable::default());
+        let local_tbl = &mut self.error_context_tables()[ty];
 
         assert!(
             !local_tbl.has_handle(table_id.rep()),


### PR DESCRIPTION
In trying to upstream this helper method it had surprising semantics for insert-beyond-the-end and so upon investigating I concluded that this may be a historical artifact at this point and no longer needed. To reduce the diff with upstream this commit removes the method and replaces the one usage with a locally-equivalent structure.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
