### PR TITLE
remove `StoreContextMut::with_{a,de}tached_instance[_async]`

### DIFF
--- a/crates/wasmtime/src/runtime/component/func/typed.rs
+++ b/crates/wasmtime/src/runtime/component/func/typed.rs
@@ -19,8 +19,6 @@ use wasmtime_environ::component::{
 #[cfg(feature = "component-model-async")]
 use crate::component::concurrent::{self, PreparedCall, ResetPtr};
 #[cfg(feature = "component-model-async")]
-use crate::runtime::vm::component::ComponentInstance;
-#[cfg(feature = "component-model-async")]
 use core::any::Any;
 #[cfg(feature = "component-model-async")]
 use core::future::{self, Future};
@@ -461,7 +459,7 @@ where
     unsafe fn lower_stack_args_fn<T>(
         func: Func,
         store: StoreContextMut<T>,
-        instance: &mut ComponentInstance,
+        instance: Instance,
         params_in: *mut u8,
         params_out: &mut [MaybeUninit<ValRaw>],
     ) -> Result<()> {
@@ -522,7 +520,7 @@ where
     unsafe fn lower_heap_args_fn<T>(
         func: Func,
         store: StoreContextMut<T>,
-        instance: &mut ComponentInstance,
+        instance: Instance,
         params_in: *mut u8,
         params_out: &mut [MaybeUninit<ValRaw>],
     ) -> Result<()> {
@@ -582,7 +580,7 @@ where
     fn lift_stack_result_fn<T>(
         func: Func,
         store: StoreContextMut<T>,
-        instance: &mut ComponentInstance,
+        instance: Instance,
         results: &[ValRaw],
     ) -> Result<Box<dyn Any + Send + Sync>>
     where
@@ -630,7 +628,7 @@ where
     fn lift_heap_result_fn<T>(
         func: Func,
         store: StoreContextMut<T>,
-        instance: &mut ComponentInstance,
+        instance: Instance,
         results: &[ValRaw],
     ) -> Result<Box<dyn Any + Send + Sync>>
     where

--- a/crates/wasmtime/src/runtime/component/instance.rs
+++ b/crates/wasmtime/src/runtime/component/instance.rs
@@ -7,10 +7,13 @@ use crate::component::{
 use crate::instance::OwnedImports;
 use crate::linker::DefinitionType;
 use crate::prelude::*;
-use crate::runtime::vm::component::{ComponentInstance, OwnedComponentInstance};
+use crate::runtime::vm::component::{
+    CallContexts, ComponentInstance, OwnedComponentInstance, ResourceTables, TypedResource,
+    TypedResourceIndex,
+};
 use crate::runtime::vm::{CompiledModuleId, VMFuncRef};
 use crate::store::{StoreOpaque, Stored};
-use crate::{AsContext, AsContextMut, Engine, Module, StoreContextMut};
+use crate::{AsContext, AsContextMut, Engine, Module, StoreContextMut, VMStore};
 use alloc::sync::Arc;
 use core::marker;
 use core::ptr::NonNull;
@@ -375,6 +378,117 @@ impl Instance {
                 data.instance().resource_types().clone(),
             )
         }
+    }
+
+    /// Implementation of the `resource.new` intrinsic for `i32`
+    /// representations.
+    pub(crate) fn resource_new32(
+        self,
+        store: &mut dyn VMStore,
+        ty: TypeResourceTableIndex,
+        rep: u32,
+    ) -> Result<u32> {
+        let (calls, _, _, instance) = store
+            .store_opaque_mut()
+            .component_resource_state_with_instance(self);
+        resource_tables(calls, instance).resource_new(TypedResource::Component { ty, rep })
+    }
+
+    /// Implementation of the `resource.rep` intrinsic for `i32`
+    /// representations.
+    pub(crate) fn resource_rep32(
+        self,
+        store: &mut dyn VMStore,
+        ty: TypeResourceTableIndex,
+        index: u32,
+    ) -> Result<u32> {
+        let (calls, _, _, instance) = store
+            .store_opaque_mut()
+            .component_resource_state_with_instance(self);
+        resource_tables(calls, instance).resource_rep(TypedResourceIndex::Component { ty, index })
+    }
+
+    /// Implementation of the `resource.drop` intrinsic.
+    pub(crate) fn resource_drop(
+        self,
+        store: &mut dyn VMStore,
+        ty: TypeResourceTableIndex,
+        index: u32,
+    ) -> Result<Option<u32>> {
+        let (calls, _, _, instance) = store
+            .store_opaque_mut()
+            .component_resource_state_with_instance(self);
+        resource_tables(calls, instance).resource_drop(TypedResourceIndex::Component { ty, index })
+    }
+
+    pub(crate) fn resource_transfer_own(
+        self,
+        store: &mut dyn VMStore,
+        index: u32,
+        src: TypeResourceTableIndex,
+        dst: TypeResourceTableIndex,
+    ) -> Result<u32> {
+        let (calls, _, _, instance) = store
+            .store_opaque_mut()
+            .component_resource_state_with_instance(self);
+        let mut tables = resource_tables(calls, instance);
+        let rep = tables.resource_lift_own(TypedResourceIndex::Component { ty: src, index })?;
+        tables.resource_lower_own(TypedResource::Component { ty: dst, rep })
+    }
+
+    pub(crate) fn resource_transfer_borrow(
+        self,
+        store: &mut dyn VMStore,
+        index: u32,
+        src: TypeResourceTableIndex,
+        dst: TypeResourceTableIndex,
+    ) -> Result<u32> {
+        let dst_owns_resource = store
+            .store_opaque()
+            .component_instance(self)
+            .resource_owned_by_own_instance(dst);
+        let (calls, _, _, instance) = store
+            .store_opaque_mut()
+            .component_resource_state_with_instance(self);
+        let mut tables = resource_tables(calls, instance);
+        let rep = tables.resource_lift_borrow(TypedResourceIndex::Component { ty: src, index })?;
+        // Implement `lower_borrow`'s special case here where if a borrow's
+        // resource type is owned by `dst` then the destination receives the
+        // representation directly rather than a handle to the representation.
+        //
+        // This can perhaps become a different libcall in the future to avoid
+        // this check at runtime since we know at compile time whether the
+        // destination type owns the resource, but that's left as a future
+        // refactoring if truly necessary.
+        if dst_owns_resource {
+            return Ok(rep);
+        }
+        tables.resource_lower_borrow(TypedResource::Component { ty: dst, rep })
+    }
+
+    pub(crate) fn resource_enter_call(self, store: &mut dyn VMStore) {
+        let (calls, _, _, instance) = store
+            .store_opaque_mut()
+            .component_resource_state_with_instance(self);
+        resource_tables(calls, instance).enter_call()
+    }
+
+    pub(crate) fn resource_exit_call(self, store: &mut dyn VMStore) -> Result<()> {
+        let (calls, _, _, instance) = store
+            .store_opaque_mut()
+            .component_resource_state_with_instance(self);
+        resource_tables(calls, instance).exit_call()
+    }
+}
+
+fn resource_tables<'a>(
+    calls: &'a mut CallContexts,
+    instance: &'a mut ComponentInstance,
+) -> ResourceTables<'a> {
+    ResourceTables {
+        host_table: None,
+        calls,
+        guest: Some(instance.guest_tables()),
     }
 }
 

--- a/crates/wasmtime/src/runtime/component/mod.rs
+++ b/crates/wasmtime/src/runtime/component/mod.rs
@@ -702,12 +702,11 @@ pub mod bindgen_examples {}
 pub(crate) mod concurrent {
     use {
         crate::{
-            AsContextMut, StoreContextMut, VMStore,
+            VMStore,
             component::{
                 Instance, Val,
                 func::{ComponentType, LiftContext, LowerContext},
             },
-            vm::component::ComponentInstance,
         },
         alloc::{sync::Arc, task::Wake},
         anyhow::Result,
@@ -720,16 +719,6 @@ pub(crate) mod concurrent {
         wasmtime_environ::component::{InterfaceType, RuntimeComponentInstanceIndex},
     };
 
-    impl<T> StoreContextMut<'_, T> {
-        pub(crate) fn with_attached_instance<R>(
-            &mut self,
-            instance: &mut ComponentInstance,
-            fun: impl FnOnce(StoreContextMut<'_, T>, Instance) -> R,
-        ) -> R {
-            fun(self.as_context_mut(), instance.instance)
-        }
-    }
-
     fn dummy_waker() -> Waker {
         struct DummyWaker;
 
@@ -740,9 +729,9 @@ pub(crate) mod concurrent {
         Arc::new(DummyWaker).into()
     }
 
-    impl ComponentInstance {
+    impl Instance {
         pub(crate) fn poll_and_block<R: Send + Sync + 'static>(
-            &mut self,
+            self,
             _store: &mut dyn VMStore,
             future: impl Future<Output = Result<R>> + Send + 'static,
             _caller_instance: RuntimeComponentInstanceIndex,

--- a/crates/wasmtime/src/runtime/vm/component/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/component/libcalls.rs
@@ -593,11 +593,15 @@ unsafe fn backpressure_set(
     caller_instance: u32,
     enabled: u32,
 ) -> Result<()> {
-    ComponentInstance::from_vmctx(vmctx, |_, instance| {
-        instance.backpressure_set(
-            wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(caller_instance),
-            enabled,
-        )
+    ComponentInstance::from_vmctx(vmctx, |store, instance| {
+        instance
+            .instance(store.store_opaque_mut())
+            .backpressure_set(
+                wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(
+                    caller_instance,
+                ),
+                enabled,
+            )
     })
 }
 
@@ -637,10 +641,14 @@ unsafe fn waitable_set_new(
     vmctx: NonNull<VMComponentContext>,
     caller_instance: u32,
 ) -> Result<u32> {
-    ComponentInstance::from_vmctx(vmctx, |_, instance| {
-        instance.waitable_set_new(
-            wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(caller_instance),
-        )
+    ComponentInstance::from_vmctx(vmctx, |store, instance| {
+        instance
+            .instance(store.store_opaque_mut())
+            .waitable_set_new(
+                wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(
+                    caller_instance,
+                ),
+            )
     })
 }
 
@@ -692,11 +700,15 @@ unsafe fn waitable_set_drop(
     caller_instance: u32,
     set: u32,
 ) -> Result<()> {
-    ComponentInstance::from_vmctx(vmctx, |_, instance| {
-        instance.waitable_set_drop(
-            wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(caller_instance),
-            set,
-        )
+    ComponentInstance::from_vmctx(vmctx, |store, instance| {
+        instance
+            .instance(store.store_opaque_mut())
+            .waitable_set_drop(
+                wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(
+                    caller_instance,
+                ),
+                set,
+            )
     })
 }
 
@@ -707,8 +719,8 @@ unsafe fn waitable_join(
     waitable: u32,
     set: u32,
 ) -> Result<()> {
-    ComponentInstance::from_vmctx(vmctx, |_, instance| {
-        instance.waitable_join(
+    ComponentInstance::from_vmctx(vmctx, |store, instance| {
+        instance.instance(store.store_opaque_mut()).waitable_join(
             wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(caller_instance),
             waitable,
             set,
@@ -727,8 +739,8 @@ unsafe fn subtask_drop(
     caller_instance: u32,
     task_id: u32,
 ) -> Result<()> {
-    ComponentInstance::from_vmctx(vmctx, |_, instance| {
-        instance.subtask_drop(
+    ComponentInstance::from_vmctx(vmctx, |store, instance| {
+        instance.instance(store.store_opaque_mut()).subtask_drop(
             wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(caller_instance),
             task_id,
         )
@@ -834,8 +846,8 @@ unsafe fn future_transfer(
     src_table: u32,
     dst_table: u32,
 ) -> Result<u32> {
-    ComponentInstance::from_vmctx(vmctx, |_, instance| {
-        instance.future_transfer(
+    ComponentInstance::from_vmctx(vmctx, |store, instance| {
+        instance.instance(store.store_opaque_mut()).future_transfer(
             src_idx,
             wasmtime_environ::component::TypeFutureTableIndex::from_u32(src_table),
             wasmtime_environ::component::TypeFutureTableIndex::from_u32(dst_table),
@@ -850,8 +862,8 @@ unsafe fn stream_transfer(
     src_table: u32,
     dst_table: u32,
 ) -> Result<u32> {
-    ComponentInstance::from_vmctx(vmctx, |_, instance| {
-        instance.stream_transfer(
+    ComponentInstance::from_vmctx(vmctx, |store, instance| {
+        instance.instance(store.store_opaque_mut()).stream_transfer(
             src_idx,
             wasmtime_environ::component::TypeStreamTableIndex::from_u32(src_table),
             wasmtime_environ::component::TypeStreamTableIndex::from_u32(dst_table),
@@ -870,8 +882,10 @@ unsafe fn error_context_transfer(
         wasmtime_environ::component::TypeComponentLocalErrorContextTableIndex::from_u32(src_table);
     let dst_table =
         wasmtime_environ::component::TypeComponentLocalErrorContextTableIndex::from_u32(dst_table);
-    ComponentInstance::from_vmctx(vmctx, |_, instance| {
-        instance.error_context_transfer(src_idx, src_table, dst_table)
+    ComponentInstance::from_vmctx(vmctx, |store, instance| {
+        instance
+            .instance(store.store_opaque_mut())
+            .error_context_transfer(src_idx, src_table, dst_table)
     })
 }
 
@@ -888,10 +902,10 @@ unsafe impl HostResultHasUnwindSentinel for ResourcePair {
 
 #[cfg(feature = "component-model-async")]
 unsafe fn future_new(vmctx: NonNull<VMComponentContext>, ty: u32) -> Result<ResourcePair> {
-    ComponentInstance::from_vmctx(vmctx, |_, instance| {
-        instance.future_new(wasmtime_environ::component::TypeFutureTableIndex::from_u32(
-            ty,
-        ))
+    ComponentInstance::from_vmctx(vmctx, |store, instance| {
+        instance.instance(store.store_opaque_mut()).future_new(
+            wasmtime_environ::component::TypeFutureTableIndex::from_u32(ty),
+        )
     })
 }
 
@@ -952,12 +966,14 @@ unsafe fn future_cancel_write(
     async_: u8,
     writer: u32,
 ) -> Result<u32> {
-    ComponentInstance::from_vmctx(vmctx, |_, instance| {
-        instance.future_cancel_write(
-            wasmtime_environ::component::TypeFutureTableIndex::from_u32(ty),
-            async_ != 0,
-            writer,
-        )
+    ComponentInstance::from_vmctx(vmctx, |store, instance| {
+        instance
+            .instance(store.store_opaque_mut())
+            .future_cancel_write(
+                wasmtime_environ::component::TypeFutureTableIndex::from_u32(ty),
+                async_ != 0,
+                writer,
+            )
     })
 }
 
@@ -968,12 +984,14 @@ unsafe fn future_cancel_read(
     async_: u8,
     reader: u32,
 ) -> Result<u32> {
-    ComponentInstance::from_vmctx(vmctx, |_, instance| {
-        instance.future_cancel_read(
-            wasmtime_environ::component::TypeFutureTableIndex::from_u32(ty),
-            async_ != 0,
-            reader,
-        )
+    ComponentInstance::from_vmctx(vmctx, |store, instance| {
+        instance
+            .instance(store.store_opaque_mut())
+            .future_cancel_read(
+                wasmtime_environ::component::TypeFutureTableIndex::from_u32(ty),
+                async_ != 0,
+                reader,
+            )
     })
 }
 
@@ -983,11 +1001,13 @@ unsafe fn future_close_writable(
     ty: u32,
     writer: u32,
 ) -> Result<()> {
-    ComponentInstance::from_vmctx(vmctx, |_, instance| {
-        instance.future_close_writable(
-            wasmtime_environ::component::TypeFutureTableIndex::from_u32(ty),
-            writer,
-        )
+    ComponentInstance::from_vmctx(vmctx, |store, instance| {
+        instance
+            .instance(store.store_opaque_mut())
+            .future_close_writable(
+                wasmtime_environ::component::TypeFutureTableIndex::from_u32(ty),
+                writer,
+            )
     })
 }
 
@@ -1008,10 +1028,10 @@ unsafe fn future_close_readable(
 
 #[cfg(feature = "component-model-async")]
 unsafe fn stream_new(vmctx: NonNull<VMComponentContext>, ty: u32) -> Result<ResourcePair> {
-    ComponentInstance::from_vmctx(vmctx, |_, instance| {
-        instance.stream_new(wasmtime_environ::component::TypeStreamTableIndex::from_u32(
-            ty,
-        ))
+    ComponentInstance::from_vmctx(vmctx, |store, instance| {
+        instance.instance(store.store_opaque_mut()).stream_new(
+            wasmtime_environ::component::TypeStreamTableIndex::from_u32(ty),
+        )
     })
 }
 
@@ -1076,12 +1096,14 @@ unsafe fn stream_cancel_write(
     async_: u8,
     writer: u32,
 ) -> Result<u32> {
-    ComponentInstance::from_vmctx(vmctx, |_, instance| {
-        instance.stream_cancel_write(
-            wasmtime_environ::component::TypeStreamTableIndex::from_u32(ty),
-            async_ != 0,
-            writer,
-        )
+    ComponentInstance::from_vmctx(vmctx, |store, instance| {
+        instance
+            .instance(store.store_opaque_mut())
+            .stream_cancel_write(
+                wasmtime_environ::component::TypeStreamTableIndex::from_u32(ty),
+                async_ != 0,
+                writer,
+            )
     })
 }
 
@@ -1092,12 +1114,14 @@ unsafe fn stream_cancel_read(
     async_: u8,
     reader: u32,
 ) -> Result<u32> {
-    ComponentInstance::from_vmctx(vmctx, |_, instance| {
-        instance.stream_cancel_read(
-            wasmtime_environ::component::TypeStreamTableIndex::from_u32(ty),
-            async_ != 0,
-            reader,
-        )
+    ComponentInstance::from_vmctx(vmctx, |store, instance| {
+        instance
+            .instance(store.store_opaque_mut())
+            .stream_cancel_read(
+                wasmtime_environ::component::TypeStreamTableIndex::from_u32(ty),
+                async_ != 0,
+                reader,
+            )
     })
 }
 
@@ -1107,11 +1131,13 @@ unsafe fn stream_close_writable(
     ty: u32,
     writer: u32,
 ) -> Result<()> {
-    ComponentInstance::from_vmctx(vmctx, |_, instance| {
-        instance.stream_close_writable(
-            wasmtime_environ::component::TypeStreamTableIndex::from_u32(ty),
-            writer,
-        )
+    ComponentInstance::from_vmctx(vmctx, |store, instance| {
+        instance
+            .instance(store.store_opaque_mut())
+            .stream_close_writable(
+                wasmtime_environ::component::TypeStreamTableIndex::from_u32(ty),
+                writer,
+            )
     })
 }
 
@@ -1240,20 +1266,30 @@ unsafe fn error_context_drop(
     ty: u32,
     err_ctx_handle: u32,
 ) -> Result<()> {
-    ComponentInstance::from_vmctx(vmctx, |_, instance| {
-        instance.error_context_drop(
-            wasmtime_environ::component::TypeComponentLocalErrorContextTableIndex::from_u32(ty),
-            err_ctx_handle,
-        )
+    ComponentInstance::from_vmctx(vmctx, |store, instance| {
+        instance
+            .instance(store.store_opaque_mut())
+            .error_context_drop(
+                wasmtime_environ::component::TypeComponentLocalErrorContextTableIndex::from_u32(ty),
+                err_ctx_handle,
+            )
     })
 }
 
 #[cfg(feature = "component-model-async")]
 unsafe fn context_get(vmctx: NonNull<VMComponentContext>, slot: u32) -> Result<u32> {
-    ComponentInstance::from_vmctx(vmctx, |_, instance| instance.context_get(slot))
+    ComponentInstance::from_vmctx(vmctx, |store, instance| {
+        instance
+            .instance(store.store_opaque_mut())
+            .context_get(slot)
+    })
 }
 
 #[cfg(feature = "component-model-async")]
 unsafe fn context_set(vmctx: NonNull<VMComponentContext>, slot: u32, val: u32) -> Result<()> {
-    ComponentInstance::from_vmctx(vmctx, |_, instance| instance.context_set(slot, val))
+    ComponentInstance::from_vmctx(vmctx, |store, instance| {
+        instance
+            .instance(store.store_opaque_mut())
+            .context_set(slot, val)
+    })
 }


### PR DESCRIPTION
This is the second phase of the cleanup I started in an earlier commit with the goal of reducing `unsafe` code in the `concurrent` module and submodules, especially with regard to functions which take mutable references to a store and a `ComponentInstance` within that store.

My earlier attempt to make such functions safe was to temporarily "detach" the instance from the store to avoid aliasing hazards, but that got messy and confusing, and Alex and I decided an index-based approach made more sense.  So now we pass `Instance` handles around instead of `ComponentInstance` references and pointers, using them to retrieve the `ComponentInstance` from the store only as necessary.

Practically speaking, this required moving a lot of inherent functions from `ComponentInstance` to `Instance` and updating their bodies accordingly. Functionally, nothing has changed.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
