### PR TITLE
Remove now-dead methods on `StoreContextMut`

### DIFF
--- a/crates/wasmtime/src/runtime/store/context.rs
+++ b/crates/wasmtime/src/runtime/store/context.rs
@@ -18,23 +18,6 @@ pub struct StoreContext<'a, T: 'static>(pub(crate) &'a StoreInner<T>);
 #[repr(transparent)]
 pub struct StoreContextMut<'a, T: 'static>(pub(crate) &'a mut StoreInner<T>);
 
-impl<'a, T> StoreContextMut<'a, T> {
-    #[doc(hidden)]
-    pub fn traitobj(&self) -> core::ptr::NonNull<dyn crate::runtime::vm::VMStore> {
-        self.0.traitobj()
-    }
-
-    #[doc(hidden)]
-    pub fn inner(&mut self) -> &mut StoreInner<T> {
-        self.0
-    }
-
-    #[doc(hidden)]
-    pub fn new(inner: &'a mut StoreInner<T>) -> Self {
-        Self(inner)
-    }
-}
-
 /// A trait used to get shared access to a [`Store`] in Wasmtime.
 ///
 /// This trait is used as a bound on the first argument of many methods within


### PR DESCRIPTION
Once needed, now no longer, so remove these.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
