### PR TITLE
Don't reexport `VMStore, VMStoreRawPtr` to the public API

### DIFF
--- a/crates/wasmtime/src/runtime.rs
+++ b/crates/wasmtime/src/runtime.rs
@@ -90,8 +90,6 @@ pub use values::*;
 
 pub(crate) use uninhabited::*;
 
-pub use vm::{VMStore, VMStoreRawPtr};
-
 #[cfg(feature = "pooling-allocator")]
 pub use vm::PoolConcurrencyLimitError;
 

--- a/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
@@ -5,7 +5,7 @@ use {
         table::{TableDebug, TableId},
     },
     crate::{
-        AsContextMut, StoreContextMut, VMStore, ValRaw,
+        AsContextMut, StoreContextMut, ValRaw,
         component::{
             Instance, Lower, Val, WasmList, WasmStr,
             func::{self, Lift, LiftContext, LowerContext, Options},
@@ -13,7 +13,7 @@ use {
             values::{ErrorContextAny, FutureAny, StreamAny},
         },
         store::{StoreOpaque, StoreToken},
-        vm::{VMFuncRef, VMMemoryDefinition, component::ComponentInstance},
+        vm::{VMFuncRef, VMMemoryDefinition, VMStore, component::ComponentInstance},
     },
     anyhow::{Context, Result, anyhow, bail},
     buffers::Extender,

--- a/crates/wasmtime/src/runtime/component/func/host.rs
+++ b/crates/wasmtime/src/runtime/component/func/host.rs
@@ -9,8 +9,10 @@ use crate::runtime::vm::SendSyncPtr;
 use crate::runtime::vm::component::{
     ComponentInstance, InstanceFlags, VMComponentContext, VMLowering, VMLoweringCallee,
 };
-use crate::runtime::vm::{VMFuncRef, VMGlobalDefinition, VMMemoryDefinition, VMOpaqueContext};
-use crate::{AsContextMut, CallHook, StoreContextMut, VMStore, ValRaw};
+use crate::runtime::vm::{
+    VMFuncRef, VMGlobalDefinition, VMMemoryDefinition, VMOpaqueContext, VMStore,
+};
+use crate::{AsContextMut, CallHook, StoreContextMut, ValRaw};
 use alloc::sync::Arc;
 use core::any::Any;
 use core::future::Future;

--- a/crates/wasmtime/src/runtime/component/instance.rs
+++ b/crates/wasmtime/src/runtime/component/instance.rs
@@ -8,13 +8,13 @@ use crate::component::{
 use crate::instance::OwnedImports;
 use crate::linker::DefinitionType;
 use crate::prelude::*;
-use crate::runtime::vm::VMFuncRef;
 use crate::runtime::vm::component::{
     CallContexts, ComponentInstance, OwnedComponentInstance, ResourceTables, TypedResource,
     TypedResourceIndex,
 };
+use crate::runtime::vm::{VMFuncRef, VMStore};
 use crate::store::StoreOpaque;
-use crate::{AsContext, AsContextMut, Engine, Module, StoreContextMut, VMStore};
+use crate::{AsContext, AsContextMut, Engine, Module, StoreContextMut};
 use alloc::sync::Arc;
 use core::marker;
 use core::ptr::NonNull;

--- a/crates/wasmtime/src/runtime/component/mod.rs
+++ b/crates/wasmtime/src/runtime/component/mod.rs
@@ -704,11 +704,11 @@ pub mod bindgen_examples {}
 pub(crate) mod concurrent {
     use {
         crate::{
-            VMStore,
             component::{
                 Instance, Val,
                 func::{ComponentType, LiftContext, LowerContext},
             },
+            runtime::vm::VMStore,
         },
         alloc::{sync::Arc, task::Wake},
         anyhow::Result,

--- a/crates/wasmtime/src/runtime/store/data.rs
+++ b/crates/wasmtime/src/runtime/store/data.rs
@@ -1,6 +1,6 @@
-use crate::runtime::vm;
+use crate::runtime::vm::{self, VMStore};
 use crate::store::StoreOpaque;
-use crate::{StoreContext, StoreContextMut, VMStore};
+use crate::{StoreContext, StoreContextMut};
 use core::num::NonZeroU64;
 use core::ops::{Index, IndexMut};
 

--- a/crates/wasmtime/src/runtime/store/token.rs
+++ b/crates/wasmtime/src/runtime/store/token.rs
@@ -1,4 +1,5 @@
-use crate::{StoreContextMut, VMStore, store::StoreId};
+use crate::runtime::vm::VMStore;
+use crate::{StoreContextMut, store::StoreId};
 use core::marker::PhantomData;
 
 pub struct StoreToken<T> {


### PR DESCRIPTION
I think this was needed historically, but no longer.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
