### PR TITLE
update `future.{write,read}` ABIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3467,7 +3467,7 @@ dependencies = [
  "wasmtime",
  "wasmtime-test-util",
  "wat",
- "wit-component 0.233.0",
+ "wit-component",
 ]
 
 [[package]]
@@ -3994,7 +3994,7 @@ dependencies = [
  "byte-array-literals",
  "object",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "wasm-encoder 0.233.0",
+ "wasm-encoder",
  "wit-bindgen-rust-macro",
 ]
 
@@ -4056,8 +4056,7 @@ checksum = "6ee99da9c5ba11bd675621338ef6fa52296b76b83305e9b6e5c77d4c286d6d49"
 [[package]]
 name = "wasm-compose"
 version = "0.233.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80a48997769da18debd9508bb8db7f0a39d5fc3972ecca9a4140c19a68f9e385"
+source = "git+https://github.com/bytecodealliance/wasm-tools#95f36d27a71c91cd210dd50bd5a26001875c61a4"
 dependencies = [
  "anyhow",
  "heck 0.4.1",
@@ -4069,26 +4068,15 @@ dependencies = [
  "serde_derive",
  "serde_yaml",
  "smallvec",
- "wasm-encoder 0.233.0",
+ "wasm-encoder",
  "wasmparser 0.233.0",
  "wat",
 ]
 
 [[package]]
 name = "wasm-encoder"
-version = "0.232.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a447e61e38d1226b57e4628edadff36d16760be24a343712ba236b5106c95156"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.232.0",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.233.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9679ae3cf7cfa2ca3a327f7fab97f27f3294d402fd1a76ca8ab514e17973e4d3"
+source = "git+https://github.com/bytecodealliance/wasm-tools#95f36d27a71c91cd210dd50bd5a26001875c61a4"
 dependencies = [
  "leb128fmt",
  "wasmparser 0.233.0",
@@ -4096,54 +4084,39 @@ dependencies = [
 
 [[package]]
 name = "wasm-metadata"
-version = "0.232.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71aba7991cf9922a097b2dcc4c36ba5bc207339bdcd3a515530fc2555f01e8eb"
-dependencies = [
- "anyhow",
- "indexmap 2.7.0",
- "wasm-encoder 0.232.0",
- "wasmparser 0.232.0",
-]
-
-[[package]]
-name = "wasm-metadata"
 version = "0.233.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ea902a6e69315e1e2371bd35ce4b45ef0d4cfcaf89d1a392ae3966ac055f25"
+source = "git+https://github.com/bytecodealliance/wasm-tools#95f36d27a71c91cd210dd50bd5a26001875c61a4"
 dependencies = [
  "anyhow",
  "indexmap 2.7.0",
- "wasm-encoder 0.233.0",
+ "wasm-encoder",
  "wasmparser 0.233.0",
 ]
 
 [[package]]
 name = "wasm-mutate"
 version = "0.233.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cdfd07fae6e4aaed2b1f411bb66ce6d8c19acd3b9e2bbce0b62ff9682107fcf"
+source = "git+https://github.com/bytecodealliance/wasm-tools#95f36d27a71c91cd210dd50bd5a26001875c61a4"
 dependencies = [
  "egg",
  "log",
  "rand",
  "thiserror 1.0.65",
- "wasm-encoder 0.233.0",
+ "wasm-encoder",
  "wasmparser 0.233.0",
 ]
 
 [[package]]
 name = "wasm-smith"
 version = "0.233.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2820810ea8e870fd5ae956750b457e0997099c806e4747d0abc4d5e608c4e59f"
+source = "git+https://github.com/bytecodealliance/wasm-tools#95f36d27a71c91cd210dd50bd5a26001875c61a4"
 dependencies = [
  "anyhow",
  "arbitrary",
  "flagset",
  "serde",
  "serde_derive",
- "wasm-encoder 0.233.0",
+ "wasm-encoder",
  "wat",
 ]
 
@@ -4158,13 +4131,12 @@ dependencies = [
 [[package]]
 name = "wasm-wave"
 version = "0.233.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d55ea4585cecac742179af2d61cd1941b0e7e96a6f60447ecfb48fd1c67686b1"
+source = "git+https://github.com/bytecodealliance/wasm-tools#95f36d27a71c91cd210dd50bd5a26001875c61a4"
 dependencies = [
  "indexmap 2.7.0",
  "logos",
  "thiserror 1.0.65",
- "wit-parser 0.233.0",
+ "wit-parser",
 ]
 
 [[package]]
@@ -4223,21 +4195,8 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.232.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917739b33bb1eb0e9a49bcd2637a351931be4578d0cc4d37b908d7a797784fbb"
-dependencies = [
- "bitflags 2.6.0",
- "hashbrown 0.15.2",
- "indexmap 2.7.0",
- "semver",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.233.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b51cb03afce7964bbfce46602d6cb358726f36430b6ba084ac6020d8ce5bc102"
+source = "git+https://github.com/bytecodealliance/wasm-tools#95f36d27a71c91cd210dd50bd5a26001875c61a4"
 dependencies = [
  "bitflags 2.6.0",
  "hashbrown 0.15.2",
@@ -4249,8 +4208,7 @@ dependencies = [
 [[package]]
 name = "wasmprinter"
 version = "0.233.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf8e5b732895c99b21aa615f1b73352e51bbe2b2cb6c87eae7f990d07c1ac18"
+source = "git+https://github.com/bytecodealliance/wasm-tools#95f36d27a71c91cd210dd50bd5a26001875c61a4"
 dependencies = [
  "anyhow",
  "termcolor",
@@ -4300,7 +4258,7 @@ dependencies = [
  "tempfile",
  "trait-variant",
  "wasi-common",
- "wasm-encoder 0.233.0",
+ "wasm-encoder",
  "wasm-wave",
  "wasmparser 0.233.0",
  "wasmtime-asm-macros",
@@ -4448,7 +4406,7 @@ dependencies = [
  "trait-variant",
  "walkdir",
  "wasi-common",
- "wasm-encoder 0.233.0",
+ "wasm-encoder",
  "wasmparser 0.233.0",
  "wasmtime",
  "wasmtime-cache",
@@ -4470,7 +4428,7 @@ dependencies = [
  "wast 233.0.0",
  "wat",
  "windows-sys 0.59.0",
- "wit-component 0.233.0",
+ "wit-component",
 ]
 
 [[package]]
@@ -4505,7 +4463,7 @@ dependencies = [
  "wasmtime",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
- "wit-parser 0.233.0",
+ "wit-parser",
 ]
 
 [[package]]
@@ -4558,7 +4516,7 @@ dependencies = [
  "serde_derive",
  "smallvec",
  "target-lexicon",
- "wasm-encoder 0.233.0",
+ "wasm-encoder",
  "wasmparser 0.233.0",
  "wasmprinter",
  "wasmtime-component-util",
@@ -4653,7 +4611,7 @@ dependencies = [
  "target-lexicon",
  "tempfile",
  "v8",
- "wasm-encoder 0.233.0",
+ "wasm-encoder",
  "wasm-mutate",
  "wasm-smith",
  "wasm-spec-interpreter",
@@ -4926,7 +4884,7 @@ dependencies = [
  "anyhow",
  "heck 0.5.0",
  "indexmap 2.7.0",
- "wit-parser 0.233.0",
+ "wit-parser",
 ]
 
 [[package]]
@@ -4945,22 +4903,20 @@ dependencies = [
 [[package]]
 name = "wast"
 version = "233.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eaf4099d8d0c922b83bf3c90663f5666f0769db9e525184284ebbbdb1dd2180"
+source = "git+https://github.com/bytecodealliance/wasm-tools#95f36d27a71c91cd210dd50bd5a26001875c61a4"
 dependencies = [
  "bumpalo",
  "gimli",
  "leb128fmt",
  "memchr",
  "unicode-width 0.2.0",
- "wasm-encoder 0.233.0",
+ "wasm-encoder",
 ]
 
 [[package]]
 name = "wat"
 version = "1.233.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d9bc80f5e4b25ea086ef41b91ccd244adde45d931c384d94a8ff64ab8bd7d87"
+source = "git+https://github.com/bytecodealliance/wasm-tools#95f36d27a71c91cd210dd50bd5a26001875c61a4"
 dependencies = [
  "wast 233.0.0",
 ]
@@ -5251,7 +5207,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen"
 version = "0.42.1"
-source = "git+https://github.com/bytecodealliance/wit-bindgen#80cf018de24a45210c9ffe15d944f4485a0457fc"
+source = "git+https://github.com/dicej/wit-bindgen?branch=new-future-abi#060520a078f0ed791a6385fb8bc190497557ea03"
 dependencies = [
  "wit-bindgen-rt 0.42.1",
  "wit-bindgen-rust-macro",
@@ -5260,11 +5216,11 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-core"
 version = "0.42.1"
-source = "git+https://github.com/bytecodealliance/wit-bindgen#80cf018de24a45210c9ffe15d944f4485a0457fc"
+source = "git+https://github.com/dicej/wit-bindgen?branch=new-future-abi#060520a078f0ed791a6385fb8bc190497557ea03"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "wit-parser 0.232.0",
+ "wit-parser",
 ]
 
 [[package]]
@@ -5288,7 +5244,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-rt"
 version = "0.42.1"
-source = "git+https://github.com/bytecodealliance/wit-bindgen#80cf018de24a45210c9ffe15d944f4485a0457fc"
+source = "git+https://github.com/dicej/wit-bindgen?branch=new-future-abi#060520a078f0ed791a6385fb8bc190497557ea03"
 dependencies = [
  "bitflags 2.6.0",
  "futures",
@@ -5298,22 +5254,22 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-rust"
 version = "0.42.1"
-source = "git+https://github.com/bytecodealliance/wit-bindgen#80cf018de24a45210c9ffe15d944f4485a0457fc"
+source = "git+https://github.com/dicej/wit-bindgen?branch=new-future-abi#060520a078f0ed791a6385fb8bc190497557ea03"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
  "indexmap 2.7.0",
  "prettyplease",
  "syn 2.0.100",
- "wasm-metadata 0.232.0",
+ "wasm-metadata",
  "wit-bindgen-core",
- "wit-component 0.232.0",
+ "wit-component",
 ]
 
 [[package]]
 name = "wit-bindgen-rust-macro"
 version = "0.42.1"
-source = "git+https://github.com/bytecodealliance/wit-bindgen#80cf018de24a45210c9ffe15d944f4485a0457fc"
+source = "git+https://github.com/dicej/wit-bindgen?branch=new-future-abi#060520a078f0ed791a6385fb8bc190497557ea03"
 dependencies = [
  "anyhow",
  "prettyplease",
@@ -5326,28 +5282,8 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.232.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d1d7a3444f5039b4461a66dc085d749a832e518a86e8c7498d6fdd9df776ed0"
-dependencies = [
- "anyhow",
- "bitflags 2.6.0",
- "indexmap 2.7.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder 0.232.0",
- "wasm-metadata 0.232.0",
- "wasmparser 0.232.0",
- "wit-parser 0.232.0",
-]
-
-[[package]]
-name = "wit-component"
 version = "0.233.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "584f35dd45ccaf0c454bebca0fa111bca4d43a4334fbac25e941f73c503e673a"
+source = "git+https://github.com/bytecodealliance/wasm-tools#95f36d27a71c91cd210dd50bd5a26001875c61a4"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -5356,35 +5292,16 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.233.0",
- "wasm-metadata 0.233.0",
+ "wasm-encoder",
+ "wasm-metadata",
  "wasmparser 0.233.0",
- "wit-parser 0.233.0",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.232.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00a0e031533e3f9082057b09b346f76d3af12a714feccbe8d32f926254319d86"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.7.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.232.0",
+ "wit-parser",
 ]
 
 [[package]]
 name = "wit-parser"
 version = "0.233.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f22f1cd55247a2e616870b619766e9522df36b7abafbb29bbeb34b7a9da7e9f0"
+source = "git+https://github.com/bytecodealliance/wasm-tools#95f36d27a71c91cd210dd50bd5a26001875c61a4"
 dependencies = [
  "anyhow",
  "id-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -597,21 +597,21 @@ lto = true
 
 # TODO: remove this once we've switched to a wasm-tools/wit-bindgen release:
 [patch.crates-io]
-# wasmparser = { git = "https://github.com/bytecodealliance/wasm-tools" }
-# wat = { git = "https://github.com/bytecodealliance/wasm-tools" }
-# wast = { git = "https://github.com/bytecodealliance/wasm-tools" }
-# wasmprinter = { git = "https://github.com/bytecodealliance/wasm-tools" }
-# wasm-encoder = { git = "https://github.com/bytecodealliance/wasm-tools" }
-# wasm-smith = { git = "https://github.com/bytecodealliance/wasm-tools" }
-# wasm-mutate = { git = "https://github.com/bytecodealliance/wasm-tools" }
-# wit-parser = { git = "https://github.com/bytecodealliance/wasm-tools" }
-# wit-component = { git = "https://github.com/bytecodealliance/wasm-tools" }
-# wasm-wave = { git = "https://github.com/bytecodealliance/wasm-tools" }
-# wasm-compose = { git = "https://github.com/bytecodealliance/wasm-tools" }
-# wasm-metadata = { git = "https://github.com/bytecodealliance/wasm-tools" }
-wit-bindgen = { git = "https://github.com/bytecodealliance/wit-bindgen" }
-wit-bindgen-rt = { git = "https://github.com/bytecodealliance/wit-bindgen" }
-wit-bindgen-rust-macro = { git = "https://github.com/bytecodealliance/wit-bindgen" }
+wasmparser = { git = "https://github.com/bytecodealliance/wasm-tools" }
+wat = { git = "https://github.com/bytecodealliance/wasm-tools" }
+wast = { git = "https://github.com/bytecodealliance/wasm-tools" }
+wasmprinter = { git = "https://github.com/bytecodealliance/wasm-tools" }
+wasm-encoder = { git = "https://github.com/bytecodealliance/wasm-tools" }
+wasm-smith = { git = "https://github.com/bytecodealliance/wasm-tools" }
+wasm-mutate = { git = "https://github.com/bytecodealliance/wasm-tools" }
+wit-parser = { git = "https://github.com/bytecodealliance/wasm-tools" }
+wit-component = { git = "https://github.com/bytecodealliance/wasm-tools" }
+wasm-wave = { git = "https://github.com/bytecodealliance/wasm-tools" }
+wasm-compose = { git = "https://github.com/bytecodealliance/wasm-tools" }
+wasm-metadata = { git = "https://github.com/bytecodealliance/wasm-tools" }
+wit-bindgen = { git = "https://github.com/dicej/wit-bindgen", branch = "new-future-abi" }
+wit-bindgen-rt = { git = "https://github.com/dicej/wit-bindgen", branch = "new-future-abi" }
+wit-bindgen-rust-macro = { git = "https://github.com/dicej/wit-bindgen", branch = "new-future-abi" }
 
 # wasmparser = { path = '../wasm-tools/crates/wasmparser' }
 # wat = { path = '../wasm-tools/crates/wat' }

--- a/crates/environ/src/component.rs
+++ b/crates/environ/src/component.rs
@@ -132,7 +132,7 @@ macro_rules! foreach_builtin_component_function {
                 string_encoding: u32,
                 result_count_or_max_if_async: u32,
                 storage: ptr_u8,
-                torage_len: size
+                storage_len: size
             ) -> bool;
             #[cfg(feature = "component-model-async")]
             sync_start(vmctx: vmctx, callback: ptr_u8, callee: ptr_u8, param_count: u32, storage: ptr_u8, storage_len: size) -> bool;
@@ -141,7 +141,7 @@ macro_rules! foreach_builtin_component_function {
             #[cfg(feature = "component-model-async")]
             future_new(vmctx: vmctx, ty: u32) -> u64;
             #[cfg(feature = "component-model-async")]
-            future_write(vmctx: vmctx, memory: ptr_u8, realloc: ptr_u8, string_encoding: u8, async_: u8, ty: u32, future: u32, address: u32) -> u64;
+            future_write(vmctx: vmctx, memory: ptr_u8, realloc: ptr_u8, string_encoding: u8, async_: u8, ty: u32, future: u32, storage: ptr_u8, storage_len: size) -> u64;
             #[cfg(feature = "component-model-async")]
             future_read(vmctx: vmctx, memory: ptr_u8, realloc: ptr_u8, string_encoding: u8, async_: u8, ty: u32, future: u32, address: u32) -> u64;
             #[cfg(feature = "component-model-async")]
@@ -149,9 +149,9 @@ macro_rules! foreach_builtin_component_function {
             #[cfg(feature = "component-model-async")]
             future_cancel_read(vmctx: vmctx, ty: u32, async_: u8, reader: u32) -> u64;
             #[cfg(feature = "component-model-async")]
-            future_close_writable(vmctx: vmctx, ty: u32, writer: u32) -> bool;
+            future_drop_writable(vmctx: vmctx, ty: u32, writer: u32) -> bool;
             #[cfg(feature = "component-model-async")]
-            future_close_readable(vmctx: vmctx, ty: u32, reader: u32) -> bool;
+            future_drop_readable(vmctx: vmctx, ty: u32, reader: u32) -> bool;
             #[cfg(feature = "component-model-async")]
             stream_new(vmctx: vmctx, ty: u32) -> u64;
             #[cfg(feature = "component-model-async")]
@@ -163,9 +163,9 @@ macro_rules! foreach_builtin_component_function {
             #[cfg(feature = "component-model-async")]
             stream_cancel_read(vmctx: vmctx, ty: u32, async_: u8, reader: u32) -> u64;
             #[cfg(feature = "component-model-async")]
-            stream_close_writable(vmctx: vmctx, ty: u32, writer: u32) -> bool;
+            stream_drop_writable(vmctx: vmctx, ty: u32, writer: u32) -> bool;
             #[cfg(feature = "component-model-async")]
-            stream_close_readable(vmctx: vmctx, ty: u32, reader: u32) -> bool;
+            stream_drop_readable(vmctx: vmctx, ty: u32, reader: u32) -> bool;
             #[cfg(feature = "component-model-async")]
             flat_stream_write(vmctx: vmctx, memory: ptr_u8, realloc: ptr_u8, async_: u8, ty: u32, payload_size: u32, payload_align: u32, stream: u32, address: u32, count: u32) -> u64;
             #[cfg(feature = "component-model-async")]

--- a/crates/environ/src/component/dfg.rs
+++ b/crates/environ/src/component/dfg.rs
@@ -337,10 +337,10 @@ pub enum Trampoline {
         ty: TypeStreamTableIndex,
         async_: bool,
     },
-    StreamCloseReadable {
+    StreamDropReadable {
         ty: TypeStreamTableIndex,
     },
-    StreamCloseWritable {
+    StreamDropWritable {
         ty: TypeStreamTableIndex,
     },
     FutureNew {
@@ -362,10 +362,10 @@ pub enum Trampoline {
         ty: TypeFutureTableIndex,
         async_: bool,
     },
-    FutureCloseReadable {
+    FutureDropReadable {
         ty: TypeFutureTableIndex,
     },
-    FutureCloseWritable {
+    FutureDropWritable {
         ty: TypeFutureTableIndex,
     },
     ErrorContextNew {
@@ -848,11 +848,11 @@ impl LinearizeDfg<'_> {
                 ty: *ty,
                 async_: *async_,
             },
-            Trampoline::StreamCloseReadable { ty } => {
-                info::Trampoline::StreamCloseReadable { ty: *ty }
+            Trampoline::StreamDropReadable { ty } => {
+                info::Trampoline::StreamDropReadable { ty: *ty }
             }
-            Trampoline::StreamCloseWritable { ty } => {
-                info::Trampoline::StreamCloseWritable { ty: *ty }
+            Trampoline::StreamDropWritable { ty } => {
+                info::Trampoline::StreamDropWritable { ty: *ty }
             }
             Trampoline::FutureNew { ty } => info::Trampoline::FutureNew { ty: *ty },
             Trampoline::FutureRead { ty, options } => info::Trampoline::FutureRead {
@@ -871,11 +871,11 @@ impl LinearizeDfg<'_> {
                 ty: *ty,
                 async_: *async_,
             },
-            Trampoline::FutureCloseReadable { ty } => {
-                info::Trampoline::FutureCloseReadable { ty: *ty }
+            Trampoline::FutureDropReadable { ty } => {
+                info::Trampoline::FutureDropReadable { ty: *ty }
             }
-            Trampoline::FutureCloseWritable { ty } => {
-                info::Trampoline::FutureCloseWritable { ty: *ty }
+            Trampoline::FutureDropWritable { ty } => {
+                info::Trampoline::FutureDropWritable { ty: *ty }
             }
             Trampoline::ErrorContextNew { ty, options } => info::Trampoline::ErrorContextNew {
                 ty: *ty,

--- a/crates/environ/src/component/info.rs
+++ b/crates/environ/src/component/info.rs
@@ -836,16 +836,16 @@ pub enum Trampoline {
         async_: bool,
     },
 
-    /// A `stream.close-readable` intrinsic to close the readable end of a
+    /// A `stream.drop-readable` intrinsic to drop the readable end of a
     /// `stream` of the specified type.
-    StreamCloseReadable {
+    StreamDropReadable {
         /// The table index for the specific `stream` type and caller instance.
         ty: TypeStreamTableIndex,
     },
 
-    /// A `stream.close-writable` intrinsic to close the writable end of a
+    /// A `stream.drop-writable` intrinsic to drop the writable end of a
     /// `stream` of the specified type.
-    StreamCloseWritable {
+    StreamDropWritable {
         /// The table index for the specific `stream` type and caller instance.
         ty: TypeStreamTableIndex,
     },
@@ -897,16 +897,16 @@ pub enum Trampoline {
         async_: bool,
     },
 
-    /// A `future.close-readable` intrinsic to close the readable end of a
+    /// A `future.drop-readable` intrinsic to drop the readable end of a
     /// `future` of the specified type.
-    FutureCloseReadable {
+    FutureDropReadable {
         /// The table index for the specific `future` type and caller instance.
         ty: TypeFutureTableIndex,
     },
 
-    /// A `future.close-writable` intrinsic to close the writable end of a
+    /// A `future.drop-writable` intrinsic to drop the writable end of a
     /// `future` of the specified type.
-    FutureCloseWritable {
+    FutureDropWritable {
         /// The table index for the specific `future` type and caller instance.
         ty: TypeFutureTableIndex,
     },
@@ -1061,15 +1061,15 @@ impl Trampoline {
             StreamWrite { .. } => format!("stream-write"),
             StreamCancelRead { .. } => format!("stream-cancel-read"),
             StreamCancelWrite { .. } => format!("stream-cancel-write"),
-            StreamCloseReadable { .. } => format!("stream-close-readable"),
-            StreamCloseWritable { .. } => format!("stream-close-writable"),
+            StreamDropReadable { .. } => format!("stream-drop-readable"),
+            StreamDropWritable { .. } => format!("stream-drop-writable"),
             FutureNew { .. } => format!("future-new"),
             FutureRead { .. } => format!("future-read"),
             FutureWrite { .. } => format!("future-write"),
             FutureCancelRead { .. } => format!("future-cancel-read"),
             FutureCancelWrite { .. } => format!("future-cancel-write"),
-            FutureCloseReadable { .. } => format!("future-close-readable"),
-            FutureCloseWritable { .. } => format!("future-close-writable"),
+            FutureDropReadable { .. } => format!("future-drop-readable"),
+            FutureDropWritable { .. } => format!("future-drop-writable"),
             ErrorContextNew { .. } => format!("error-context-new"),
             ErrorContextDebugMessage { .. } => format!("error-context-debug-message"),
             ErrorContextDrop { .. } => format!("error-context-drop"),

--- a/crates/environ/src/component/translate.rs
+++ b/crates/environ/src/component/translate.rs
@@ -253,11 +253,11 @@ enum LocalInitializer<'data> {
         func: ModuleInternedTypeIndex,
         async_: bool,
     },
-    StreamCloseReadable {
+    StreamDropReadable {
         ty: ComponentDefinedTypeId,
         func: ModuleInternedTypeIndex,
     },
-    StreamCloseWritable {
+    StreamDropWritable {
         ty: ComponentDefinedTypeId,
         func: ModuleInternedTypeIndex,
     },
@@ -285,11 +285,11 @@ enum LocalInitializer<'data> {
         func: ModuleInternedTypeIndex,
         async_: bool,
     },
-    FutureCloseReadable {
+    FutureDropReadable {
         ty: ComponentDefinedTypeId,
         func: ModuleInternedTypeIndex,
     },
-    FutureCloseWritable {
+    FutureDropWritable {
         ty: ComponentDefinedTypeId,
         func: ModuleInternedTypeIndex,
     },
@@ -767,17 +767,17 @@ impl<'a, 'data> Translator<'a, 'data> {
                             core_func_index += 1;
                             LocalInitializer::StreamCancelWrite { ty, func, async_ }
                         }
-                        wasmparser::CanonicalFunction::StreamCloseReadable { ty } => {
+                        wasmparser::CanonicalFunction::StreamDropReadable { ty } => {
                             let ty = types.component_defined_type_at(ty);
                             let func = self.core_func_signature(core_func_index)?;
                             core_func_index += 1;
-                            LocalInitializer::StreamCloseReadable { ty, func }
+                            LocalInitializer::StreamDropReadable { ty, func }
                         }
-                        wasmparser::CanonicalFunction::StreamCloseWritable { ty } => {
+                        wasmparser::CanonicalFunction::StreamDropWritable { ty } => {
                             let ty = types.component_defined_type_at(ty);
                             let func = self.core_func_signature(core_func_index)?;
                             core_func_index += 1;
-                            LocalInitializer::StreamCloseWritable { ty, func }
+                            LocalInitializer::StreamDropWritable { ty, func }
                         }
                         wasmparser::CanonicalFunction::FutureNew { ty } => {
                             let ty = types.component_defined_type_at(ty);
@@ -811,17 +811,17 @@ impl<'a, 'data> Translator<'a, 'data> {
                             core_func_index += 1;
                             LocalInitializer::FutureCancelWrite { ty, func, async_ }
                         }
-                        wasmparser::CanonicalFunction::FutureCloseReadable { ty } => {
+                        wasmparser::CanonicalFunction::FutureDropReadable { ty } => {
                             let ty = types.component_defined_type_at(ty);
                             let func = self.core_func_signature(core_func_index)?;
                             core_func_index += 1;
-                            LocalInitializer::FutureCloseReadable { ty, func }
+                            LocalInitializer::FutureDropReadable { ty, func }
                         }
-                        wasmparser::CanonicalFunction::FutureCloseWritable { ty } => {
+                        wasmparser::CanonicalFunction::FutureDropWritable { ty } => {
                             let ty = types.component_defined_type_at(ty);
                             let func = self.core_func_signature(core_func_index)?;
                             core_func_index += 1;
-                            LocalInitializer::FutureCloseWritable { ty, func }
+                            LocalInitializer::FutureDropWritable { ty, func }
                         }
                         wasmparser::CanonicalFunction::ErrorContextNew { options } => {
                             let options = self.canonical_options(&options);

--- a/crates/environ/src/component/translate/inline.rs
+++ b/crates/environ/src/component/translate/inline.rs
@@ -863,7 +863,7 @@ impl<'a> Inliner<'a> {
                 ));
                 frame.funcs.push(dfg::CoreDef::Trampoline(index));
             }
-            StreamCloseReadable { ty, func } => {
+            StreamDropReadable { ty, func } => {
                 let InterfaceType::Stream(ty) =
                     types.defined_type(frame.translation.types_ref(), *ty)?
                 else {
@@ -872,10 +872,10 @@ impl<'a> Inliner<'a> {
                 let index = self
                     .result
                     .trampolines
-                    .push((*func, dfg::Trampoline::StreamCloseReadable { ty }));
+                    .push((*func, dfg::Trampoline::StreamDropReadable { ty }));
                 frame.funcs.push(dfg::CoreDef::Trampoline(index));
             }
-            StreamCloseWritable { ty, func } => {
+            StreamDropWritable { ty, func } => {
                 let InterfaceType::Stream(ty) =
                     types.defined_type(frame.translation.types_ref(), *ty)?
                 else {
@@ -884,7 +884,7 @@ impl<'a> Inliner<'a> {
                 let index = self
                     .result
                     .trampolines
-                    .push((*func, dfg::Trampoline::StreamCloseWritable { ty }));
+                    .push((*func, dfg::Trampoline::StreamDropWritable { ty }));
                 frame.funcs.push(dfg::CoreDef::Trampoline(index));
             }
             FutureNew { ty, func } => {
@@ -957,7 +957,7 @@ impl<'a> Inliner<'a> {
                 ));
                 frame.funcs.push(dfg::CoreDef::Trampoline(index));
             }
-            FutureCloseReadable { ty, func } => {
+            FutureDropReadable { ty, func } => {
                 let InterfaceType::Future(ty) =
                     types.defined_type(frame.translation.types_ref(), *ty)?
                 else {
@@ -966,10 +966,10 @@ impl<'a> Inliner<'a> {
                 let index = self
                     .result
                     .trampolines
-                    .push((*func, dfg::Trampoline::FutureCloseReadable { ty }));
+                    .push((*func, dfg::Trampoline::FutureDropReadable { ty }));
                 frame.funcs.push(dfg::CoreDef::Trampoline(index));
             }
-            FutureCloseWritable { ty, func } => {
+            FutureDropWritable { ty, func } => {
                 let InterfaceType::Future(ty) =
                     types.defined_type(frame.translation.types_ref(), *ty)?
                 else {
@@ -978,7 +978,7 @@ impl<'a> Inliner<'a> {
                 let index = self
                     .result
                     .trampolines
-                    .push((*func, dfg::Trampoline::FutureCloseWritable { ty }));
+                    .push((*func, dfg::Trampoline::FutureDropWritable { ty }));
                 frame.funcs.push(dfg::CoreDef::Trampoline(index));
             }
             ErrorContextNew { func, options } => {

--- a/crates/test-programs/src/async_.rs
+++ b/crates/test-programs/src/async_.rs
@@ -145,4 +145,4 @@ pub const CALLBACK_CODE_WAIT: u32 = 2;
 pub const CALLBACK_CODE_POLL: u32 = 3;
 
 pub const BLOCKED: u32 = 0xffff_ffff;
-pub const CLOSED: u32 = 1;
+pub const DROPPED: u32 = 1;

--- a/crates/test-programs/src/bin/async_transmit_caller.rs
+++ b/crates/test-programs/src/bin/async_transmit_caller.rs
@@ -107,7 +107,7 @@ impl Guest for Component {
                 Err(mut send) => {
                     caller_future_tx1 = match send.as_mut().cancel() {
                         FutureWriteCancel::AlreadySent => unreachable!(),
-                        FutureWriteCancel::Closed(_) => unreachable!(),
+                        FutureWriteCancel::Dropped(_) => unreachable!(),
                         FutureWriteCancel::Cancelled(_, writer) => writer,
                     }
                 }

--- a/crates/test-programs/src/bin/p3_http_echo.rs
+++ b/crates/test-programs/src/bin/p3_http_echo.rs
@@ -39,7 +39,7 @@ impl Handler for Component {
                             chunk = pipe_tx.write_all(chunk).await;
                             assert!(chunk.is_empty());
                         }
-                        StreamResult::Closed => break,
+                        StreamResult::Dropped => break,
                         StreamResult::Cancelled => unreachable!(),
                     }
                 }

--- a/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
@@ -10,6 +10,7 @@ use {
             Instance, Lower, Val, WasmList, WasmStr,
             func::{self, Lift, LiftContext, LowerContext, Options},
             matching::InstanceType,
+            storage,
             values::{ErrorContextAny, FutureAny, StreamAny},
         },
         store::{StoreOpaque, StoreToken},
@@ -46,6 +47,11 @@ pub use buffers::{ReadBuffer, TakeBuffer, VecBuffer, WriteBuffer};
 
 mod buffers;
 
+pub(super) enum WriteSource {
+    Indirect(usize),
+    Flat(Vec<ValRaw>),
+}
+
 /// Enum for distinguishing between a stream or future in functions that handle
 /// both.
 #[derive(Copy, Clone, Debug)]
@@ -59,7 +65,7 @@ enum TransmitKind {
 pub enum ReturnCode {
     Blocked,
     Completed(u32),
-    Closed(u32),
+    Dropped(u32),
     Cancelled(u32),
 }
 
@@ -71,7 +77,7 @@ impl ReturnCode {
     pub fn encode(&self) -> u32 {
         const BLOCKED: u32 = 0xffff_ffff;
         const COMPLETED: u32 = 0x0;
-        const CLOSED: u32 = 0x1;
+        const DROPPED: u32 = 0x1;
         const CANCELLED: u32 = 0x2;
         match self {
             ReturnCode::Blocked => BLOCKED,
@@ -79,9 +85,9 @@ impl ReturnCode {
                 debug_assert!(*n < (1 << 28));
                 (n << 4) | COMPLETED
             }
-            ReturnCode::Closed(n) => {
+            ReturnCode::Dropped(n) => {
                 debug_assert!(*n < (1 << 28));
-                (n << 4) | CLOSED
+                (n << 4) | DROPPED
             }
             ReturnCode::Cancelled(n) => {
                 debug_assert!(*n < (1 << 28));
@@ -90,14 +96,14 @@ impl ReturnCode {
         }
     }
 
-    /// Returns `Self::Closed` if `matches!(kind, TransmitKind::Future) && count
+    /// Returns `Self::Dropped` if `matches!(kind, TransmitKind::Future) && count
     /// == 1`; otherwise returns `Self::Completed`.
     ///
-    /// Futures, unlike streams, are automatically closed once the payload is
+    /// Futures, unlike streams, are automatically dropped once the payload is
     /// delivered.
-    fn completed_or_closed(kind: TransmitKind, count: u32) -> Self {
+    fn completed_or_dropped(kind: TransmitKind, count: u32) -> Self {
         if matches!(kind, TransmitKind::Future) && count == 1 {
-            Self::Closed(count)
+            Self::Dropped(count)
         } else {
             Self::Completed(count)
         }
@@ -127,16 +133,16 @@ impl TableIndex {
 enum PostWrite {
     /// Continue performing writes
     Continue,
-    /// Close the channel post-write
-    Close,
+    /// Drop the channel post-write
+    Drop,
 }
 
 /// Represents the result of a host-initiated stream or future read or write.
 struct HostResult<B> {
     /// The buffer provided when reading or writing.
     buffer: B,
-    /// Whether the other end of the stream or future has been closed.
-    closed: bool,
+    /// Whether the other end of the stream or future has been dropped.
+    dropped: bool,
 }
 
 /// Retrieve the payload type of the specified stream or future, or `None` if it
@@ -189,7 +195,7 @@ fn waitable_state(ty: TableIndex, state: StreamFutureState) -> WaitableState {
     }
 }
 
-/// Return a closure which matches a host write operation to a read (or close)
+/// Return a closure which matches a host write operation to a read (or drop)
 /// operation.
 ///
 /// This may be used when the host initiates a write but there is no read
@@ -237,25 +243,25 @@ fn accept_reader<T: func::Lower + Send + 'static, B: WriteBuffer<T>, U: 'static>
                 buffer.skip(count);
                 _ = tx.send(HostResult {
                     buffer,
-                    closed: false,
+                    dropped: false,
                 });
-                ReturnCode::completed_or_closed(kind, count.try_into().unwrap())
+                ReturnCode::completed_or_dropped(kind, count.try_into().unwrap())
             }
             Reader::Host { accept } => {
                 let count = buffer.remaining().len();
                 let count = accept(&mut buffer, count);
                 _ = tx.send(HostResult {
                     buffer,
-                    closed: false,
+                    dropped: false,
                 });
-                ReturnCode::completed_or_closed(kind, count.try_into().unwrap())
+                ReturnCode::completed_or_dropped(kind, count.try_into().unwrap())
             }
             Reader::End => {
                 _ = tx.send(HostResult {
                     buffer,
-                    closed: true,
+                    dropped: true,
                 });
-                ReturnCode::Closed(0)
+                ReturnCode::Dropped(0)
             }
         };
 
@@ -263,7 +269,7 @@ fn accept_reader<T: func::Lower + Send + 'static, B: WriteBuffer<T>, U: 'static>
     }
 }
 
-/// Return a closure which matches a host read operation to a write (or close)
+/// Return a closure which matches a host read operation to a write (or drop)
 /// operation.
 ///
 /// This may be used when the host initiates a read but there is no write
@@ -280,7 +286,7 @@ fn accept_writer<T: func::Lift + Send + 'static, B: ReadBuffer<T>, U>(
             Writer::Guest {
                 lift,
                 ty,
-                address,
+                source,
                 count,
             } => {
                 let count = count.min(buffer.remaining_capacity());
@@ -294,22 +300,44 @@ fn accept_writer<T: func::Lift + Send + 'static, B: ReadBuffer<T>, U>(
                     )
                 } else {
                     let ty = ty.unwrap();
-                    if address % usize::try_from(T::ALIGN32)? != 0 {
-                        bail!("write pointer not aligned");
-                    }
-                    lift.memory()
-                        .get(address..)
-                        .and_then(|b| b.get(..T::SIZE32 * count))
-                        .ok_or_else(|| anyhow::anyhow!("write pointer out of bounds of memory"))?;
+                    match source {
+                        WriteSource::Indirect(address) => {
+                            if address % usize::try_from(T::ALIGN32)? != 0 {
+                                bail!("write pointer not aligned");
+                            }
+                            lift.memory()
+                                .get(address..)
+                                .and_then(|b| b.get(..T::SIZE32 * count))
+                                .ok_or_else(|| {
+                                    anyhow::anyhow!("write pointer out of bounds of memory")
+                                })?;
 
-                    let list = &WasmList::new(address, count, lift, ty)?;
-                    T::load_into(lift, list, &mut Extender(&mut buffer), count)?
+                            let list = &WasmList::new(address, count, lift, ty)?;
+                            T::load_into(lift, list, &mut Extender(&mut buffer), count)?
+                        }
+                        WriteSource::Flat(source) => {
+                            assert_eq!(count, 1);
+                            // SAFETY: The `accept_writer` function is used only
+                            // in `host_read` as part of a `FutureReader::read`
+                            // operation, and that `FutureReader` will have
+                            // either been created via `Instance::future` or by
+                            // the guest using the `future.new` intrinsic and
+                            // then passed to the host.  In either case, the
+                            // payload type will have been typechecked.
+                            // Additionally, `slice_to_storage` will
+                            // double-check the size and alignment match the
+                            // expected values.
+                            buffer.extend(iter::once(T::lift(lift, ty, unsafe {
+                                storage::slice_to_storage(&source)
+                            })?));
+                        }
+                    }
                 }
                 _ = tx.send(HostResult {
                     buffer,
-                    closed: false,
+                    dropped: false,
                 });
-                ReturnCode::completed_or_closed(kind, count.try_into().unwrap())
+                ReturnCode::completed_or_dropped(kind, count.try_into().unwrap())
             }
             Writer::Host {
                 buffer: input,
@@ -319,16 +347,16 @@ fn accept_writer<T: func::Lift + Send + 'static, B: ReadBuffer<T>, U>(
                 buffer.move_from(input, count);
                 _ = tx.send(HostResult {
                     buffer,
-                    closed: false,
+                    dropped: false,
                 });
-                ReturnCode::completed_or_closed(kind, count.try_into().unwrap())
+                ReturnCode::completed_or_dropped(kind, count.try_into().unwrap())
             }
             Writer::End => {
                 _ = tx.send(HostResult {
                     buffer,
-                    closed: true,
+                    dropped: true,
                 });
-                ReturnCode::Closed(0)
+                ReturnCode::Dropped(0)
             }
         };
 
@@ -373,10 +401,10 @@ enum WriteEvent<B> {
         buffer: B,
         tx: oneshot::Sender<HostResult<B>>,
     },
-    /// Close the write end of the stream or future.
-    Close(Option<Box<dyn FnOnce() -> B + Send + Sync>>),
+    /// Drop the write end of the stream or future.
+    Drop(Option<Box<dyn FnOnce() -> B + Send + Sync>>),
     /// Watch the read (i.e. opposite) end of this stream or future, dropping
-    /// the specified sender when it is closed.
+    /// the specified sender when it is dropped.
     Watch { tx: oneshot::Sender<()> },
 }
 
@@ -390,10 +418,10 @@ enum ReadEvent<B> {
         buffer: B,
         tx: oneshot::Sender<HostResult<B>>,
     },
-    /// Close the read end of the stream or future.
-    Close,
+    /// Drop the read end of the stream or future.
+    Drop,
     /// Watch the write (i.e. opposite) end of this stream or future, dropping
-    /// the specified sender when it is closed.
+    /// the specified sender when it is dropped.
     Watch { tx: oneshot::Sender<()> },
 }
 
@@ -503,7 +531,7 @@ impl<T> FutureWriter<T> {
     /// Write the specified value to this `future`.
     ///
     /// The returned `Future` will yield `true` if the read end accepted the
-    /// value; otherwise it will return `false`, meaning the read end was closed
+    /// value; otherwise it will return `false`, meaning the read end was dropped
     /// before the value could be delivered.
     ///
     /// Note that the returned `Future` must be polled from the event loop of
@@ -528,7 +556,7 @@ impl<T> FutureWriter<T> {
             rx.map(move |v| {
                 drop(self);
                 match v {
-                    Ok(HostResult { closed, .. }) => !closed,
+                    Ok(HostResult { dropped, .. }) => !dropped,
                     Err(_) => todo!("guarantee buffer recovery if event loop errors or panics"),
                 }
             }),
@@ -536,7 +564,7 @@ impl<T> FutureWriter<T> {
     }
 
     /// Convert this object into a `Future` which will resolve when the read end
-    /// of this `future` is closed, plus a `Watch` which can be used to retrieve
+    /// of this `future` is dropped, plus a `Watch` which can be used to retrieve
     /// the `FutureWriter` again.
     ///
     /// Note that calling `Watch::into_inner` on the returned `Watch` will have
@@ -562,7 +590,7 @@ impl<T> Drop for FutureWriter<T> {
         if let Some(mut tx) = self.tx.take() {
             send(
                 &mut tx,
-                WriteEvent::Close(self.default.take().map(|v| {
+                WriteEvent::Drop(self.default.take().map(|v| {
                     Box::new(move || Some(v()))
                         as Box<dyn FnOnce() -> Option<T> + Send + Sync + 'static>
                 })),
@@ -573,7 +601,7 @@ impl<T> Drop for FutureWriter<T> {
 
 /// Represents the readable end of a Component Model `future`.
 ///
-/// In order to actually read from or close this `future`, first convert it to a
+/// In order to actually read from or drop this `future`, first convert it to a
 /// [`FutureReader`] using the `into_reader` method.
 ///
 /// Note that if a value of this type is dropped without either being converted
@@ -778,7 +806,7 @@ impl<T> FutureReader<T> {
 
                 if let Ok(HostResult {
                     mut buffer,
-                    closed: false,
+                    dropped: false,
                 }) = v
                 {
                     buffer.take()
@@ -790,7 +818,7 @@ impl<T> FutureReader<T> {
     }
 
     /// Convert this object into a `Future` which will resolve when the write
-    /// end of this `future` is closed, plus a `Watch` which can be used to
+    /// end of this `future` is dropped, plus a `Watch` which can be used to
     /// retrieve the `FutureReader` again.
     ///
     /// Note that calling `Watch::into_inner` on the returned `Watch` will have
@@ -814,7 +842,7 @@ impl<T> FutureReader<T> {
 impl<T> Drop for FutureReader<T> {
     fn drop(&mut self) {
         if let Some(mut tx) = self.tx.take() {
-            send(&mut tx, ReadEvent::Close);
+            send(&mut tx, ReadEvent::Drop);
         }
     }
 }
@@ -834,7 +862,7 @@ impl<B> StreamWriter<B> {
     ///
     /// Note that this will only write as many items as the reader accepts
     /// during its current or next read.  Use `write_all` to loop until the
-    /// buffer is drained or the read end is closed.
+    /// buffer is drained or the read end is dropped.
     ///
     /// The returned `Future` will yield a `(Some(_), _)` if the write completed
     /// (possibly consuming a subset of the items or nothing depending on the
@@ -859,14 +887,14 @@ impl<B> StreamWriter<B> {
         super::checked(
             instance,
             rx.map(move |v| match v {
-                Ok(HostResult { buffer, closed }) => ((!closed).then_some(self), buffer),
+                Ok(HostResult { buffer, dropped }) => ((!dropped).then_some(self), buffer),
                 Err(_) => todo!("guarantee buffer recovery if event loop errors or panics"),
             }),
         )
     }
 
     /// Write the specified values until either the buffer is drained or the
-    /// read end is closed.
+    /// read end is dropped.
     ///
     /// The returned `Future` will yield a `(Some(_), _)` if the write completed
     /// (i.e. all the items were accepted).  It will return `(None, _)` if the
@@ -902,7 +930,7 @@ impl<B> StreamWriter<B> {
     }
 
     /// Convert this object into a `Future` which will resolve when the read end
-    /// of this `stream` is closed, plus a `Watch` which can be used to retrieve
+    /// of this `stream` is dropped, plus a `Watch` which can be used to retrieve
     /// the `StreamWriter` again.
     ///
     /// Note that calling `Watch::into_inner` on the returned `Watch` will have
@@ -926,14 +954,14 @@ impl<B> StreamWriter<B> {
 impl<T> Drop for StreamWriter<T> {
     fn drop(&mut self) {
         if let Some(mut tx) = self.tx.take() {
-            send(&mut tx, WriteEvent::Close(None));
+            send(&mut tx, WriteEvent::Drop(None));
         }
     }
 }
 
 /// Represents the readable end of a Component Model `stream`.
 ///
-/// In order to actually read from or close this `stream`, first convert it to a
+/// In order to actually read from or drop this `stream`, first convert it to a
 /// [`FutureReader`] using the `into_reader` method.
 ///
 /// Note that if a value of this type is dropped without either being converted
@@ -1140,7 +1168,7 @@ impl<B> StreamReader<B> {
         super::checked(
             instance,
             rx.map(move |v| match v {
-                Ok(HostResult { buffer, closed }) => ((!closed).then_some(self), buffer),
+                Ok(HostResult { buffer, dropped }) => ((!dropped).then_some(self), buffer),
                 Err(_) => {
                     todo!("guarantee buffer recovery if event loop errors or panics")
                 }
@@ -1149,7 +1177,7 @@ impl<B> StreamReader<B> {
     }
 
     /// Convert this object into a `Future` which will resolve when the write
-    /// end of this `stream` is closed, plus a `Watch` which can be used to
+    /// end of this `stream` is dropped, plus a `Watch` which can be used to
     /// retrieve the `StreamReader` again.
     ///
     /// Note that calling `Watch::into_inner` on the returned `Watch` will have
@@ -1173,7 +1201,7 @@ impl<B> StreamReader<B> {
 impl<B> Drop for StreamReader<B> {
     fn drop(&mut self) {
         if let Some(mut tx) = self.tx.take() {
-            send(&mut tx, ReadEvent::Close);
+            send(&mut tx, ReadEvent::Drop);
         }
     }
 }
@@ -1324,15 +1352,15 @@ struct TransmitState {
     /// See `ReadState`
     read: ReadState,
     /// The `Sender`, if any, to be dropped when the write end of the stream or
-    /// future is closed.
+    /// future is dropped.
     ///
     /// This will signal to the host-owned read end that the write end has been
-    /// closed.
+    /// dropped.
     writer_watcher: Option<oneshot::Sender<()>>,
     /// Like `writer_watcher`, but for the reverse direction.
     reader_watcher: Option<oneshot::Sender<()>>,
-    /// Whether the write end may be closed or not.
-    may_close_writer: bool,
+    /// Whether the write end may be dropped or not.
+    may_drop_writer: bool,
 }
 
 impl Default for TransmitState {
@@ -1344,7 +1372,7 @@ impl Default for TransmitState {
             write: WriteState::Open,
             reader_watcher: None,
             writer_watcher: None,
-            may_close_writer: true,
+            may_drop_writer: true,
         }
     }
 }
@@ -1364,7 +1392,7 @@ enum WriteState {
         ty: TableIndex,
         flat_abi: Option<FlatAbi>,
         options: Options,
-        address: usize,
+        source: WriteSource,
         count: usize,
         handle: u32,
         post_write: PostWrite,
@@ -1375,8 +1403,8 @@ enum WriteState {
             Box<dyn FnOnce(&mut dyn VMStore, Instance, Reader) -> Result<ReturnCode> + Send + Sync>,
         post_write: PostWrite,
     },
-    /// The write end has been closed.
-    Closed,
+    /// The write end has been dropped.
+    Dropped,
 }
 
 /// Represents the state of the read end of a stream or future.
@@ -1396,8 +1424,8 @@ enum ReadState {
     HostReady {
         accept: Box<dyn FnOnce(Writer) -> Result<ReturnCode> + Send + Sync>,
     },
-    /// The read end has been closed.
-    Closed,
+    /// The read end has been dropped.
+    Dropped,
 }
 
 /// Parameter type to pass to a `ReadState::HostReady` closure.
@@ -1408,7 +1436,7 @@ enum Writer<'a> {
     Guest {
         lift: &'a mut LiftContext<'a>,
         ty: Option<InterfaceType>,
-        address: usize,
+        source: WriteSource,
         count: usize,
     },
     /// The write end is owned by the host.
@@ -1416,7 +1444,7 @@ enum Writer<'a> {
         buffer: &'a mut dyn TakeBuffer,
         count: usize,
     },
-    /// The write end has been closed.
+    /// The write end has been dropped.
     End,
 }
 
@@ -1435,7 +1463,7 @@ enum Reader<'a> {
     Host {
         accept: Box<dyn FnOnce(&mut dyn TakeBuffer, usize) -> usize>,
     },
-    /// The read end has been closed.
+    /// The read end has been dropped.
     End,
 }
 
@@ -1445,7 +1473,7 @@ impl Instance {
     ///
     /// The `default` parameter will be used if the returned `FutureWriter` is
     /// dropped before `FutureWriter::write` is called.  Since the write end of
-    /// a Component Model `future` must be written to before it is closed, and
+    /// a Component Model `future` must be written to before it is dropped, and
     /// since Rust does not currently provide a way to statically enforce that
     /// (e.g. linear typing), we use this mechanism to ensure a value is always
     /// written prior to closing.
@@ -1525,7 +1553,7 @@ impl Instance {
     ///
     /// The spawned task will accept host events from the `Receiver` corresponding to
     /// the returned `Sender`, handling each event it receives and then exiting
-    /// when the channel is closed.
+    /// when the channel is dropped.
     ///
     /// We handle `StreamWriter` and `FutureWriter` operations this way so that
     /// they can be initiated without access to the store and possibly outside
@@ -1567,7 +1595,7 @@ impl Instance {
                                 )
                             })?
                         }
-                        WriteEvent::Close(default) => {
+                        WriteEvent::Drop(default) => {
                             super::with_local_instance(|store, instance| {
                                 if let Some(default) = default {
                                     instance.host_write::<_, _, U>(
@@ -1579,14 +1607,14 @@ impl Instance {
                                         kind,
                                     )?;
                                 }
-                                store[instance.id()].host_close_writer(rep, kind)
+                                store[instance.id()].host_drop_writer(rep, kind)
                             })?
                         }
                         WriteEvent::Watch { tx } => {
                             super::with_local_instance(|store, instance| {
                                 let state = store[instance.id()]
                                     .get_mut(TableId::<TransmitState>::new(rep))?;
-                                if !matches!(&state.read, ReadState::Closed) {
+                                if !matches!(&state.read, ReadState::Dropped) {
                                     state.reader_watcher = Some(tx);
                                 }
                                 Ok::<_, anyhow::Error>(())
@@ -1643,8 +1671,8 @@ impl Instance {
                                 )
                             })?
                         }
-                        ReadEvent::Close => super::with_local_instance(|store, instance| {
-                            instance.host_close_reader(store, rep, kind)
+                        ReadEvent::Drop => super::with_local_instance(|store, instance| {
+                            instance.host_drop_reader(store, rep, kind)
                         })?,
                         ReadEvent::Watch { tx } => {
                             super::with_local_instance(|store, instance| {
@@ -1652,13 +1680,13 @@ impl Instance {
                                     .get_mut(TableId::<TransmitState>::new(rep))?;
                                 if !matches!(
                                     &state.write,
-                                    WriteState::Closed
+                                    WriteState::Dropped
                                         | WriteState::GuestReady {
-                                            post_write: PostWrite::Close,
+                                            post_write: PostWrite::Drop,
                                             ..
                                         }
                                         | WriteState::HostReady {
-                                            post_write: PostWrite::Close,
+                                            post_write: PostWrite::Drop,
                                             ..
                                         }
                                 ) {
@@ -1688,7 +1716,7 @@ impl Instance {
     /// * `store` - The store to which this instance belongs
     /// * `transmit_rep` - The `TransmitState` rep for the stream or future
     /// * `buffer` - Buffer of values that should be written
-    /// * `post_write` - Whether the transmit should be closed after write, possibly with an error context
+    /// * `post_write` - Whether the transmit should be dropped after write, possibly with an error context
     /// * `tx` - Oneshot channel to notify when operation completes (or drop on error)
     /// * `kind` - whether this is a stream or a future
     fn host_write<T: func::Lower + Send + 'static, B: WriteBuffer<T>, U: 'static>(
@@ -1704,10 +1732,10 @@ impl Instance {
         let transmit = store[self.id()]
             .get_mut(transmit_id)
             .with_context(|| format!("retrieving state for transmit [{transmit_rep}]"))?;
-        transmit.may_close_writer = true;
+        transmit.may_drop_writer = true;
 
-        let new_state = if let ReadState::Closed = &transmit.read {
-            ReadState::Closed
+        let new_state = if let ReadState::Dropped = &transmit.read {
+            ReadState::Dropped
         } else {
             ReadState::Open
         };
@@ -1771,26 +1799,26 @@ impl Instance {
                     buffer: &mut buffer,
                     count,
                 })?;
-                let (ReturnCode::Completed(_) | ReturnCode::Closed(_)) = code else {
+                let (ReturnCode::Completed(_) | ReturnCode::Dropped(_)) = code else {
                     unreachable!()
                 };
 
                 _ = tx.send(HostResult {
                     buffer,
-                    closed: false,
+                    dropped: false,
                 });
             }
 
-            ReadState::Closed => {
+            ReadState::Dropped => {
                 _ = tx.send(HostResult {
                     buffer,
-                    closed: true,
+                    dropped: true,
                 });
             }
         }
 
-        if let PostWrite::Close = post_write {
-            store[self.id()].host_close_writer(transmit_rep, kind)?;
+        if let PostWrite::Drop = post_write {
+            store[self.id()].host_drop_writer(transmit_rep, kind)?;
         }
 
         Ok(())
@@ -1818,8 +1846,8 @@ impl Instance {
             .get_mut(transmit_id)
             .with_context(|| rep.to_string())?;
 
-        let new_state = if let WriteState::Closed = &transmit.write {
-            WriteState::Closed
+        let new_state = if let WriteState::Dropped = &transmit.write {
+            WriteState::Dropped
         } else {
             WriteState::Open
         };
@@ -1837,7 +1865,7 @@ impl Instance {
                 ty,
                 flat_abi: _,
                 options,
-                address,
+                source,
                 count,
                 handle,
                 post_write,
@@ -1850,13 +1878,13 @@ impl Instance {
                 let code = accept_writer::<T, B, U>(buffer, tx, kind)(Writer::Guest {
                     lift,
                     ty: payload(ty, &types),
-                    address,
+                    source,
                     count,
                 })?;
 
                 let instance = &mut store[self.id()];
-                let pending = if let PostWrite::Close = post_write {
-                    instance.get_mut(transmit_id)?.write = WriteState::Closed;
+                let pending = if let PostWrite::Drop = post_write {
+                    instance.get_mut(transmit_id)?.write = WriteState::Dropped;
                     false
                 } else {
                     true
@@ -1887,22 +1915,22 @@ impl Instance {
                             buffer.move_from(input, count);
                             _ = tx.send(HostResult {
                                 buffer,
-                                closed: false,
+                                dropped: false,
                             });
                             count
                         }),
                     },
                 )?;
 
-                if let PostWrite::Close = post_write {
-                    store[self.id()].get_mut(transmit_id)?.write = WriteState::Closed;
+                if let PostWrite::Drop = post_write {
+                    store[self.id()].get_mut(transmit_id)?.write = WriteState::Dropped;
                 }
             }
 
-            WriteState::Closed => {
+            WriteState::Dropped => {
                 _ = tx.send(HostResult {
                     buffer,
-                    closed: true,
+                    dropped: true,
                 });
             }
         }
@@ -1910,13 +1938,13 @@ impl Instance {
         Ok(())
     }
 
-    /// Close the read end of a stream or future read from the host.
+    /// Drop the read end of a stream or future read from the host.
     ///
     /// # Arguments
     ///
     /// * `store` - The store to which this instance belongs
     /// * `transmit_rep` - The `TransmitState` rep for the stream or future.
-    fn host_close_reader(
+    fn host_drop_reader(
         self,
         store: &mut dyn VMStore,
         transmit_rep: u32,
@@ -1928,13 +1956,13 @@ impl Instance {
             .get_mut(transmit_id)
             .with_context(|| format!("error closing reader {transmit_rep}"))?;
 
-        transmit.read = ReadState::Closed;
+        transmit.read = ReadState::Dropped;
         transmit.reader_watcher = None;
 
-        // If the write end is already closed, it should stay closed,
+        // If the write end is already dropped, it should stay dropped,
         // otherwise, it should be opened.
-        let new_state = if let WriteState::Closed = &transmit.write {
-            WriteState::Closed
+        let new_state = if let WriteState::Dropped = &transmit.write {
+            WriteState::Dropped
         } else {
             WriteState::Open
         };
@@ -1943,25 +1971,25 @@ impl Instance {
 
         match mem::replace(&mut transmit.write, new_state) {
             // If a guest is waiting to write, notify it that the read end has
-            // been closed.
+            // been dropped.
             WriteState::GuestReady {
                 ty,
                 handle,
                 post_write,
                 ..
             } => {
-                if let PostWrite::Close = post_write {
+                if let PostWrite::Drop = post_write {
                     instance.delete_transmit(transmit_id)?;
                 } else {
                     instance.update_event(
                         write_handle.rep(),
                         match ty {
                             TableIndex::Future(ty) => Event::FutureWrite {
-                                code: ReturnCode::Closed(0),
+                                code: ReturnCode::Dropped(0),
                                 pending: Some((ty, handle)),
                             },
                             TableIndex::Stream(ty) => Event::StreamWrite {
-                                code: ReturnCode::Closed(0),
+                                code: ReturnCode::Dropped(0),
                                 pending: Some((ty, handle)),
                             },
                         },
@@ -1978,19 +2006,19 @@ impl Instance {
                     write_handle.rep(),
                     match kind {
                         TransmitKind::Future => Event::FutureWrite {
-                            code: ReturnCode::Closed(0),
+                            code: ReturnCode::Dropped(0),
                             pending: None,
                         },
                         TransmitKind::Stream => Event::StreamWrite {
-                            code: ReturnCode::Closed(0),
+                            code: ReturnCode::Dropped(0),
                             pending: None,
                         },
                     },
                 )?;
             }
 
-            WriteState::Closed => {
-                log::trace!("host_close_reader delete {transmit_rep}");
+            WriteState::Dropped => {
+                log::trace!("host_drop_reader delete {transmit_rep}");
                 instance.delete_transmit(transmit_id)?;
             }
         }
@@ -2005,7 +2033,7 @@ impl Instance {
         flat_abi: Option<FlatAbi>,
         write_ty: TableIndex,
         write_options: &Options,
-        write_address: usize,
+        write_source: &WriteSource,
         read_ty: TableIndex,
         read_options: &Options,
         read_address: usize,
@@ -2021,26 +2049,31 @@ impl Instance {
                     .payload
                     .map(|ty| {
                         let abi = types.canonical_abi(&ty);
-                        // FIXME: needs to read an i64 for memory64
-                        if write_address % usize::try_from(abi.align32)? != 0 {
-                            bail!("write pointer not aligned");
-                        }
-
                         let lift = &mut LiftContext::new(
                             store.0.store_opaque_mut(),
                             write_options,
                             &types,
                             self,
                         );
-                        let bytes = lift
-                            .memory()
-                            .get(write_address..)
-                            .and_then(|b| b.get(..usize::try_from(abi.size32).unwrap()))
-                            .ok_or_else(|| {
-                                anyhow::anyhow!("write pointer out of bounds of memory")
-                            })?;
+                        match write_source {
+                            WriteSource::Indirect(write_address) => {
+                                let write_address = *write_address;
+                                // FIXME: needs to read an i64 for memory64
+                                if write_address % usize::try_from(abi.align32)? != 0 {
+                                    bail!("write pointer not aligned");
+                                }
+                                let bytes = lift
+                                    .memory()
+                                    .get(write_address..)
+                                    .and_then(|b| b.get(..usize::try_from(abi.size32).unwrap()))
+                                    .ok_or_else(|| {
+                                        anyhow::anyhow!("write pointer out of bounds of memory")
+                                    })?;
 
-                        Val::load(lift, ty, bytes)
+                                Val::load(lift, ty, bytes)
+                            }
+                            WriteSource::Flat(flat) => Val::lift(lift, ty, &mut flat.iter()),
+                        }
                     })
                     .transpose()?;
 
@@ -2057,6 +2090,10 @@ impl Instance {
                 }
             }
             (TableIndex::Stream(write_ty), TableIndex::Stream(read_ty)) => {
+                let WriteSource::Indirect(write_address) = write_source else {
+                    unreachable!();
+                };
+                let write_address = *write_address;
                 if let Some(flat_abi) = flat_abi {
                     // Fast path memcpy for "flat" (i.e. no pointers or handles) payloads:
                     let length_in_bytes = usize::try_from(flat_abi.size).unwrap() * count;
@@ -2154,14 +2191,13 @@ impl Instance {
         ty: TableIndex,
         flat_abi: Option<FlatAbi>,
         handle: u32,
-        address: u32,
+        source: WriteSource,
         count: u32,
     ) -> Result<ReturnCode> {
         if !async_ {
             bail!("synchronous stream and future writes not yet supported");
         }
 
-        let address = usize::try_from(address).unwrap();
         let count = usize::try_from(count).unwrap();
         // SAFETY: Per this function's contract, `memory` and `realloc` are
         // valid.
@@ -2189,21 +2225,21 @@ impl Instance {
         let transmit_id = instance.get(transmit_handle)?.state;
         log::trace!("guest_write {transmit_handle:?} (handle {handle}; state {transmit_id:?})",);
         let transmit = instance.get_mut(transmit_id)?;
-        transmit.may_close_writer = true;
-        let new_state = if let ReadState::Closed = &transmit.read {
-            ReadState::Closed
+        transmit.may_drop_writer = true;
+        let new_state = if let ReadState::Dropped = &transmit.read {
+            ReadState::Dropped
         } else {
             ReadState::Open
         };
 
-        let set_guest_ready = |me: &mut ComponentInstance| {
+        let set_guest_ready = |me: &mut ComponentInstance, source| {
             let transmit = me.get_mut(transmit_id)?;
             assert!(matches!(&transmit.write, WriteState::Open));
             transmit.write = WriteState::GuestReady {
                 ty,
                 flat_abi,
                 options,
-                address,
+                source,
                 count,
                 handle,
                 post_write: PostWrite::Continue,
@@ -2256,7 +2292,7 @@ impl Instance {
                     flat_abi,
                     ty,
                     &options,
-                    address,
+                    &source,
                     read_ty,
                     &read_options,
                     read_address,
@@ -2277,7 +2313,7 @@ impl Instance {
                         count
                     };
 
-                    let code = ReturnCode::completed_or_closed(ty.kind(), total);
+                    let code = ReturnCode::completed_or_dropped(ty.kind(), total);
 
                     instance.set_event(
                         read_handle_rep,
@@ -2311,9 +2347,9 @@ impl Instance {
                 }
 
                 if write_complete {
-                    ReturnCode::completed_or_closed(ty.kind(), count.try_into().unwrap())
+                    ReturnCode::completed_or_dropped(ty.kind(), count.try_into().unwrap())
                 } else {
-                    set_guest_ready(instance)?;
+                    set_guest_ready(instance, source)?;
                     ReturnCode::Blocked
                 }
             }
@@ -2325,17 +2361,17 @@ impl Instance {
                 accept(Writer::Guest {
                     lift,
                     ty: payload(ty, &types),
-                    address,
+                    source,
                     count,
                 })?
             }
 
             ReadState::Open => {
-                set_guest_ready(instance)?;
+                set_guest_ready(instance, source)?;
                 ReturnCode::Blocked
             }
 
-            ReadState::Closed => ReturnCode::Closed(0),
+            ReadState::Dropped => ReturnCode::Dropped(0),
         };
 
         if result != ReturnCode::Blocked {
@@ -2393,8 +2429,8 @@ impl Instance {
         let transmit_id = instance.get(transmit_handle)?.state;
         log::trace!("guest_read {transmit_handle:?} (handle {handle}; state {transmit_id:?})",);
         let transmit = instance.get_mut(transmit_id)?;
-        let new_state = if let WriteState::Closed = &transmit.write {
-            WriteState::Closed
+        let new_state = if let WriteState::Dropped = &transmit.write {
+            WriteState::Dropped
         } else {
             WriteState::Open
         };
@@ -2418,7 +2454,7 @@ impl Instance {
                 ty: write_ty,
                 flat_abi: write_flat_abi,
                 options: write_options,
-                address: write_address,
+                source: write_source,
                 count: write_count,
                 handle: write_handle,
                 post_write,
@@ -2444,7 +2480,7 @@ impl Instance {
                     flat_abi,
                     write_ty,
                     &write_options,
-                    write_address,
+                    &write_source,
                     ty,
                     &options,
                     address,
@@ -2453,8 +2489,8 @@ impl Instance {
                 )?;
 
                 let instance = &mut store[self.id()];
-                let pending = if let PostWrite::Close = post_write {
-                    instance.get_mut(transmit_id)?.write = WriteState::Closed;
+                let pending = if let PostWrite::Drop = post_write {
+                    instance.get_mut(transmit_id)?.write = WriteState::Dropped;
                     false
                 } else {
                     true
@@ -2472,7 +2508,7 @@ impl Instance {
                         count
                     };
 
-                    let code = ReturnCode::completed_or_closed(ty.kind(), total);
+                    let code = ReturnCode::completed_or_dropped(ty.kind(), total);
 
                     instance.set_event(
                         write_handle_rep,
@@ -2490,6 +2526,9 @@ impl Instance {
                 }
 
                 if write_buffer_remaining {
+                    let WriteSource::Indirect(write_address) = write_source else {
+                        unreachable!();
+                    };
                     let types = instance.component().types();
                     let item_size = payload(ty, types)
                         .map(|ty| usize::try_from(types.canonical_abi(&ty).size32).unwrap())
@@ -2499,7 +2538,7 @@ impl Instance {
                         ty: write_ty,
                         flat_abi: write_flat_abi,
                         options: write_options,
-                        address: write_address + (count * item_size),
+                        source: WriteSource::Indirect(write_address + (count * item_size)),
                         count: write_count - count,
                         handle: write_handle,
                         post_write,
@@ -2507,7 +2546,7 @@ impl Instance {
                 }
 
                 if read_complete {
-                    ReturnCode::completed_or_closed(ty.kind(), count.try_into().unwrap())
+                    ReturnCode::completed_or_dropped(ty.kind(), count.try_into().unwrap())
                 } else {
                     set_guest_ready(instance)?;
                     ReturnCode::Blocked
@@ -2526,8 +2565,8 @@ impl Instance {
                     },
                 )?;
 
-                if let PostWrite::Close = post_write {
-                    store[self.id()].get_mut(transmit_id)?.write = WriteState::Closed;
+                if let PostWrite::Drop = post_write {
+                    store[self.id()].get_mut(transmit_id)?.write = WriteState::Dropped;
                 }
 
                 code
@@ -2538,7 +2577,7 @@ impl Instance {
                 ReturnCode::Blocked
             }
 
-            WriteState::Closed => ReturnCode::Closed(0),
+            WriteState::Dropped => ReturnCode::Dropped(0),
         };
 
         if result != ReturnCode::Blocked {
@@ -2548,8 +2587,8 @@ impl Instance {
         Ok(result)
     }
 
-    /// Close the readable end of the specified stream or future from the guest.
-    fn guest_close_readable(
+    /// Drop the readable end of the specified stream or future from the guest.
+    fn guest_drop_readable(
         self,
         store: &mut dyn VMStore,
         ty: TableIndex,
@@ -2567,14 +2606,14 @@ impl Instance {
         match state {
             StreamFutureState::Read => {}
             StreamFutureState::Write => {
-                bail!("passed write end to `{{stream|future}}.close-readable`")
+                bail!("passed write end to `{{stream|future}}.drop-readable`")
             }
             StreamFutureState::Busy => bail!("cannot drop busy stream or future"),
         }
         let id = TableId::<TransmitHandle>::new(rep);
         let rep = instance.get(id)?.state.rep();
-        log::trace!("guest_close_readable: close reader {id:?}");
-        self.host_close_reader(store, rep, kind)
+        log::trace!("guest_drop_readable: drop reader {id:?}");
+        self.host_drop_reader(store, rep, kind)
     }
 
     /// Create a new error context for the given component.
@@ -2713,24 +2752,24 @@ impl Instance {
         Ok(())
     }
 
-    /// Implements the `future.close-readable` intrinsic.
-    pub(crate) fn future_close_readable(
+    /// Implements the `future.drop-readable` intrinsic.
+    pub(crate) fn future_drop_readable(
         self,
         store: &mut dyn VMStore,
         ty: TypeFutureTableIndex,
         reader: u32,
     ) -> Result<()> {
-        self.guest_close_readable(store, TableIndex::Future(ty), reader)
+        self.guest_drop_readable(store, TableIndex::Future(ty), reader)
     }
 
-    /// Implements the `stream.close-readable` intrinsic.
-    pub(crate) fn stream_close_readable(
+    /// Implements the `stream.drop-readable` intrinsic.
+    pub(crate) fn stream_drop_readable(
         self,
         store: &mut dyn VMStore,
         ty: TypeStreamTableIndex,
         reader: u32,
     ) -> Result<()> {
-        self.guest_close_readable(store, TableIndex::Stream(ty), reader)
+        self.guest_drop_readable(store, TableIndex::Stream(ty), reader)
     }
 }
 
@@ -2783,7 +2822,7 @@ impl ComponentInstance {
     /// the `pending` field if applicable.
     // TODO: This is a bit awkward due to how
     // `Event::{Stream,Future}{Write,Read}` and
-    // `ReturnCode::{Completed,Closed,Cancelled}` are currently represented.
+    // `ReturnCode::{Completed,Dropped,Cancelled}` are currently represented.
     // Consider updating those representations in a way that allows this
     // function to be simplified.
     fn update_event(&mut self, waitable: u32, event: Event) -> Result<()> {
@@ -2791,14 +2830,14 @@ impl ComponentInstance {
 
         fn update_code(old: ReturnCode, new: ReturnCode) -> ReturnCode {
             let (ReturnCode::Completed(count)
-            | ReturnCode::Closed(count)
+            | ReturnCode::Dropped(count)
             | ReturnCode::Cancelled(count)) = old
             else {
                 unreachable!()
             };
 
             match new {
-                ReturnCode::Closed(0) => ReturnCode::Closed(count),
+                ReturnCode::Dropped(0) => ReturnCode::Dropped(count),
                 ReturnCode::Cancelled(0) => ReturnCode::Cancelled(count),
                 _ => unreachable!(),
             }
@@ -2876,7 +2915,7 @@ impl ComponentInstance {
         state.read_handle = read;
 
         if let TransmitKind::Future = kind {
-            state.may_close_writer = false;
+            state.may_drop_writer = false;
         }
 
         log::trace!("new transmit: state {state_id:?}; write {write:?}; read {read:?}",);
@@ -2942,7 +2981,7 @@ impl ComponentInstance {
             };
             match code {
                 ReturnCode::Completed(count) => ReturnCode::Cancelled(count),
-                ReturnCode::Closed(_) => code,
+                ReturnCode::Dropped(_) => code,
                 _ => unreachable!(),
             }
         } else {
@@ -2956,13 +2995,13 @@ impl ComponentInstance {
                 transmit.write = WriteState::Open;
             }
 
-            WriteState::Open | WriteState::Closed => {}
+            WriteState::Open | WriteState::Dropped => {}
         }
 
         log::trace!("cancelled write {transmit_id:?}");
 
         if let (TransmitKind::Future, ReturnCode::Cancelled(0)) = (kind, code) {
-            transmit.may_close_writer = false;
+            transmit.may_drop_writer = false;
         }
 
         Ok(code)
@@ -2983,7 +3022,7 @@ impl ComponentInstance {
             };
             match code {
                 ReturnCode::Completed(count) => ReturnCode::Cancelled(count),
-                ReturnCode::Closed(_) => code,
+                ReturnCode::Dropped(_) => code,
                 _ => unreachable!(),
             }
         } else {
@@ -2997,7 +3036,7 @@ impl ComponentInstance {
                 transmit.read = ReadState::Open;
             }
 
-            ReadState::Open | ReadState::Closed => {}
+            ReadState::Open | ReadState::Dropped => {}
         }
 
         log::trace!("cancelled read {transmit_id:?}");
@@ -3005,19 +3044,19 @@ impl ComponentInstance {
         Ok(code)
     }
 
-    /// Close the write end of a stream or future read from the host.
+    /// Drop the write end of a stream or future read from the host.
     ///
     /// # Arguments
     ///
     /// * `transmit_rep` - The `TransmitState` rep for the stream or future.
-    fn host_close_writer(&mut self, transmit_rep: u32, kind: TransmitKind) -> Result<()> {
+    fn host_drop_writer(&mut self, transmit_rep: u32, kind: TransmitKind) -> Result<()> {
         let transmit_id = TableId::<TransmitState>::new(transmit_rep);
         let transmit = self
             .get_mut(transmit_id)
             .with_context(|| format!("error closing writer {transmit_rep}"))?;
 
-        if !transmit.may_close_writer {
-            bail!("cannot close future write end without first writing a value")
+        if !transmit.may_drop_writer {
+            bail!("cannot drop future write end without first writing a value")
         }
 
         transmit.writer_watcher = None;
@@ -3025,24 +3064,24 @@ impl ComponentInstance {
         // Existing queued transmits must be updated with information for the impending writer closure
         match &mut transmit.write {
             WriteState::GuestReady { post_write, .. } => {
-                *post_write = PostWrite::Close;
+                *post_write = PostWrite::Drop;
             }
             WriteState::HostReady { post_write, .. } => {
-                *post_write = PostWrite::Close;
+                *post_write = PostWrite::Drop;
             }
             v @ WriteState::Open => {
-                *v = WriteState::Closed;
+                *v = WriteState::Dropped;
             }
-            WriteState::Closed => unreachable!("write state is already closed"),
+            WriteState::Dropped => unreachable!("write state is already dropped"),
         }
 
-        // If the existing read state is closed, then there's nothing to read
+        // If the existing read state is dropped, then there's nothing to read
         // and we can keep it that way.
         //
         // If the read state was any other state, then we must set the new state to open
         // to indicate that there *is* data to be read
-        let new_state = if let ReadState::Closed = &transmit.read {
-            ReadState::Closed
+        let new_state = if let ReadState::Dropped = &transmit.read {
+            ReadState::Dropped
         } else {
             ReadState::Open
         };
@@ -3051,7 +3090,7 @@ impl ComponentInstance {
 
         // Swap in the new read state
         match mem::replace(&mut transmit.read, new_state) {
-            // If the guest was ready to read, then we cannot close the reader (or writer)
+            // If the guest was ready to read, then we cannot drop the reader (or writer)
             // we must deliver the event, and update the state associated with the handle to
             // represent that a read must be performed
             ReadState::GuestReady { ty, handle, .. } => {
@@ -3060,18 +3099,18 @@ impl ComponentInstance {
                     read_handle.rep(),
                     match ty {
                         TableIndex::Future(ty) => Event::FutureRead {
-                            code: ReturnCode::Closed(0),
+                            code: ReturnCode::Dropped(0),
                             pending: Some((ty, handle)),
                         },
                         TableIndex::Stream(ty) => Event::StreamRead {
-                            code: ReturnCode::Closed(0),
+                            code: ReturnCode::Dropped(0),
                             pending: Some((ty, handle)),
                         },
                     },
                 )?;
             }
 
-            // If the host was ready to read, and the writer end is being closed (host->host write?)
+            // If the host was ready to read, and the writer end is being dropped (host->host write?)
             // signal to the reader that we've reached the end of the stream
             ReadState::HostReady { accept } => {
                 accept(Writer::End)?;
@@ -3083,21 +3122,21 @@ impl ComponentInstance {
                     read_handle.rep(),
                     match kind {
                         TransmitKind::Future => Event::FutureRead {
-                            code: ReturnCode::Closed(0),
+                            code: ReturnCode::Dropped(0),
                             pending: None,
                         },
                         TransmitKind::Stream => Event::StreamRead {
-                            code: ReturnCode::Closed(0),
+                            code: ReturnCode::Dropped(0),
                             pending: None,
                         },
                     },
                 )?;
             }
 
-            // If the read state was already closed, then we can remove the transmit state completely
-            // (both writer and reader have been closed)
-            ReadState::Closed => {
-                log::trace!("host_close_writer delete {transmit_rep}");
+            // If the read state was already dropped, then we can remove the transmit state completely
+            // (both writer and reader have been dropped)
+            ReadState::Dropped => {
+                log::trace!("host_drop_writer delete {transmit_rep}");
                 self.delete_transmit(transmit_id)?;
             }
         }
@@ -3163,8 +3202,8 @@ impl ComponentInstance {
         self.host_cancel_read(rep)
     }
 
-    /// Close the writable end of the specified stream or future from the guest.
-    fn guest_close_writable(&mut self, ty: TableIndex, writer: u32) -> Result<()> {
+    /// Drop the writable end of the specified stream or future from the guest.
+    fn guest_drop_writable(&mut self, ty: TableIndex, writer: u32) -> Result<()> {
         let (transmit_rep, state) = self
             .state_table(ty)
             .remove_by_index(writer)
@@ -3179,7 +3218,7 @@ impl ComponentInstance {
         match state {
             StreamFutureState::Write => {}
             StreamFutureState::Read => {
-                bail!("passed read end to `{{stream|future}}.close-writable`")
+                bail!("passed read end to `{{stream|future}}.drop-writable`")
             }
             StreamFutureState::Busy => bail!("cannot drop busy stream or future"),
         }
@@ -3188,7 +3227,7 @@ impl ComponentInstance {
             .get(TableId::<TransmitHandle>::new(transmit_rep))?
             .state
             .rep();
-        self.host_close_writer(transmit_rep, kind)
+        self.host_drop_writer(transmit_rep, kind)
     }
 
     /// Drop the specified error context.
@@ -3303,13 +3342,13 @@ impl ComponentInstance {
             .map(|result| result.encode())
     }
 
-    /// Implements the `future.close-writable` intrinsic.
-    pub(crate) fn future_close_writable(
+    /// Implements the `future.drop-writable` intrinsic.
+    pub(crate) fn future_drop_writable(
         &mut self,
         ty: TypeFutureTableIndex,
         writer: u32,
     ) -> Result<()> {
-        self.guest_close_writable(TableIndex::Future(ty), writer)
+        self.guest_drop_writable(TableIndex::Future(ty), writer)
     }
 
     /// Implements the `stream.new` intrinsic.
@@ -3339,13 +3378,13 @@ impl ComponentInstance {
             .map(|result| result.encode())
     }
 
-    /// Implements the `stream.close-writable` intrinsic.
-    pub(crate) fn stream_close_writable(
+    /// Implements the `stream.drop-writable` intrinsic.
+    pub(crate) fn stream_drop_writable(
         &mut self,
         ty: TypeStreamTableIndex,
         writer: u32,
     ) -> Result<()> {
-        self.guest_close_writable(TableIndex::Stream(ty), writer)
+        self.guest_drop_writable(TableIndex::Stream(ty), writer)
     }
 
     /// Transfer ownership of the specified future read end from one guest to

--- a/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams/buffers.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams/buffers.rs
@@ -70,9 +70,7 @@ unsafe impl<T: Send + Sync + 'static> TakeBuffer for Option<T> {
 impl<T: Send + Sync + 'static> WriteBuffer<T> for Option<T> {
     fn remaining(&self) -> &[T] {
         if let Some(me) = self {
-            // SAFETY: This effectively transmutes a `&T` to a `&[T; 1]`, which
-            // should be sound.
-            unsafe { slice::from_raw_parts(me, 1) }
+            slice::from_ref(me)
         } else {
             &[]
         }

--- a/crates/wasmtime/src/runtime/vm/component/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/component/libcalls.rs
@@ -940,7 +940,8 @@ unsafe fn future_write(
     async_: u8,
     ty: u32,
     future: u32,
-    address: u32,
+    storage: *mut u8,
+    storage_len: usize,
 ) -> Result<u32> {
     store.component_async_store().future_write(
         instance,
@@ -950,7 +951,8 @@ unsafe fn future_write(
         async_ != 0,
         wasmtime_environ::component::TypeFutureTableIndex::from_u32(ty),
         future,
-        address,
+        storage.cast::<crate::ValRaw>(),
+        storage_len,
     )
 }
 
@@ -1009,26 +1011,26 @@ fn future_cancel_read(
 }
 
 #[cfg(feature = "component-model-async")]
-fn future_close_writable(
+fn future_drop_writable(
     store: &mut dyn VMStore,
     instance: Instance,
     ty: u32,
     writer: u32,
 ) -> Result<()> {
-    store[instance.id()].future_close_writable(
+    store[instance.id()].future_drop_writable(
         wasmtime_environ::component::TypeFutureTableIndex::from_u32(ty),
         writer,
     )
 }
 
 #[cfg(feature = "component-model-async")]
-fn future_close_readable(
+fn future_drop_readable(
     store: &mut dyn VMStore,
     instance: Instance,
     ty: u32,
     reader: u32,
 ) -> Result<()> {
-    instance.future_close_readable(
+    instance.future_drop_readable(
         store,
         wasmtime_environ::component::TypeFutureTableIndex::from_u32(ty),
         reader,
@@ -1125,26 +1127,26 @@ fn stream_cancel_read(
 }
 
 #[cfg(feature = "component-model-async")]
-fn stream_close_writable(
+fn stream_drop_writable(
     store: &mut dyn VMStore,
     instance: Instance,
     ty: u32,
     writer: u32,
 ) -> Result<()> {
-    store[instance.id()].stream_close_writable(
+    store[instance.id()].stream_drop_writable(
         wasmtime_environ::component::TypeStreamTableIndex::from_u32(ty),
         writer,
     )
 }
 
 #[cfg(feature = "component-model-async")]
-fn stream_close_readable(
+fn stream_drop_readable(
     store: &mut dyn VMStore,
     instance: Instance,
     ty: u32,
     reader: u32,
 ) -> Result<()> {
-    instance.stream_close_readable(
+    instance.stream_drop_readable(
         store,
         wasmtime_environ::component::TypeStreamTableIndex::from_u32(ty),
         reader,

--- a/tests/misc_testsuite/component-model-async/cancel-stream.wast
+++ b/tests/misc_testsuite/component-model-async/cancel-stream.wast
@@ -19,7 +19,7 @@
       (import "" "stream.new" (func $stream.new (result i64)))
       (import "" "stream.write" (func $stream.write (param i32 i32 i32) (result i32)))
       (import "" "stream.cancel-write" (func $stream.cancel-write (param i32) (result i32)))
-      (import "" "stream.close-writable" (func $stream.close-writable (param i32)))
+      (import "" "stream.drop-writable" (func $stream.drop-writable (param i32)))
 
       (global $sw (mut i32) (i32.const 0))
 
@@ -40,9 +40,9 @@
           (then unreachable))
       )
 
-      (func $write4-and-close (export "write4-and-close")
+      (func $write4-and-drop (export "write4-and-drop")
         (call $write4)
-        (call $stream.close-writable (global.get $sw))
+        (call $stream.drop-writable (global.get $sw))
       )
 
       (func $start-blocking-write (export "start-blocking-write")
@@ -77,18 +77,18 @@
     (canon stream.new $ST (core func $stream.new))
     (canon stream.write $ST async (memory $memory "mem") (core func $stream.write))
     (canon stream.cancel-write $ST (core func $stream.cancel-write))
-    (canon stream.close-writable $ST (core func $stream.close-writable))
+    (canon stream.drop-writable $ST (core func $stream.drop-writable))
     (core instance $cm (instantiate $CM (with "" (instance
       (export "mem" (memory $memory "mem"))
       (export "task.return" (func $task.return))
       (export "stream.new" (func $stream.new))
       (export "stream.write" (func $stream.write))
       (export "stream.cancel-write" (func $stream.cancel-write))
-      (export "stream.close-writable" (func $stream.close-writable))
+      (export "stream.drop-writable" (func $stream.drop-writable))
     ))))
     (func (export "start-stream") (result (stream u8)) (canon lift (core func $cm "start-stream")))
     (func (export "write4") (canon lift (core func $cm "write4")))
-    (func (export "write4-and-close") (canon lift (core func $cm "write4-and-close")))
+    (func (export "write4-and-drop") (canon lift (core func $cm "write4-and-drop")))
     (func (export "start-blocking-write") (canon lift (core func $cm "start-blocking-write")))
     (func (export "cancel-after-read4") (canon lift (core func $cm "cancel-after-read4")))
   )
@@ -97,7 +97,7 @@
     (import "c" (instance $c
       (export "start-stream" (func (result (stream u8))))
       (export "write4" (func))
-      (export "write4-and-close" (func))
+      (export "write4-and-drop" (func))
       (export "start-blocking-write" (func))
       (export "cancel-after-read4" (func))
     ))
@@ -108,10 +108,10 @@
       (import "" "mem" (memory 1))
       (import "" "stream.read" (func $stream.read (param i32 i32 i32) (result i32)))
       (import "" "stream.cancel-read" (func $stream.cancel-read (param i32) (result i32)))
-      (import "" "stream.close-readable" (func $stream.close-readable (param i32)))
+      (import "" "stream.drop-readable" (func $stream.drop-readable (param i32)))
       (import "" "start-stream" (func $start-stream (result i32)))
       (import "" "write4" (func $write4))
-      (import "" "write4-and-close" (func $write4-and-close))
+      (import "" "write4-and-drop" (func $write4-and-drop))
       (import "" "start-blocking-write" (func $start-blocking-write))
       (import "" "cancel-after-read4" (func $cancel-after-read4))
 
@@ -146,18 +146,18 @@
         (if (i32.ne (i32.const 0xabcd) (i32.load (i32.const 8)))
           (then unreachable))
 
-        ;; read, block, call $C to write 4 bytes into the buffer and close,
-        ;; then cancel, which should show "4+closed"
+        ;; read, block, call $C to write 4 bytes into the buffer and drop,
+        ;; then cancel, which should show "4+dropped"
         (local.set $ret (call $stream.read (local.get $sr) (i32.const 8) (i32.const 100)))
         (if (i32.ne (i32.const -1 (; BLOCKED;)) (local.get $ret))
           (then unreachable))
-        (call $write4-and-close)
+        (call $write4-and-drop)
         (local.set $ret (call $stream.cancel-read (local.get $sr)))
-        (if (i32.ne (i32.const 0x41 (; CLOSED=1 | (4<<4) ;)) (local.get $ret))
+        (if (i32.ne (i32.const 0x41 (; DROPPED=1 | (4<<4) ;)) (local.get $ret))
           (then unreachable))
         (if (i32.ne (i32.const 0xabcd) (i32.load (i32.const 8)))
           (then unreachable))
-        (call $stream.close-readable (local.get $sr))
+        (call $stream.drop-readable (local.get $sr))
 
         ;; get a new $sr
         (local.set $sr (call $start-stream))
@@ -181,20 +181,20 @@
     (type $ST (stream u8))
     (canon stream.read $ST async (memory $memory "mem") (core func $stream.read))
     (canon stream.cancel-read $ST (core func $stream.cancel-read))
-    (canon stream.close-readable $ST (core func $stream.close-readable))
+    (canon stream.drop-readable $ST (core func $stream.drop-readable))
     (canon lower (func $c "start-stream") (core func $start-stream'))
     (canon lower (func $c "write4") (core func $write4'))
-    (canon lower (func $c "write4-and-close") (core func $write4-and-close'))
+    (canon lower (func $c "write4-and-drop") (core func $write4-and-drop'))
     (canon lower (func $c "start-blocking-write") (core func $start-blocking-write'))
     (canon lower (func $c "cancel-after-read4") (core func $cancel-after-read4'))
     (core instance $dm (instantiate $DM (with "" (instance
       (export "mem" (memory $memory "mem"))
       (export "stream.read" (func $stream.read))
       (export "stream.cancel-read" (func $stream.cancel-read))
-      (export "stream.close-readable" (func $stream.close-readable))
+      (export "stream.drop-readable" (func $stream.drop-readable))
       (export "start-stream" (func $start-stream'))
       (export "write4" (func $write4'))
-      (export "write4-and-close" (func $write4-and-close'))
+      (export "write4-and-drop" (func $write4-and-drop'))
       (export "start-blocking-write" (func $start-blocking-write'))
       (export "cancel-after-read4" (func $cancel-after-read4'))
     ))))

--- a/tests/misc_testsuite/component-model-async/empty-wait.wast
+++ b/tests/misc_testsuite/component-model-async/empty-wait.wast
@@ -21,10 +21,10 @@
       (import "" "waitable-set.new" (func $waitable-set.new (result i32)))
       (import "" "waitable-set.wait" (func $waitable-set.wait (param i32 i32) (result i32)))
       (import "" "future.new" (func $future.new (result i64)))
-      (import "" "future.read" (func $future.read (param i32 i32) (result i32)))
-      (import "" "future.write" (func $future.write (param i32 i32) (result i32)))
-      (import "" "future.close-readable" (func $future.close-readable (param i32)))
-      (import "" "future.close-writable" (func $future.close-writable (param i32)))
+      (import "" "future.read" (func $future.read (param i32) (result i32)))
+      (import "" "future.write" (func $future.write (param i32) (result i32)))
+      (import "" "future.drop-readable" (func $future.drop-readable (param i32)))
+      (import "" "future.drop-writable" (func $future.drop-writable (param i32)))
 
       ;; $ws is waited on by 'blocker' and added to by 'unblocker'
       (global $ws (mut i32) (i32.const 0))
@@ -47,7 +47,7 @@
         (if (i32.ne (i32.const 0x11) (local.get $payload))
           (then unreachable))
 
-        (call $future.close-readable (global.get $futr))
+        (call $future.drop-readable (global.get $futr))
 
         ;; return 42 to $D.run
         (call $task.return (i32.const 42))
@@ -69,17 +69,17 @@
 
         ;; perform a future.read which will block, and add this future to the waitable-set
         ;; being waited on by 'blocker'
-        (local.set $ret (call $future.read (global.get $futr) (i32.const 0xdeadbeef)))
+        (local.set $ret (call $future.read (global.get $futr)))
         (if (i32.ne (i32.const -1 (; BLOCKED ;)) (local.get $ret))
           (then unreachable))
         (call $waitable.join (global.get $futr) (global.get $ws))
 
         ;; perform a future.write which will rendezvous with the write and complete
-        (local.set $ret (call $future.write (local.get $futw) (i32.const 0xdeadbeef)))
+        (local.set $ret (call $future.write (local.get $futw)))
         (if (i32.ne (i32.const 0x11) (local.get $ret))
           (then unreachable))
 
-        (call $future.close-writable (local.get $futw))
+        (call $future.drop-writable (local.get $futw))
 
         ;; return 43 to $D.run
         (call $task.return (i32.const 43))
@@ -98,8 +98,8 @@
     (canon future.new $FT (core func $future.new))
     (canon future.read $FT async (memory $memory "mem") (core func $future.read))
     (canon future.write $FT async (memory $memory "mem") (core func $future.write))
-    (canon future.close-readable $FT (core func $future.close-readable))
-    (canon future.close-writable $FT (core func $future.close-writable))
+    (canon future.drop-readable $FT (core func $future.drop-readable))
+    (canon future.drop-writable $FT (core func $future.drop-writable))
     (core instance $cm (instantiate $CM (with "" (instance
       (export "mem" (memory $memory "mem"))
       (export "task.return" (func $task.return))
@@ -109,8 +109,8 @@
       (export "future.new" (func $future.new))
       (export "future.read" (func $future.read))
       (export "future.write" (func $future.write))
-      (export "future.close-readable" (func $future.close-readable))
-      (export "future.close-writable" (func $future.close-writable))
+      (export "future.drop-readable" (func $future.drop-readable))
+      (export "future.drop-writable" (func $future.drop-writable))
     ))))
     (func (export "blocker") (result u32) (canon lift
       (core func $cm "blocker")

--- a/tests/misc_testsuite/component-model-async/future-cancel-read-dropped.wast
+++ b/tests/misc_testsuite/component-model-async/future-cancel-read-dropped.wast
@@ -1,6 +1,6 @@
 ;;! component_model_async = true
 
-;; Create a future, start a read, close the write end, and cancel the read.
+;; Create a future, start a read, drop the write end, and cancel the read.
 (component
   (type $f (future))
   (core func $new (canon future.new $f))
@@ -9,13 +9,13 @@
   (core func $read (canon future.read $f async (memory $libc "mem")))
   (core func $cancel (canon future.cancel-read $f))
   (core func $write (canon future.write $f async (memory $libc "mem")))
-  (core func $close-write (canon future.close-writable $f))
+  (core func $drop-write (canon future.drop-writable $f))
   (core module $m
     (import "" "new" (func $new (result i64)))
-    (import "" "read" (func $read (param i32 i32) (result i32)))
+    (import "" "read" (func $read (param i32) (result i32)))
     (import "" "cancel" (func $cancel (param i32) (result i32)))
-    (import "" "write" (func $write (param i32 i32) (result i32)))
-    (import "" "close-write" (func $close-write (param i32)))
+    (import "" "write" (func $write (param i32) (result i32)))
+    (import "" "drop-write" (func $drop-write (param i32)))
 
     (func (export "f") (result i32)
       (local $read i32)
@@ -28,19 +28,17 @@
 
       ;; start a read
       local.get $read
-      i32.const 0
       call $read
       i32.const -1
       i32.ne
       if unreachable end
 
-      ;; close the write end
+      ;; drop the write end
       local.get $write
-      i32.const 0
       call $write
       drop
       local.get $write
-      call $close-write
+      call $drop-write
 
       ;; cancel the read, returning the result
       local.get $read
@@ -54,11 +52,11 @@
       (export "read" (func $read))
       (export "cancel" (func $cancel))
       (export "write" (func $write))
-      (export "close-write" (func $close-write))
+      (export "drop-write" (func $drop-write))
     ))
   ))
 
   (func (export "f") (result u32) (canon lift (core func $i "f")))
 )
 
-(assert_return (invoke "f") (u32.const 0x11)) ;; expect CLOSED status (not CANCELLED)
+(assert_return (invoke "f") (u32.const 0x11)) ;; expect DROPPED status (not CANCELLED)

--- a/tests/misc_testsuite/component-model-async/future-cancel-write-completed.wast
+++ b/tests/misc_testsuite/component-model-async/future-cancel-write-completed.wast
@@ -11,30 +11,29 @@
     (core module $libc (memory (export "mem") 1))
     (core instance $libc (instantiate $libc))
     (core func $read (canon future.read $f async (memory $libc "mem")))
-    (core func $close-read (canon future.close-readable $f))
+    (core func $drop-read (canon future.drop-readable $f))
     (core module $inner
-      (import "" "read" (func $read (param i32 i32) (result i32)))
-      (import "" "close-read" (func $close-read (param i32)))
+      (import "" "read" (func $read (param i32) (result i32)))
+      (import "" "drop-read" (func $drop-read (param i32)))
 
       (func (export "f") (param i32)
         ;; start a read, asserting it completes with one item
         local.get 0
-        i32.const 0
         call $read
         i32.const 0x11
         i32.ne
         if unreachable end
 
-        ;; close the read end
+        ;; drop the read end
         local.get 0
-        call $close-read
+        call $drop-read
       )
     )
 
     (core instance $i (instantiate $inner
       (with "" (instance
         (export "read" (func $read))
-        (export "close-read" (func $close-read))
+        (export "drop-read" (func $drop-read))
       ))
     ))
 
@@ -50,7 +49,7 @@
   (core func $drain (canon lower (func $c "f")))
   (core module $m
     (import "" "new" (func $new (result i64)))
-    (import "" "write" (func $write (param i32 i32) (result i32)))
+    (import "" "write" (func $write (param i32) (result i32)))
     (import "" "cancel" (func $cancel (param i32) (result i32)))
     (import "" "drain" (func $drain (param i32)))
 
@@ -65,7 +64,6 @@
 
       ;; start a write
       local.get $write
-      i32.const 0
       call $write
       i32.const -1
       i32.ne

--- a/tests/misc_testsuite/component-model-async/future-cancel-write-dropped.wast
+++ b/tests/misc_testsuite/component-model-async/future-cancel-write-dropped.wast
@@ -1,6 +1,6 @@
 ;;! component_model_async = true
 
-;; Create a future, start a write, close the read end, and cancel the write.
+;; Create a future, start a write, drop the read end, and cancel the write.
 (component
   (type $f (future))
   (core func $new (canon future.new $f))
@@ -8,12 +8,12 @@
   (core instance $libc (instantiate $libc))
   (core func $write (canon future.write $f async (memory $libc "mem")))
   (core func $cancel (canon future.cancel-write $f))
-  (core func $close-read (canon future.close-readable $f))
+  (core func $drop-read (canon future.drop-readable $f))
   (core module $m
     (import "" "new" (func $new (result i64)))
-    (import "" "write" (func $write (param i32 i32) (result i32)))
+    (import "" "write" (func $write (param i32) (result i32)))
     (import "" "cancel" (func $cancel (param i32) (result i32)))
-    (import "" "close-read" (func $close-read (param i32)))
+    (import "" "drop-read" (func $drop-read (param i32)))
 
     (func (export "f") (result i32)
       (local $read i32)
@@ -26,15 +26,14 @@
 
       ;; start a write
       local.get $write
-      i32.const 0
       call $write
       i32.const -1
       i32.ne
       if unreachable end
 
-      ;; close the read end
+      ;; drop the read end
       local.get $read
-      call $close-read
+      call $drop-read
 
       ;; cancel the write, returning the result
       local.get $write
@@ -47,11 +46,11 @@
       (export "new" (func $new))
       (export "write" (func $write))
       (export "cancel" (func $cancel))
-      (export "close-read" (func $close-read))
+      (export "drop-read" (func $drop-read))
     ))
   ))
 
   (func (export "f") (result u32) (canon lift (core func $i "f")))
 )
 
-(assert_return (invoke "f") (u32.const 1)) ;; expect CLOSED status (not CANCELLED)
+(assert_return (invoke "f") (u32.const 1)) ;; expect DROPPED status (not CANCELLED)

--- a/tests/misc_testsuite/component-model-async/future-read.wast
+++ b/tests/misc_testsuite/component-model-async/future-read.wast
@@ -13,10 +13,10 @@
     (core func $read (canon future.read $future (memory $libc "memory")))
 
     (core module $m
-      (import "" "read" (func $read (param i32 i32) (result i32)))
+      (import "" "read" (func $read (param i32) (result i32)))
 
       (func (export "run") (param $future i32)
-        (call $read (local.get $future) (i32.const 0))
+        (call $read (local.get $future))
         drop
       )
     )
@@ -65,10 +65,10 @@
     (core func $read (canon future.read $future (memory $libc "memory") async))
 
     (core module $m
-      (import "" "read" (func $read (param i32 i32) (result i32)))
+      (import "" "read" (func $read (param i32) (result i32)))
 
       (func (export "run") (param $future i32)
-        (call $read (local.get $future) (i32.const 0))
+        (call $read (local.get $future))
         drop
       )
     )
@@ -117,10 +117,10 @@
     (core func $read (canon future.read $future (memory $libc "memory")))
 
     (core module $m
-      (import "" "read" (func $read (param i32 i32) (result i32)))
+      (import "" "read" (func $read (param i32) (result i32)))
 
       (func (export "run") (param $future i32) (result i32)
-        (call $read (local.get $future) (i32.const 0))
+        (call $read (local.get $future))
         drop
         i32.const 0 ;; TODO
       )
@@ -174,11 +174,11 @@
     (core func $return (canon task.return))
 
     (core module $m
-      (import "" "read" (func $read (param i32 i32) (result i32)))
+      (import "" "read" (func $read (param i32) (result i32)))
       (import "" "return" (func $return))
 
       (func (export "run") (param $future i32) (result i32)
-        (call $read (local.get $future) (i32.const 0))
+        (call $read (local.get $future))
         drop
         call $return
         i32.const 0

--- a/tests/misc_testsuite/component-model-async/futures-must-write.wast
+++ b/tests/misc_testsuite/component-model-async/futures-must-write.wast
@@ -15,7 +15,7 @@
       (import "" "mem" (memory 1))
       (import "" "future.new" (func $future.new (result i64)))
       (import "" "future.write" (func $future.write (param i32 i32) (result i32)))
-      (import "" "future.close-writable" (func $future.close-writable (param i32)))
+      (import "" "future.drop-writable" (func $future.drop-writable (param i32)))
 
       (global $fw (mut i32) (i32.const 0))
 
@@ -27,11 +27,11 @@
         (i32.wrap_i64 (local.get $ret64))
       )
       (func $attempt-write (export "attempt-write") (result i32)
-        ;; because the caller already closed the readable end, this write will eagerly
-        ;; return CLOSED having written no values.
+        ;; because the caller already dropped the readable end, this write will eagerly
+        ;; return DROPPED having written no values.
         (local $ret i32)
         (local.set $ret (call $future.write (global.get $fw) (i32.const 42)))
-        (if (i32.ne (i32.const 0x01 (; CLOSED=1 | (0<<4) ;)) (local.get $ret))
+        (if (i32.ne (i32.const 0x01 (; DROPPED=1 | (0<<4) ;)) (local.get $ret))
           (then
             (i32.load (i32.add (local.get $ret) (i32.const 0x8000_0000)))
           unreachable))
@@ -39,30 +39,30 @@
         ;; return without trapping
         (i32.const 42)
       )
-      (func $close-writable (export "close-writable")
+      (func $drop-writable (export "drop-writable")
         ;; maybe boom
-        (call $future.close-writable (global.get $fw))
+        (call $future.drop-writable (global.get $fw))
       )
     )
     (type $FT (future u8))
     (canon future.new $FT (core func $future.new))
     (canon future.write $FT async (memory $memory "mem") (core func $future.write))
-    (canon future.close-writable $FT (core func $future.close-writable))
+    (canon future.drop-writable $FT (core func $future.drop-writable))
     (core instance $cm (instantiate $CM (with "" (instance
       (export "mem" (memory $memory "mem"))
       (export "future.new" (func $future.new))
       (export "future.write" (func $future.write))
-      (export "future.close-writable" (func $future.close-writable))
+      (export "future.drop-writable" (func $future.drop-writable))
     ))))
     (func (export "start-future") (result (future u8)) (canon lift (core func $cm "start-future")))
     (func (export "attempt-write") (result u32) (canon lift (core func $cm "attempt-write")))
-    (func (export "close-writable") (canon lift (core func $cm "close-writable")))
+    (func (export "drop-writable") (canon lift (core func $cm "drop-writable")))
   )
   (component $D
     (import "c" (instance $c
       (export "start-future" (func (result (future u8))))
       (export "attempt-write" (func (result u32)))
-      (export "close-writable" (func))
+      (export "drop-writable" (func))
     ))
 
     (core module $Memory (memory (export "mem") 1))
@@ -70,25 +70,25 @@
     (core module $Core
       (import "" "mem" (memory 1))
       (import "" "future.read" (func $future.read (param i32 i32) (result i32)))
-      (import "" "future.close-readable" (func $future.close-readable (param i32)))
+      (import "" "future.drop-readable" (func $future.drop-readable (param i32)))
       (import "" "start-future" (func $start-future (result i32)))
       (import "" "attempt-write" (func $attempt-write (result i32)))
-      (import "" "close-writable" (func $close-writable))
+      (import "" "drop-writable" (func $drop-writable))
 
-      (func $close-readable-future-before-read (export "close-readable-future-before-read") (result i32)
+      (func $drop-readable-future-before-read (export "drop-readable-future-before-read") (result i32)
         ;; call 'start-future' to get the future we'll be working with
         (local $fr i32)
         (local.set $fr (call $start-future))
         (if (i32.ne (i32.const 1) (local.get $fr))
           (then unreachable))
 
-        ;; ok to immediately close the readable end
-        (call $future.close-readable (local.get $fr))
+        ;; ok to immediately drop the readable end
+        (call $future.drop-readable (local.get $fr))
 
-        ;; the callee will see that we closed the readable end when it tries to write
+        ;; the callee will see that we dropped the readable end when it tries to write
         (call $attempt-write)
       )
-      (func $close-writable-future-before-write (export "close-writable-future-before-write")
+      (func $drop-writable-future-before-write (export "drop-writable-future-before-write")
         ;; call 'start-future' to get the future we'll be working with
         (local $fr i32)
         (local.set $fr (call $start-future))
@@ -96,33 +96,33 @@
           (then unreachable))
 
         ;; boom
-        (call $close-writable)
+        (call $drop-writable)
       )
     )
     (type $FT (future u8))
     (canon future.new $FT (core func $future.new))
     (canon future.read $FT async (memory $memory "mem") (core func $future.read))
-    (canon future.close-readable $FT (core func $future.close-readable))
+    (canon future.drop-readable $FT (core func $future.drop-readable))
     (canon lower (func $c "start-future") (core func $start-future'))
     (canon lower (func $c "attempt-write") (core func $attempt-write'))
-    (canon lower (func $c "close-writable") (core func $close-writable'))
+    (canon lower (func $c "drop-writable") (core func $drop-writable'))
     (core instance $core (instantiate $Core (with "" (instance
       (export "mem" (memory $memory "mem"))
       (export "future.new" (func $future.new))
       (export "future.read" (func $future.read))
-      (export "future.close-readable" (func $future.close-readable))
+      (export "future.drop-readable" (func $future.drop-readable))
       (export "start-future" (func $start-future'))
       (export "attempt-write" (func $attempt-write'))
-      (export "close-writable" (func $close-writable'))
+      (export "drop-writable" (func $drop-writable'))
     ))))
-    (func (export "close-readable-future-before-read") (result u32) (canon lift (core func $core "close-readable-future-before-read")))
-    (func (export "close-writable-future-before-write") (canon lift (core func $core "close-writable-future-before-write")))
+    (func (export "drop-readable-future-before-read") (result u32) (canon lift (core func $core "drop-readable-future-before-read")))
+    (func (export "drop-writable-future-before-write") (canon lift (core func $core "drop-writable-future-before-write")))
   )
   (instance $c (instantiate $C))
   (instance $d (instantiate $D (with "c" (instance $c))))
-  (func (export "close-writable-future-before-write") (alias export $d "close-writable-future-before-write"))
-  (func (export "close-readable-future-before-read") (alias export $d "close-readable-future-before-read"))
+  (func (export "drop-writable-future-before-write") (alias export $d "drop-writable-future-before-write"))
+  (func (export "drop-readable-future-before-read") (alias export $d "drop-readable-future-before-read"))
 )
 
-(assert_return (invoke "close-readable-future-before-read") (u32.const 42))
-(assert_trap (invoke "close-writable-future-before-write") "cannot close future write end without first writing a value")
+(assert_return (invoke "drop-readable-future-before-read") (u32.const 42))
+(assert_trap (invoke "drop-writable-future-before-write") "cannot drop future write end without first writing a value")

--- a/tests/misc_testsuite/component-model-async/futures.wast
+++ b/tests/misc_testsuite/component-model-async/futures.wast
@@ -70,22 +70,22 @@
   (core instance $i (instantiate $m (with "" (instance (export "future.cancel-write" (func $future-cancel-write))))))
 )
 
-;; future.close-readable
+;; future.drop-readable
 (component
   (core module $m
-    (import "" "future.close-readable" (func $future-close-readable (param i32)))
+    (import "" "future.drop-readable" (func $future-drop-readable (param i32)))
   )
   (type $future-type (future u8))
-  (core func $future-close-readable (canon future.close-readable $future-type))
-  (core instance $i (instantiate $m (with "" (instance (export "future.close-readable" (func $future-close-readable))))))
+  (core func $future-drop-readable (canon future.drop-readable $future-type))
+  (core instance $i (instantiate $m (with "" (instance (export "future.drop-readable" (func $future-drop-readable))))))
 )
 
-;; future.close-writable
+;; future.drop-writable
 (component
   (core module $m
-    (import "" "future.close-writable" (func $future-close-writable (param i32)))
+    (import "" "future.drop-writable" (func $future-drop-writable (param i32)))
   )
   (type $future-type (future u8))
-  (core func $future-close-writable (canon future.close-writable $future-type))
-  (core instance $i (instantiate $m (with "" (instance (export "future.close-writable" (func $future-close-writable))))))
+  (core func $future-drop-writable (canon future.drop-writable $future-type))
+  (core instance $i (instantiate $m (with "" (instance (export "future.drop-writable" (func $future-drop-writable))))))
 )

--- a/tests/misc_testsuite/component-model-async/streams.wast
+++ b/tests/misc_testsuite/component-model-async/streams.wast
@@ -70,22 +70,22 @@
   (core instance $i (instantiate $m (with "" (instance (export "stream.cancel-write" (func $stream-cancel-write))))))
 )
 
-;; stream.close-readable
+;; stream.drop-readable
 (component
   (core module $m
-    (import "" "stream.close-readable" (func $stream-close-readable (param i32)))
+    (import "" "stream.drop-readable" (func $stream-drop-readable (param i32)))
   )
   (type $stream-type (stream u8))
-  (core func $stream-close-readable (canon stream.close-readable $stream-type))
-  (core instance $i (instantiate $m (with "" (instance (export "stream.close-readable" (func $stream-close-readable))))))
+  (core func $stream-drop-readable (canon stream.drop-readable $stream-type))
+  (core instance $i (instantiate $m (with "" (instance (export "stream.drop-readable" (func $stream-drop-readable))))))
 )
 
-;; stream.close-writable
+;; stream.drop-writable
 (component
   (core module $m
-    (import "" "stream.close-writable" (func $stream-close-writable (param i32)))
+    (import "" "stream.drop-writable" (func $stream-drop-writable (param i32)))
   )
   (type $stream-type (stream u8))
-  (core func $stream-close-writable (canon stream.close-writable $stream-type))
-  (core instance $i (instantiate $m (with "" (instance (export "stream.close-writable" (func $stream-close-writable))))))
+  (core func $stream-drop-writable (canon stream.drop-writable $stream-type))
+  (core instance $i (instantiate $m (with "" (instance (export "stream.drop-writable" (func $stream-drop-writable))))))
 )


### PR DESCRIPTION
This updates the plumbing, FACT, compilation, and runtime code to use the new ABI defined in https://github.com/WebAssembly/component-model/pull/524.

- `future.write` now accepts its payload value as up to 4 flat parameters before spilling to linear memory.

- `future.read` takes no payload pointer when it has no payload type

- `{stream,future}.close-{readable,writable}` have been renamed to `{stream,future}.drop-{readable,writable}`

This commit does _not_ address the following items:

> * There is no "number of elements written" packed in the high 28 bits of the `future.{read,write}` results.
> * On successful copy, `future.{read,write}` return `COMPLETED` instead of `CLOSED` (which, as noted above, was renamed to `DROPPED`, making it especially "wrong" as the result code).
> * When a `future` is "done" (by a `COMPLETED` read/write or by the writable end receiving `DROPPED`), the only valid operation is `future.drop-{readable,writable}`.  `future.{read,write}` or lifting traps.
> * Because there's no great reason for streams to be more permissive than futures in this regard, streams are also given a "done" state with the same trapping rules as futures, but the stream "done" state is only set when `DROPPED` is received.

I'll address those in one or more follow-up commits.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
