### PR TITLE
Refactor `serve` subcommand p3 support

### DIFF
--- a/crates/wasi-http/src/p3/client.rs
+++ b/crates/wasi-http/src/p3/client.rs
@@ -57,7 +57,10 @@ pub trait Client: Clone + Send + Sync {
                     impl Future<
                         Output = Result<
                             http::Response<
-                                impl http_body::Body<Data = Bytes, Error = Self::Error> + Send + 'static,
+                                impl http_body::Body<Data = Bytes, Error = Self::Error>
+                                + Send
+                                + Sync
+                                + 'static,
                             >,
                             ErrorCode,
                         >,

--- a/crates/wasi-http/src/p3/host/handler.rs
+++ b/crates/wasi-http/src/p3/host/handler.rs
@@ -155,9 +155,7 @@ where
                             Ok(())
                         }));
                         match response.await {
-                            Ok(response) => {
-                                response.map(|body| body.map_err(Into::into).boxed_unsync())
-                            }
+                            Ok(response) => response.map(|body| body.map_err(Into::into).boxed()),
                             Err(err) => return Ok(Err(err)),
                         }
                     }
@@ -185,9 +183,7 @@ where
                             Ok(())
                         }));
                         match response.await {
-                            Ok(response) => {
-                                response.map(|body| body.map_err(Into::into).boxed_unsync())
-                            }
+                            Ok(response) => response.map(|body| body.map_err(Into::into).boxed()),
                             Err(err) => return Ok(Err(err)),
                         }
                     }
@@ -235,9 +231,7 @@ where
                             Ok(())
                         }));
                         match response.await {
-                            Ok(response) => {
-                                response.map(|body| body.map_err(Into::into).boxed_unsync())
-                            }
+                            Ok(response) => response.map(|body| body.map_err(Into::into).boxed()),
                             Err(err) => return Ok(Err(err)),
                         }
                     }
@@ -275,9 +269,7 @@ where
                             Ok(())
                         }));
                         match response.await {
-                            Ok(response) => {
-                                response.map(|body| body.map_err(Into::into).boxed_unsync())
-                            }
+                            Ok(response) => response.map(|body| body.map_err(Into::into).boxed()),
 
                             Err(err) => return Ok(Err(err)),
                         }
@@ -299,9 +291,7 @@ where
                             Ok(())
                         }));
                         match response.await {
-                            Ok(response) => {
-                                response.map(|body| body.map_err(Into::into).boxed_unsync())
-                            }
+                            Ok(response) => response.map(|body| body.map_err(Into::into).boxed()),
                             Err(err) => return Ok(Err(err)),
                         }
                     }
@@ -322,9 +312,7 @@ where
                             Ok(())
                         }));
                         match response.await {
-                            Ok(response) => {
-                                response.map(|body| body.map_err(Into::into).boxed_unsync())
-                            }
+                            Ok(response) => response.map(|body| body.map_err(Into::into).boxed()),
                             Err(err) => return Ok(Err(err)),
                         }
                     }
@@ -348,9 +336,7 @@ where
                             Ok(())
                         }));
                         match response.await {
-                            Ok(response) => {
-                                response.map(|body| body.map_err(Into::into).boxed_unsync())
-                            }
+                            Ok(response) => response.map(|body| body.map_err(Into::into).boxed()),
                             Err(err) => return Ok(Err(err)),
                         }
                     }
@@ -370,9 +356,7 @@ where
                             Ok(())
                         }));
                         match response.await {
-                            Ok(response) => {
-                                response.map(|body| body.map_err(Into::into).boxed_unsync())
-                            }
+                            Ok(response) => response.map(|body| body.map_err(Into::into).boxed()),
                             Err(err) => return Ok(Err(err)),
                         }
                     }
@@ -394,9 +378,7 @@ where
                             Ok(())
                         }));
                         match response.await {
-                            Ok(response) => {
-                                response.map(|body| body.map_err(Into::into).boxed_unsync())
-                            }
+                            Ok(response) => response.map(|body| body.map_err(Into::into).boxed()),
                             Err(err) => return Ok(Err(err)),
                         }
                     }


### PR DESCRIPTION
Reduce duplication and reduce the diff with `main` to make merges easier, I otherwise can't figure out how best to duplicate all the helpers any more.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
