### PR TITLE
update `future`/`stream` ABIs and names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3467,7 +3467,7 @@ dependencies = [
  "wasmtime",
  "wasmtime-test-util",
  "wat",
- "wit-component 0.233.0",
+ "wit-component",
 ]
 
 [[package]]
@@ -3994,7 +3994,7 @@ dependencies = [
  "byte-array-literals",
  "object",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "wasm-encoder 0.233.0",
+ "wasm-encoder",
  "wit-bindgen-rust-macro",
 ]
 
@@ -4056,8 +4056,7 @@ checksum = "6ee99da9c5ba11bd675621338ef6fa52296b76b83305e9b6e5c77d4c286d6d49"
 [[package]]
 name = "wasm-compose"
 version = "0.233.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80a48997769da18debd9508bb8db7f0a39d5fc3972ecca9a4140c19a68f9e385"
+source = "git+https://github.com/bytecodealliance/wasm-tools#8ebb40209399e6ab401e7256ee10df06b3bcc512"
 dependencies = [
  "anyhow",
  "heck 0.4.1",
@@ -4069,26 +4068,15 @@ dependencies = [
  "serde_derive",
  "serde_yaml",
  "smallvec",
- "wasm-encoder 0.233.0",
+ "wasm-encoder",
  "wasmparser 0.233.0",
  "wat",
 ]
 
 [[package]]
 name = "wasm-encoder"
-version = "0.232.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a447e61e38d1226b57e4628edadff36d16760be24a343712ba236b5106c95156"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.232.0",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.233.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9679ae3cf7cfa2ca3a327f7fab97f27f3294d402fd1a76ca8ab514e17973e4d3"
+source = "git+https://github.com/bytecodealliance/wasm-tools#8ebb40209399e6ab401e7256ee10df06b3bcc512"
 dependencies = [
  "leb128fmt",
  "wasmparser 0.233.0",
@@ -4096,54 +4084,39 @@ dependencies = [
 
 [[package]]
 name = "wasm-metadata"
-version = "0.232.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71aba7991cf9922a097b2dcc4c36ba5bc207339bdcd3a515530fc2555f01e8eb"
-dependencies = [
- "anyhow",
- "indexmap 2.7.0",
- "wasm-encoder 0.232.0",
- "wasmparser 0.232.0",
-]
-
-[[package]]
-name = "wasm-metadata"
 version = "0.233.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ea902a6e69315e1e2371bd35ce4b45ef0d4cfcaf89d1a392ae3966ac055f25"
+source = "git+https://github.com/bytecodealliance/wasm-tools#8ebb40209399e6ab401e7256ee10df06b3bcc512"
 dependencies = [
  "anyhow",
  "indexmap 2.7.0",
- "wasm-encoder 0.233.0",
+ "wasm-encoder",
  "wasmparser 0.233.0",
 ]
 
 [[package]]
 name = "wasm-mutate"
 version = "0.233.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cdfd07fae6e4aaed2b1f411bb66ce6d8c19acd3b9e2bbce0b62ff9682107fcf"
+source = "git+https://github.com/bytecodealliance/wasm-tools#8ebb40209399e6ab401e7256ee10df06b3bcc512"
 dependencies = [
  "egg",
  "log",
  "rand",
  "thiserror 1.0.65",
- "wasm-encoder 0.233.0",
+ "wasm-encoder",
  "wasmparser 0.233.0",
 ]
 
 [[package]]
 name = "wasm-smith"
 version = "0.233.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2820810ea8e870fd5ae956750b457e0997099c806e4747d0abc4d5e608c4e59f"
+source = "git+https://github.com/bytecodealliance/wasm-tools#8ebb40209399e6ab401e7256ee10df06b3bcc512"
 dependencies = [
  "anyhow",
  "arbitrary",
  "flagset",
  "serde",
  "serde_derive",
- "wasm-encoder 0.233.0",
+ "wasm-encoder",
  "wat",
 ]
 
@@ -4158,13 +4131,12 @@ dependencies = [
 [[package]]
 name = "wasm-wave"
 version = "0.233.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d55ea4585cecac742179af2d61cd1941b0e7e96a6f60447ecfb48fd1c67686b1"
+source = "git+https://github.com/bytecodealliance/wasm-tools#8ebb40209399e6ab401e7256ee10df06b3bcc512"
 dependencies = [
  "indexmap 2.7.0",
  "logos",
  "thiserror 1.0.65",
- "wit-parser 0.233.0",
+ "wit-parser",
 ]
 
 [[package]]
@@ -4223,21 +4195,8 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.232.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917739b33bb1eb0e9a49bcd2637a351931be4578d0cc4d37b908d7a797784fbb"
-dependencies = [
- "bitflags 2.6.0",
- "hashbrown 0.15.2",
- "indexmap 2.7.0",
- "semver",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.233.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b51cb03afce7964bbfce46602d6cb358726f36430b6ba084ac6020d8ce5bc102"
+source = "git+https://github.com/bytecodealliance/wasm-tools#8ebb40209399e6ab401e7256ee10df06b3bcc512"
 dependencies = [
  "bitflags 2.6.0",
  "hashbrown 0.15.2",
@@ -4249,8 +4208,7 @@ dependencies = [
 [[package]]
 name = "wasmprinter"
 version = "0.233.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf8e5b732895c99b21aa615f1b73352e51bbe2b2cb6c87eae7f990d07c1ac18"
+source = "git+https://github.com/bytecodealliance/wasm-tools#8ebb40209399e6ab401e7256ee10df06b3bcc512"
 dependencies = [
  "anyhow",
  "termcolor",
@@ -4300,7 +4258,7 @@ dependencies = [
  "tempfile",
  "trait-variant",
  "wasi-common",
- "wasm-encoder 0.233.0",
+ "wasm-encoder",
  "wasm-wave",
  "wasmparser 0.233.0",
  "wasmtime-environ",
@@ -4412,7 +4370,7 @@ dependencies = [
  "trait-variant",
  "walkdir",
  "wasi-common",
- "wasm-encoder 0.233.0",
+ "wasm-encoder",
  "wasmparser 0.233.0",
  "wasmtime",
  "wasmtime-cli-flags",
@@ -4434,7 +4392,7 @@ dependencies = [
  "wast 233.0.0",
  "wat",
  "windows-sys 0.59.0",
- "wit-component 0.233.0",
+ "wit-component",
 ]
 
 [[package]]
@@ -4473,7 +4431,7 @@ dependencies = [
  "serde_derive",
  "smallvec",
  "target-lexicon",
- "wasm-encoder 0.233.0",
+ "wasm-encoder",
  "wasmparser 0.233.0",
  "wasmprinter",
  "wasmtime-internal-component-util",
@@ -4538,7 +4496,7 @@ dependencies = [
  "target-lexicon",
  "tempfile",
  "v8",
- "wasm-encoder 0.233.0",
+ "wasm-encoder",
  "wasm-mutate",
  "wasm-smith",
  "wasm-spec-interpreter",
@@ -4605,7 +4563,7 @@ dependencies = [
  "wasmtime",
  "wasmtime-internal-component-util",
  "wasmtime-internal-wit-bindgen",
- "wit-parser 0.233.0",
+ "wit-parser",
 ]
 
 [[package]]
@@ -4740,7 +4698,7 @@ dependencies = [
  "anyhow",
  "heck 0.5.0",
  "indexmap 2.7.0",
- "wit-parser 0.233.0",
+ "wit-parser",
 ]
 
 [[package]]
@@ -4945,22 +4903,20 @@ dependencies = [
 [[package]]
 name = "wast"
 version = "233.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eaf4099d8d0c922b83bf3c90663f5666f0769db9e525184284ebbbdb1dd2180"
+source = "git+https://github.com/bytecodealliance/wasm-tools#8ebb40209399e6ab401e7256ee10df06b3bcc512"
 dependencies = [
  "bumpalo",
  "gimli",
  "leb128fmt",
  "memchr",
  "unicode-width 0.2.0",
- "wasm-encoder 0.233.0",
+ "wasm-encoder",
 ]
 
 [[package]]
 name = "wat"
 version = "1.233.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d9bc80f5e4b25ea086ef41b91ccd244adde45d931c384d94a8ff64ab8bd7d87"
+source = "git+https://github.com/bytecodealliance/wasm-tools#8ebb40209399e6ab401e7256ee10df06b3bcc512"
 dependencies = [
  "wast 233.0.0",
 ]
@@ -5251,7 +5207,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen"
 version = "0.42.1"
-source = "git+https://github.com/bytecodealliance/wit-bindgen#80cf018de24a45210c9ffe15d944f4485a0457fc"
+source = "git+https://github.com/dicej/wit-bindgen?branch=future-and-stream-changes#cf6deea12419e06201b2977ff109374c89a380a8"
 dependencies = [
  "wit-bindgen-rt 0.42.1",
  "wit-bindgen-rust-macro",
@@ -5260,11 +5216,11 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-core"
 version = "0.42.1"
-source = "git+https://github.com/bytecodealliance/wit-bindgen#80cf018de24a45210c9ffe15d944f4485a0457fc"
+source = "git+https://github.com/dicej/wit-bindgen?branch=future-and-stream-changes#cf6deea12419e06201b2977ff109374c89a380a8"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "wit-parser 0.232.0",
+ "wit-parser",
 ]
 
 [[package]]
@@ -5288,7 +5244,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-rt"
 version = "0.42.1"
-source = "git+https://github.com/bytecodealliance/wit-bindgen#80cf018de24a45210c9ffe15d944f4485a0457fc"
+source = "git+https://github.com/dicej/wit-bindgen?branch=future-and-stream-changes#cf6deea12419e06201b2977ff109374c89a380a8"
 dependencies = [
  "bitflags 2.6.0",
  "futures",
@@ -5298,22 +5254,22 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-rust"
 version = "0.42.1"
-source = "git+https://github.com/bytecodealliance/wit-bindgen#80cf018de24a45210c9ffe15d944f4485a0457fc"
+source = "git+https://github.com/dicej/wit-bindgen?branch=future-and-stream-changes#cf6deea12419e06201b2977ff109374c89a380a8"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
  "indexmap 2.7.0",
  "prettyplease",
  "syn 2.0.100",
- "wasm-metadata 0.232.0",
+ "wasm-metadata",
  "wit-bindgen-core",
- "wit-component 0.232.0",
+ "wit-component",
 ]
 
 [[package]]
 name = "wit-bindgen-rust-macro"
 version = "0.42.1"
-source = "git+https://github.com/bytecodealliance/wit-bindgen#80cf018de24a45210c9ffe15d944f4485a0457fc"
+source = "git+https://github.com/dicej/wit-bindgen?branch=future-and-stream-changes#cf6deea12419e06201b2977ff109374c89a380a8"
 dependencies = [
  "anyhow",
  "prettyplease",
@@ -5326,28 +5282,8 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.232.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d1d7a3444f5039b4461a66dc085d749a832e518a86e8c7498d6fdd9df776ed0"
-dependencies = [
- "anyhow",
- "bitflags 2.6.0",
- "indexmap 2.7.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder 0.232.0",
- "wasm-metadata 0.232.0",
- "wasmparser 0.232.0",
- "wit-parser 0.232.0",
-]
-
-[[package]]
-name = "wit-component"
 version = "0.233.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "584f35dd45ccaf0c454bebca0fa111bca4d43a4334fbac25e941f73c503e673a"
+source = "git+https://github.com/bytecodealliance/wasm-tools#8ebb40209399e6ab401e7256ee10df06b3bcc512"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -5356,35 +5292,16 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.233.0",
- "wasm-metadata 0.233.0",
+ "wasm-encoder",
+ "wasm-metadata",
  "wasmparser 0.233.0",
- "wit-parser 0.233.0",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.232.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00a0e031533e3f9082057b09b346f76d3af12a714feccbe8d32f926254319d86"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.7.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.232.0",
+ "wit-parser",
 ]
 
 [[package]]
 name = "wit-parser"
 version = "0.233.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f22f1cd55247a2e616870b619766e9522df36b7abafbb29bbeb34b7a9da7e9f0"
+source = "git+https://github.com/bytecodealliance/wasm-tools#8ebb40209399e6ab401e7256ee10df06b3bcc512"
 dependencies = [
  "anyhow",
  "id-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -618,21 +618,21 @@ lto = true
 
 # TODO: remove this once we've switched to a wasm-tools/wit-bindgen release:
 [patch.crates-io]
-# wasmparser = { git = "https://github.com/bytecodealliance/wasm-tools" }
-# wat = { git = "https://github.com/bytecodealliance/wasm-tools" }
-# wast = { git = "https://github.com/bytecodealliance/wasm-tools" }
-# wasmprinter = { git = "https://github.com/bytecodealliance/wasm-tools" }
-# wasm-encoder = { git = "https://github.com/bytecodealliance/wasm-tools" }
-# wasm-smith = { git = "https://github.com/bytecodealliance/wasm-tools" }
-# wasm-mutate = { git = "https://github.com/bytecodealliance/wasm-tools" }
-# wit-parser = { git = "https://github.com/bytecodealliance/wasm-tools" }
-# wit-component = { git = "https://github.com/bytecodealliance/wasm-tools" }
-# wasm-wave = { git = "https://github.com/bytecodealliance/wasm-tools" }
-# wasm-compose = { git = "https://github.com/bytecodealliance/wasm-tools" }
-# wasm-metadata = { git = "https://github.com/bytecodealliance/wasm-tools" }
-wit-bindgen = { git = "https://github.com/bytecodealliance/wit-bindgen" }
-wit-bindgen-rt = { git = "https://github.com/bytecodealliance/wit-bindgen" }
-wit-bindgen-rust-macro = { git = "https://github.com/bytecodealliance/wit-bindgen" }
+wasmparser = { git = "https://github.com/bytecodealliance/wasm-tools" }
+wat = { git = "https://github.com/bytecodealliance/wasm-tools" }
+wast = { git = "https://github.com/bytecodealliance/wasm-tools" }
+wasmprinter = { git = "https://github.com/bytecodealliance/wasm-tools" }
+wasm-encoder = { git = "https://github.com/bytecodealliance/wasm-tools" }
+wasm-smith = { git = "https://github.com/bytecodealliance/wasm-tools" }
+wasm-mutate = { git = "https://github.com/bytecodealliance/wasm-tools" }
+wit-parser = { git = "https://github.com/bytecodealliance/wasm-tools" }
+wit-component = { git = "https://github.com/bytecodealliance/wasm-tools" }
+wasm-wave = { git = "https://github.com/bytecodealliance/wasm-tools" }
+wasm-compose = { git = "https://github.com/bytecodealliance/wasm-tools" }
+wasm-metadata = { git = "https://github.com/bytecodealliance/wasm-tools" }
+wit-bindgen = { git = "https://github.com/dicej/wit-bindgen", branch = "future-and-stream-changes" }
+wit-bindgen-rt = { git = "https://github.com/dicej/wit-bindgen", branch = "future-and-stream-changes" }
+wit-bindgen-rust-macro = { git = "https://github.com/dicej/wit-bindgen", branch = "future-and-stream-changes" }
 
 # wasmparser = { path = '../wasm-tools/crates/wasmparser' }
 # wat = { path = '../wasm-tools/crates/wat' }

--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -175,16 +175,16 @@ impl<'a> TrampolineCompiler<'a> {
             Trampoline::StreamCancelWrite { ty, async_ } => {
                 self.translate_cancel_call(ty.as_u32(), *async_, host::stream_cancel_write)
             }
-            Trampoline::StreamCloseReadable { ty } => self.translate_future_or_stream_call(
+            Trampoline::StreamDropReadable { ty } => self.translate_future_or_stream_call(
                 &[ty.as_u32()],
                 None,
-                host::stream_close_readable,
+                host::stream_drop_readable,
                 TrapSentinel::Falsy,
             ),
-            Trampoline::StreamCloseWritable { ty } => self.translate_future_or_stream_call(
+            Trampoline::StreamDropWritable { ty } => self.translate_future_or_stream_call(
                 &[ty.as_u32()],
                 None,
-                host::stream_close_writable,
+                host::stream_drop_writable,
                 TrapSentinel::Falsy,
             ),
             Trampoline::FutureNew { ty } => self.translate_future_or_stream_call(
@@ -211,16 +211,16 @@ impl<'a> TrampolineCompiler<'a> {
             Trampoline::FutureCancelWrite { ty, async_ } => {
                 self.translate_cancel_call(ty.as_u32(), *async_, host::future_cancel_write)
             }
-            Trampoline::FutureCloseReadable { ty } => self.translate_future_or_stream_call(
+            Trampoline::FutureDropReadable { ty } => self.translate_future_or_stream_call(
                 &[ty.as_u32()],
                 None,
-                host::future_close_readable,
+                host::future_drop_readable,
                 TrapSentinel::Falsy,
             ),
-            Trampoline::FutureCloseWritable { ty } => self.translate_future_or_stream_call(
+            Trampoline::FutureDropWritable { ty } => self.translate_future_or_stream_call(
                 &[ty.as_u32()],
                 None,
-                host::future_close_writable,
+                host::future_drop_writable,
                 TrapSentinel::Falsy,
             ),
             Trampoline::ErrorContextNew { ty, options } => self.translate_error_context_call(

--- a/crates/environ/src/component.rs
+++ b/crates/environ/src/component.rs
@@ -132,7 +132,7 @@ macro_rules! foreach_builtin_component_function {
                 string_encoding: u32,
                 result_count_or_max_if_async: u32,
                 storage: ptr_u8,
-                torage_len: size
+                storage_len: size
             ) -> bool;
             #[cfg(feature = "component-model-async")]
             sync_start(vmctx: vmctx, callback: ptr_u8, callee: ptr_u8, param_count: u32, storage: ptr_u8, storage_len: size) -> bool;
@@ -149,9 +149,9 @@ macro_rules! foreach_builtin_component_function {
             #[cfg(feature = "component-model-async")]
             future_cancel_read(vmctx: vmctx, ty: u32, async_: u8, reader: u32) -> u64;
             #[cfg(feature = "component-model-async")]
-            future_close_writable(vmctx: vmctx, ty: u32, writer: u32) -> bool;
+            future_drop_writable(vmctx: vmctx, ty: u32, writer: u32) -> bool;
             #[cfg(feature = "component-model-async")]
-            future_close_readable(vmctx: vmctx, ty: u32, reader: u32) -> bool;
+            future_drop_readable(vmctx: vmctx, ty: u32, reader: u32) -> bool;
             #[cfg(feature = "component-model-async")]
             stream_new(vmctx: vmctx, ty: u32) -> u64;
             #[cfg(feature = "component-model-async")]
@@ -163,9 +163,9 @@ macro_rules! foreach_builtin_component_function {
             #[cfg(feature = "component-model-async")]
             stream_cancel_read(vmctx: vmctx, ty: u32, async_: u8, reader: u32) -> u64;
             #[cfg(feature = "component-model-async")]
-            stream_close_writable(vmctx: vmctx, ty: u32, writer: u32) -> bool;
+            stream_drop_writable(vmctx: vmctx, ty: u32, writer: u32) -> bool;
             #[cfg(feature = "component-model-async")]
-            stream_close_readable(vmctx: vmctx, ty: u32, reader: u32) -> bool;
+            stream_drop_readable(vmctx: vmctx, ty: u32, reader: u32) -> bool;
             #[cfg(feature = "component-model-async")]
             flat_stream_write(vmctx: vmctx, memory: ptr_u8, realloc: ptr_u8, async_: u8, ty: u32, payload_size: u32, payload_align: u32, stream: u32, address: u32, count: u32) -> u64;
             #[cfg(feature = "component-model-async")]

--- a/crates/environ/src/component/dfg.rs
+++ b/crates/environ/src/component/dfg.rs
@@ -337,10 +337,10 @@ pub enum Trampoline {
         ty: TypeStreamTableIndex,
         async_: bool,
     },
-    StreamCloseReadable {
+    StreamDropReadable {
         ty: TypeStreamTableIndex,
     },
-    StreamCloseWritable {
+    StreamDropWritable {
         ty: TypeStreamTableIndex,
     },
     FutureNew {
@@ -362,10 +362,10 @@ pub enum Trampoline {
         ty: TypeFutureTableIndex,
         async_: bool,
     },
-    FutureCloseReadable {
+    FutureDropReadable {
         ty: TypeFutureTableIndex,
     },
-    FutureCloseWritable {
+    FutureDropWritable {
         ty: TypeFutureTableIndex,
     },
     ErrorContextNew {
@@ -848,11 +848,11 @@ impl LinearizeDfg<'_> {
                 ty: *ty,
                 async_: *async_,
             },
-            Trampoline::StreamCloseReadable { ty } => {
-                info::Trampoline::StreamCloseReadable { ty: *ty }
+            Trampoline::StreamDropReadable { ty } => {
+                info::Trampoline::StreamDropReadable { ty: *ty }
             }
-            Trampoline::StreamCloseWritable { ty } => {
-                info::Trampoline::StreamCloseWritable { ty: *ty }
+            Trampoline::StreamDropWritable { ty } => {
+                info::Trampoline::StreamDropWritable { ty: *ty }
             }
             Trampoline::FutureNew { ty } => info::Trampoline::FutureNew { ty: *ty },
             Trampoline::FutureRead { ty, options } => info::Trampoline::FutureRead {
@@ -871,11 +871,11 @@ impl LinearizeDfg<'_> {
                 ty: *ty,
                 async_: *async_,
             },
-            Trampoline::FutureCloseReadable { ty } => {
-                info::Trampoline::FutureCloseReadable { ty: *ty }
+            Trampoline::FutureDropReadable { ty } => {
+                info::Trampoline::FutureDropReadable { ty: *ty }
             }
-            Trampoline::FutureCloseWritable { ty } => {
-                info::Trampoline::FutureCloseWritable { ty: *ty }
+            Trampoline::FutureDropWritable { ty } => {
+                info::Trampoline::FutureDropWritable { ty: *ty }
             }
             Trampoline::ErrorContextNew { ty, options } => info::Trampoline::ErrorContextNew {
                 ty: *ty,

--- a/crates/environ/src/component/info.rs
+++ b/crates/environ/src/component/info.rs
@@ -836,16 +836,16 @@ pub enum Trampoline {
         async_: bool,
     },
 
-    /// A `stream.close-readable` intrinsic to close the readable end of a
+    /// A `stream.drop-readable` intrinsic to drop the readable end of a
     /// `stream` of the specified type.
-    StreamCloseReadable {
+    StreamDropReadable {
         /// The table index for the specific `stream` type and caller instance.
         ty: TypeStreamTableIndex,
     },
 
-    /// A `stream.close-writable` intrinsic to close the writable end of a
+    /// A `stream.drop-writable` intrinsic to drop the writable end of a
     /// `stream` of the specified type.
-    StreamCloseWritable {
+    StreamDropWritable {
         /// The table index for the specific `stream` type and caller instance.
         ty: TypeStreamTableIndex,
     },
@@ -897,16 +897,16 @@ pub enum Trampoline {
         async_: bool,
     },
 
-    /// A `future.close-readable` intrinsic to close the readable end of a
+    /// A `future.drop-readable` intrinsic to drop the readable end of a
     /// `future` of the specified type.
-    FutureCloseReadable {
+    FutureDropReadable {
         /// The table index for the specific `future` type and caller instance.
         ty: TypeFutureTableIndex,
     },
 
-    /// A `future.close-writable` intrinsic to close the writable end of a
+    /// A `future.drop-writable` intrinsic to drop the writable end of a
     /// `future` of the specified type.
-    FutureCloseWritable {
+    FutureDropWritable {
         /// The table index for the specific `future` type and caller instance.
         ty: TypeFutureTableIndex,
     },
@@ -1061,15 +1061,15 @@ impl Trampoline {
             StreamWrite { .. } => format!("stream-write"),
             StreamCancelRead { .. } => format!("stream-cancel-read"),
             StreamCancelWrite { .. } => format!("stream-cancel-write"),
-            StreamCloseReadable { .. } => format!("stream-close-readable"),
-            StreamCloseWritable { .. } => format!("stream-close-writable"),
+            StreamDropReadable { .. } => format!("stream-drop-readable"),
+            StreamDropWritable { .. } => format!("stream-drop-writable"),
             FutureNew { .. } => format!("future-new"),
             FutureRead { .. } => format!("future-read"),
             FutureWrite { .. } => format!("future-write"),
             FutureCancelRead { .. } => format!("future-cancel-read"),
             FutureCancelWrite { .. } => format!("future-cancel-write"),
-            FutureCloseReadable { .. } => format!("future-close-readable"),
-            FutureCloseWritable { .. } => format!("future-close-writable"),
+            FutureDropReadable { .. } => format!("future-drop-readable"),
+            FutureDropWritable { .. } => format!("future-drop-writable"),
             ErrorContextNew { .. } => format!("error-context-new"),
             ErrorContextDebugMessage { .. } => format!("error-context-debug-message"),
             ErrorContextDrop { .. } => format!("error-context-drop"),

--- a/crates/environ/src/component/translate.rs
+++ b/crates/environ/src/component/translate.rs
@@ -253,11 +253,11 @@ enum LocalInitializer<'data> {
         func: ModuleInternedTypeIndex,
         async_: bool,
     },
-    StreamCloseReadable {
+    StreamDropReadable {
         ty: ComponentDefinedTypeId,
         func: ModuleInternedTypeIndex,
     },
-    StreamCloseWritable {
+    StreamDropWritable {
         ty: ComponentDefinedTypeId,
         func: ModuleInternedTypeIndex,
     },
@@ -285,11 +285,11 @@ enum LocalInitializer<'data> {
         func: ModuleInternedTypeIndex,
         async_: bool,
     },
-    FutureCloseReadable {
+    FutureDropReadable {
         ty: ComponentDefinedTypeId,
         func: ModuleInternedTypeIndex,
     },
-    FutureCloseWritable {
+    FutureDropWritable {
         ty: ComponentDefinedTypeId,
         func: ModuleInternedTypeIndex,
     },
@@ -767,17 +767,17 @@ impl<'a, 'data> Translator<'a, 'data> {
                             core_func_index += 1;
                             LocalInitializer::StreamCancelWrite { ty, func, async_ }
                         }
-                        wasmparser::CanonicalFunction::StreamCloseReadable { ty } => {
+                        wasmparser::CanonicalFunction::StreamDropReadable { ty } => {
                             let ty = types.component_defined_type_at(ty);
                             let func = self.core_func_signature(core_func_index)?;
                             core_func_index += 1;
-                            LocalInitializer::StreamCloseReadable { ty, func }
+                            LocalInitializer::StreamDropReadable { ty, func }
                         }
-                        wasmparser::CanonicalFunction::StreamCloseWritable { ty } => {
+                        wasmparser::CanonicalFunction::StreamDropWritable { ty } => {
                             let ty = types.component_defined_type_at(ty);
                             let func = self.core_func_signature(core_func_index)?;
                             core_func_index += 1;
-                            LocalInitializer::StreamCloseWritable { ty, func }
+                            LocalInitializer::StreamDropWritable { ty, func }
                         }
                         wasmparser::CanonicalFunction::FutureNew { ty } => {
                             let ty = types.component_defined_type_at(ty);
@@ -811,17 +811,17 @@ impl<'a, 'data> Translator<'a, 'data> {
                             core_func_index += 1;
                             LocalInitializer::FutureCancelWrite { ty, func, async_ }
                         }
-                        wasmparser::CanonicalFunction::FutureCloseReadable { ty } => {
+                        wasmparser::CanonicalFunction::FutureDropReadable { ty } => {
                             let ty = types.component_defined_type_at(ty);
                             let func = self.core_func_signature(core_func_index)?;
                             core_func_index += 1;
-                            LocalInitializer::FutureCloseReadable { ty, func }
+                            LocalInitializer::FutureDropReadable { ty, func }
                         }
-                        wasmparser::CanonicalFunction::FutureCloseWritable { ty } => {
+                        wasmparser::CanonicalFunction::FutureDropWritable { ty } => {
                             let ty = types.component_defined_type_at(ty);
                             let func = self.core_func_signature(core_func_index)?;
                             core_func_index += 1;
-                            LocalInitializer::FutureCloseWritable { ty, func }
+                            LocalInitializer::FutureDropWritable { ty, func }
                         }
                         wasmparser::CanonicalFunction::ErrorContextNew { options } => {
                             let options = self.canonical_options(&options);

--- a/crates/environ/src/component/translate/inline.rs
+++ b/crates/environ/src/component/translate/inline.rs
@@ -863,7 +863,7 @@ impl<'a> Inliner<'a> {
                 ));
                 frame.funcs.push(dfg::CoreDef::Trampoline(index));
             }
-            StreamCloseReadable { ty, func } => {
+            StreamDropReadable { ty, func } => {
                 let InterfaceType::Stream(ty) =
                     types.defined_type(frame.translation.types_ref(), *ty)?
                 else {
@@ -872,10 +872,10 @@ impl<'a> Inliner<'a> {
                 let index = self
                     .result
                     .trampolines
-                    .push((*func, dfg::Trampoline::StreamCloseReadable { ty }));
+                    .push((*func, dfg::Trampoline::StreamDropReadable { ty }));
                 frame.funcs.push(dfg::CoreDef::Trampoline(index));
             }
-            StreamCloseWritable { ty, func } => {
+            StreamDropWritable { ty, func } => {
                 let InterfaceType::Stream(ty) =
                     types.defined_type(frame.translation.types_ref(), *ty)?
                 else {
@@ -884,7 +884,7 @@ impl<'a> Inliner<'a> {
                 let index = self
                     .result
                     .trampolines
-                    .push((*func, dfg::Trampoline::StreamCloseWritable { ty }));
+                    .push((*func, dfg::Trampoline::StreamDropWritable { ty }));
                 frame.funcs.push(dfg::CoreDef::Trampoline(index));
             }
             FutureNew { ty, func } => {
@@ -957,7 +957,7 @@ impl<'a> Inliner<'a> {
                 ));
                 frame.funcs.push(dfg::CoreDef::Trampoline(index));
             }
-            FutureCloseReadable { ty, func } => {
+            FutureDropReadable { ty, func } => {
                 let InterfaceType::Future(ty) =
                     types.defined_type(frame.translation.types_ref(), *ty)?
                 else {
@@ -966,10 +966,10 @@ impl<'a> Inliner<'a> {
                 let index = self
                     .result
                     .trampolines
-                    .push((*func, dfg::Trampoline::FutureCloseReadable { ty }));
+                    .push((*func, dfg::Trampoline::FutureDropReadable { ty }));
                 frame.funcs.push(dfg::CoreDef::Trampoline(index));
             }
-            FutureCloseWritable { ty, func } => {
+            FutureDropWritable { ty, func } => {
                 let InterfaceType::Future(ty) =
                     types.defined_type(frame.translation.types_ref(), *ty)?
                 else {
@@ -978,7 +978,7 @@ impl<'a> Inliner<'a> {
                 let index = self
                     .result
                     .trampolines
-                    .push((*func, dfg::Trampoline::FutureCloseWritable { ty }));
+                    .push((*func, dfg::Trampoline::FutureDropWritable { ty }));
                 frame.funcs.push(dfg::CoreDef::Trampoline(index));
             }
             ErrorContextNew { func, options } => {

--- a/crates/test-programs/src/async_.rs
+++ b/crates/test-programs/src/async_.rs
@@ -145,4 +145,5 @@ pub const CALLBACK_CODE_WAIT: u32 = 2;
 pub const CALLBACK_CODE_POLL: u32 = 3;
 
 pub const BLOCKED: u32 = 0xffff_ffff;
-pub const CLOSED: u32 = 1;
+pub const DROPPED: u32 = 1;
+pub const COMPLETED: u32 = 0;

--- a/crates/test-programs/src/bin/async_intertask_communication.rs
+++ b/crates/test-programs/src/bin/async_intertask_communication.rs
@@ -8,7 +8,7 @@ mod bindings {
 use {
     std::sync::atomic::{AtomicU32, Ordering::Relaxed},
     test_programs::async_::{
-        BLOCKED, CALLBACK_CODE_EXIT, CALLBACK_CODE_WAIT, CLOSED, EVENT_FUTURE_WRITE, EVENT_NONE,
+        BLOCKED, CALLBACK_CODE_EXIT, CALLBACK_CODE_WAIT, COMPLETED, EVENT_FUTURE_WRITE, EVENT_NONE,
         context_get, context_set, waitable_join, waitable_set_drop, waitable_set_new,
     },
 };
@@ -73,34 +73,34 @@ fn future_read(reader: u32) -> u32 {
     unsafe { future_read(reader, 0) }
 }
 
-fn future_close_readable(reader: u32) {
+fn future_drop_readable(reader: u32) {
     #[cfg(target_arch = "wasm32")]
     #[link(wasm_import_module = "local:local/intertask")]
     unsafe extern "C" {
-        #[link_name = "[future-close-readable-0]foo"]
-        fn future_close_readable(_: u32);
+        #[link_name = "[future-drop-readable-0]foo"]
+        fn future_drop_readable(_: u32);
     }
     #[cfg(not(target_arch = "wasm32"))]
-    unsafe extern "C" fn future_close_readable(_: u32) {
+    unsafe extern "C" fn future_drop_readable(_: u32) {
         unreachable!()
     }
 
-    unsafe { future_close_readable(reader) }
+    unsafe { future_drop_readable(reader) }
 }
 
-fn future_close_writable(writer: u32) {
+fn future_drop_writable(writer: u32) {
     #[cfg(target_arch = "wasm32")]
     #[link(wasm_import_module = "local:local/intertask")]
     unsafe extern "C" {
-        #[link_name = "[future-close-writable-0]foo"]
-        fn future_close_writable(_: u32);
+        #[link_name = "[future-drop-writable-0]foo"]
+        fn future_drop_writable(_: u32);
     }
     #[cfg(not(target_arch = "wasm32"))]
-    unsafe extern "C" fn future_close_writable(_: u32) {
+    unsafe extern "C" fn future_drop_writable(_: u32) {
         unreachable!()
     }
 
-    unsafe { future_close_writable(writer) }
+    unsafe { future_drop_writable(writer) }
 }
 
 static TASK_NUMBER: AtomicU32 = AtomicU32::new(0);
@@ -165,9 +165,9 @@ unsafe extern "C" fn callback_run(event0: u32, event1: u32, event2: u32) -> u32 
                         waitable_join(tx, set);
 
                         let status = future_read(rx);
-                        assert_eq!(status, 1 << 4 | CLOSED); // i.e. one element was read
+                        assert_eq!(status, COMPLETED); // i.e. one element was read
 
-                        future_close_readable(rx);
+                        future_drop_readable(rx);
 
                         task_return_run();
                         CALLBACK_CODE_EXIT
@@ -180,11 +180,11 @@ unsafe extern "C" fn callback_run(event0: u32, event1: u32, event2: u32) -> u32 
 
             State::S1 { set } => {
                 assert_eq!(event0, EVENT_FUTURE_WRITE);
-                assert_eq!(event2, 1 << 4 | CLOSED); // i.e. one element was written
+                assert_eq!(event2, COMPLETED); // i.e. one element was written
 
                 waitable_join(event1, 0);
                 waitable_set_drop(*set);
-                future_close_writable(event1);
+                future_drop_writable(event1);
 
                 TASK_NUMBER.store(0, Relaxed);
 

--- a/crates/test-programs/src/bin/async_transmit_caller.rs
+++ b/crates/test-programs/src/bin/async_transmit_caller.rs
@@ -107,7 +107,7 @@ impl Guest for Component {
                 Err(mut send) => {
                     caller_future_tx1 = match send.as_mut().cancel() {
                         FutureWriteCancel::AlreadySent => unreachable!(),
-                        FutureWriteCancel::Closed(_) => unreachable!(),
+                        FutureWriteCancel::Dropped(_) => unreachable!(),
                         FutureWriteCancel::Cancelled(_, writer) => writer,
                     }
                 }

--- a/crates/test-programs/src/bin/p3_http_echo.rs
+++ b/crates/test-programs/src/bin/p3_http_echo.rs
@@ -39,7 +39,7 @@ impl Handler for Component {
                             chunk = pipe_tx.write_all(chunk).await;
                             assert!(chunk.is_empty());
                         }
-                        StreamResult::Closed => break,
+                        StreamResult::Dropped => break,
                         StreamResult::Cancelled => unreachable!(),
                     }
                 }

--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -1196,7 +1196,7 @@ impl Instance {
     /// - One or more guest tasks are still pending (i.e. have not yet returned,
     /// or, in the case of async-lifted exports with callbacks, have not yet
     /// returned `CALLBACK_CODE_EXIT`) even though all host tasks have completed
-    /// all host-owned stream and future handles have been closed, etc.
+    /// all host-owned stream and future handles have been dropped, etc.
     ///
     /// - Any and all guest tasks complete normally, but the future passed to
     /// this function continues to return `Pending` when polled.  In that case,

--- a/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams/buffers.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams/buffers.rs
@@ -70,9 +70,7 @@ unsafe impl<T: Send + Sync + 'static> TakeBuffer for Option<T> {
 impl<T: Send + Sync + 'static> WriteBuffer<T> for Option<T> {
     fn remaining(&self) -> &[T] {
         if let Some(me) = self {
-            // SAFETY: This effectively transmutes a `&T` to a `&[T; 1]`, which
-            // should be sound.
-            unsafe { slice::from_raw_parts(me, 1) }
+            slice::from_ref(me)
         } else {
             &[]
         }

--- a/crates/wasmtime/src/runtime/vm/component/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/component/libcalls.rs
@@ -1009,26 +1009,26 @@ fn future_cancel_read(
 }
 
 #[cfg(feature = "component-model-async")]
-fn future_close_writable(
+fn future_drop_writable(
     store: &mut dyn VMStore,
     instance: Instance,
     ty: u32,
     writer: u32,
 ) -> Result<()> {
-    store[instance.id()].future_close_writable(
+    store[instance.id()].future_drop_writable(
         wasmtime_environ::component::TypeFutureTableIndex::from_u32(ty),
         writer,
     )
 }
 
 #[cfg(feature = "component-model-async")]
-fn future_close_readable(
+fn future_drop_readable(
     store: &mut dyn VMStore,
     instance: Instance,
     ty: u32,
     reader: u32,
 ) -> Result<()> {
-    instance.future_close_readable(
+    instance.future_drop_readable(
         store,
         wasmtime_environ::component::TypeFutureTableIndex::from_u32(ty),
         reader,
@@ -1125,26 +1125,26 @@ fn stream_cancel_read(
 }
 
 #[cfg(feature = "component-model-async")]
-fn stream_close_writable(
+fn stream_drop_writable(
     store: &mut dyn VMStore,
     instance: Instance,
     ty: u32,
     writer: u32,
 ) -> Result<()> {
-    store[instance.id()].stream_close_writable(
+    store[instance.id()].stream_drop_writable(
         wasmtime_environ::component::TypeStreamTableIndex::from_u32(ty),
         writer,
     )
 }
 
 #[cfg(feature = "component-model-async")]
-fn stream_close_readable(
+fn stream_drop_readable(
     store: &mut dyn VMStore,
     instance: Instance,
     ty: u32,
     reader: u32,
 ) -> Result<()> {
-    instance.stream_close_readable(
+    instance.stream_drop_readable(
         store,
         wasmtime_environ::component::TypeStreamTableIndex::from_u32(ty),
         reader,

--- a/tests/misc_testsuite/component-model-async/cancel-stream.wast
+++ b/tests/misc_testsuite/component-model-async/cancel-stream.wast
@@ -19,7 +19,7 @@
       (import "" "stream.new" (func $stream.new (result i64)))
       (import "" "stream.write" (func $stream.write (param i32 i32 i32) (result i32)))
       (import "" "stream.cancel-write" (func $stream.cancel-write (param i32) (result i32)))
-      (import "" "stream.close-writable" (func $stream.close-writable (param i32)))
+      (import "" "stream.drop-writable" (func $stream.drop-writable (param i32)))
 
       (global $sw (mut i32) (i32.const 0))
 
@@ -40,9 +40,9 @@
           (then unreachable))
       )
 
-      (func $write4-and-close (export "write4-and-close")
+      (func $write4-and-drop (export "write4-and-drop")
         (call $write4)
-        (call $stream.close-writable (global.get $sw))
+        (call $stream.drop-writable (global.get $sw))
       )
 
       (func $start-blocking-write (export "start-blocking-write")
@@ -77,18 +77,18 @@
     (canon stream.new $ST (core func $stream.new))
     (canon stream.write $ST async (memory $memory "mem") (core func $stream.write))
     (canon stream.cancel-write $ST (core func $stream.cancel-write))
-    (canon stream.close-writable $ST (core func $stream.close-writable))
+    (canon stream.drop-writable $ST (core func $stream.drop-writable))
     (core instance $cm (instantiate $CM (with "" (instance
       (export "mem" (memory $memory "mem"))
       (export "task.return" (func $task.return))
       (export "stream.new" (func $stream.new))
       (export "stream.write" (func $stream.write))
       (export "stream.cancel-write" (func $stream.cancel-write))
-      (export "stream.close-writable" (func $stream.close-writable))
+      (export "stream.drop-writable" (func $stream.drop-writable))
     ))))
     (func (export "start-stream") (result (stream u8)) (canon lift (core func $cm "start-stream")))
     (func (export "write4") (canon lift (core func $cm "write4")))
-    (func (export "write4-and-close") (canon lift (core func $cm "write4-and-close")))
+    (func (export "write4-and-drop") (canon lift (core func $cm "write4-and-drop")))
     (func (export "start-blocking-write") (canon lift (core func $cm "start-blocking-write")))
     (func (export "cancel-after-read4") (canon lift (core func $cm "cancel-after-read4")))
   )
@@ -97,7 +97,7 @@
     (import "c" (instance $c
       (export "start-stream" (func (result (stream u8))))
       (export "write4" (func))
-      (export "write4-and-close" (func))
+      (export "write4-and-drop" (func))
       (export "start-blocking-write" (func))
       (export "cancel-after-read4" (func))
     ))
@@ -108,10 +108,10 @@
       (import "" "mem" (memory 1))
       (import "" "stream.read" (func $stream.read (param i32 i32 i32) (result i32)))
       (import "" "stream.cancel-read" (func $stream.cancel-read (param i32) (result i32)))
-      (import "" "stream.close-readable" (func $stream.close-readable (param i32)))
+      (import "" "stream.drop-readable" (func $stream.drop-readable (param i32)))
       (import "" "start-stream" (func $start-stream (result i32)))
       (import "" "write4" (func $write4))
-      (import "" "write4-and-close" (func $write4-and-close))
+      (import "" "write4-and-drop" (func $write4-and-drop))
       (import "" "start-blocking-write" (func $start-blocking-write))
       (import "" "cancel-after-read4" (func $cancel-after-read4))
 
@@ -146,18 +146,18 @@
         (if (i32.ne (i32.const 0xabcd) (i32.load (i32.const 8)))
           (then unreachable))
 
-        ;; read, block, call $C to write 4 bytes into the buffer and close,
-        ;; then cancel, which should show "4+closed"
+        ;; read, block, call $C to write 4 bytes into the buffer and drop,
+        ;; then cancel, which should show "4+dropped"
         (local.set $ret (call $stream.read (local.get $sr) (i32.const 8) (i32.const 100)))
         (if (i32.ne (i32.const -1 (; BLOCKED;)) (local.get $ret))
           (then unreachable))
-        (call $write4-and-close)
+        (call $write4-and-drop)
         (local.set $ret (call $stream.cancel-read (local.get $sr)))
-        (if (i32.ne (i32.const 0x41 (; CLOSED=1 | (4<<4) ;)) (local.get $ret))
+        (if (i32.ne (i32.const 0x41 (; DROPPED=1 | (4<<4) ;)) (local.get $ret))
           (then unreachable))
         (if (i32.ne (i32.const 0xabcd) (i32.load (i32.const 8)))
           (then unreachable))
-        (call $stream.close-readable (local.get $sr))
+        (call $stream.drop-readable (local.get $sr))
 
         ;; get a new $sr
         (local.set $sr (call $start-stream))
@@ -181,20 +181,20 @@
     (type $ST (stream u8))
     (canon stream.read $ST async (memory $memory "mem") (core func $stream.read))
     (canon stream.cancel-read $ST (core func $stream.cancel-read))
-    (canon stream.close-readable $ST (core func $stream.close-readable))
+    (canon stream.drop-readable $ST (core func $stream.drop-readable))
     (canon lower (func $c "start-stream") (core func $start-stream'))
     (canon lower (func $c "write4") (core func $write4'))
-    (canon lower (func $c "write4-and-close") (core func $write4-and-close'))
+    (canon lower (func $c "write4-and-drop") (core func $write4-and-drop'))
     (canon lower (func $c "start-blocking-write") (core func $start-blocking-write'))
     (canon lower (func $c "cancel-after-read4") (core func $cancel-after-read4'))
     (core instance $dm (instantiate $DM (with "" (instance
       (export "mem" (memory $memory "mem"))
       (export "stream.read" (func $stream.read))
       (export "stream.cancel-read" (func $stream.cancel-read))
-      (export "stream.close-readable" (func $stream.close-readable))
+      (export "stream.drop-readable" (func $stream.drop-readable))
       (export "start-stream" (func $start-stream'))
       (export "write4" (func $write4'))
-      (export "write4-and-close" (func $write4-and-close'))
+      (export "write4-and-drop" (func $write4-and-drop'))
       (export "start-blocking-write" (func $start-blocking-write'))
       (export "cancel-after-read4" (func $cancel-after-read4'))
     ))))

--- a/tests/misc_testsuite/component-model-async/empty-wait.wast
+++ b/tests/misc_testsuite/component-model-async/empty-wait.wast
@@ -23,8 +23,8 @@
       (import "" "future.new" (func $future.new (result i64)))
       (import "" "future.read" (func $future.read (param i32 i32) (result i32)))
       (import "" "future.write" (func $future.write (param i32 i32) (result i32)))
-      (import "" "future.close-readable" (func $future.close-readable (param i32)))
-      (import "" "future.close-writable" (func $future.close-writable (param i32)))
+      (import "" "future.drop-readable" (func $future.drop-readable (param i32)))
+      (import "" "future.drop-writable" (func $future.drop-writable (param i32)))
 
       ;; $ws is waited on by 'blocker' and added to by 'unblocker'
       (global $ws (mut i32) (i32.const 0))
@@ -44,10 +44,10 @@
           (then unreachable))
         (if (i32.ne (global.get $futr) (local.get $index))
           (then unreachable))
-        (if (i32.ne (i32.const 0x11) (local.get $payload))
+        (if (i32.ne (i32.const 0) (local.get $payload))
           (then unreachable))
 
-        (call $future.close-readable (global.get $futr))
+        (call $future.drop-readable (global.get $futr))
 
         ;; return 42 to $D.run
         (call $task.return (i32.const 42))
@@ -69,17 +69,17 @@
 
         ;; perform a future.read which will block, and add this future to the waitable-set
         ;; being waited on by 'blocker'
-        (local.set $ret (call $future.read (global.get $futr) (i32.const 0xdeadbeef)))
+        (local.set $ret (call $future.read (global.get $futr) (i32.const 0)))
         (if (i32.ne (i32.const -1 (; BLOCKED ;)) (local.get $ret))
           (then unreachable))
         (call $waitable.join (global.get $futr) (global.get $ws))
 
         ;; perform a future.write which will rendezvous with the write and complete
-        (local.set $ret (call $future.write (local.get $futw) (i32.const 0xdeadbeef)))
-        (if (i32.ne (i32.const 0x11) (local.get $ret))
+        (local.set $ret (call $future.write (local.get $futw) (i32.const 0)))
+        (if (i32.ne (i32.const 0) (local.get $ret))
           (then unreachable))
 
-        (call $future.close-writable (local.get $futw))
+        (call $future.drop-writable (local.get $futw))
 
         ;; return 43 to $D.run
         (call $task.return (i32.const 43))
@@ -98,8 +98,8 @@
     (canon future.new $FT (core func $future.new))
     (canon future.read $FT async (memory $memory "mem") (core func $future.read))
     (canon future.write $FT async (memory $memory "mem") (core func $future.write))
-    (canon future.close-readable $FT (core func $future.close-readable))
-    (canon future.close-writable $FT (core func $future.close-writable))
+    (canon future.drop-readable $FT (core func $future.drop-readable))
+    (canon future.drop-writable $FT (core func $future.drop-writable))
     (core instance $cm (instantiate $CM (with "" (instance
       (export "mem" (memory $memory "mem"))
       (export "task.return" (func $task.return))
@@ -109,8 +109,8 @@
       (export "future.new" (func $future.new))
       (export "future.read" (func $future.read))
       (export "future.write" (func $future.write))
-      (export "future.close-readable" (func $future.close-readable))
-      (export "future.close-writable" (func $future.close-writable))
+      (export "future.drop-readable" (func $future.drop-readable))
+      (export "future.drop-writable" (func $future.drop-writable))
     ))))
     (func (export "blocker") (result u32) (canon lift
       (core func $cm "blocker")

--- a/tests/misc_testsuite/component-model-async/future-cancel-write-completed.wast
+++ b/tests/misc_testsuite/component-model-async/future-cancel-write-completed.wast
@@ -11,30 +11,30 @@
     (core module $libc (memory (export "mem") 1))
     (core instance $libc (instantiate $libc))
     (core func $read (canon future.read $f async (memory $libc "mem")))
-    (core func $close-read (canon future.close-readable $f))
+    (core func $drop-read (canon future.drop-readable $f))
     (core module $inner
       (import "" "read" (func $read (param i32 i32) (result i32)))
-      (import "" "close-read" (func $close-read (param i32)))
+      (import "" "drop-read" (func $drop-read (param i32)))
 
       (func (export "f") (param i32)
         ;; start a read, asserting it completes with one item
         local.get 0
         i32.const 0
         call $read
-        i32.const 0x11
+        i32.const 0
         i32.ne
         if unreachable end
 
-        ;; close the read end
+        ;; drop the read end
         local.get 0
-        call $close-read
+        call $drop-read
       )
     )
 
     (core instance $i (instantiate $inner
       (with "" (instance
         (export "read" (func $read))
-        (export "close-read" (func $close-read))
+        (export "drop-read" (func $drop-read))
       ))
     ))
 
@@ -93,4 +93,4 @@
   (func (export "f") (result u32) (canon lift (core func $i "f")))
 )
 
-(assert_return (invoke "f") (u32.const 0x11))
+(assert_return (invoke "f") (u32.const 0))

--- a/tests/misc_testsuite/component-model-async/futures-must-write.wast
+++ b/tests/misc_testsuite/component-model-async/futures-must-write.wast
@@ -15,7 +15,7 @@
       (import "" "mem" (memory 1))
       (import "" "future.new" (func $future.new (result i64)))
       (import "" "future.write" (func $future.write (param i32 i32) (result i32)))
-      (import "" "future.close-writable" (func $future.close-writable (param i32)))
+      (import "" "future.drop-writable" (func $future.drop-writable (param i32)))
 
       (global $fw (mut i32) (i32.const 0))
 
@@ -27,11 +27,11 @@
         (i32.wrap_i64 (local.get $ret64))
       )
       (func $attempt-write (export "attempt-write") (result i32)
-        ;; because the caller already closed the readable end, this write will eagerly
-        ;; return CLOSED having written no values.
+        ;; because the caller already dropped the readable end, this write will eagerly
+        ;; return DROPPED having written no values.
         (local $ret i32)
         (local.set $ret (call $future.write (global.get $fw) (i32.const 42)))
-        (if (i32.ne (i32.const 0x01 (; CLOSED=1 | (0<<4) ;)) (local.get $ret))
+        (if (i32.ne (i32.const 0x01 (; DROPPED=1 | (0<<4) ;)) (local.get $ret))
           (then
             (i32.load (i32.add (local.get $ret) (i32.const 0x8000_0000)))
           unreachable))
@@ -39,30 +39,30 @@
         ;; return without trapping
         (i32.const 42)
       )
-      (func $close-writable (export "close-writable")
+      (func $drop-writable (export "drop-writable")
         ;; maybe boom
-        (call $future.close-writable (global.get $fw))
+        (call $future.drop-writable (global.get $fw))
       )
     )
     (type $FT (future u8))
     (canon future.new $FT (core func $future.new))
     (canon future.write $FT async (memory $memory "mem") (core func $future.write))
-    (canon future.close-writable $FT (core func $future.close-writable))
+    (canon future.drop-writable $FT (core func $future.drop-writable))
     (core instance $cm (instantiate $CM (with "" (instance
       (export "mem" (memory $memory "mem"))
       (export "future.new" (func $future.new))
       (export "future.write" (func $future.write))
-      (export "future.close-writable" (func $future.close-writable))
+      (export "future.drop-writable" (func $future.drop-writable))
     ))))
     (func (export "start-future") (result (future u8)) (canon lift (core func $cm "start-future")))
     (func (export "attempt-write") (result u32) (canon lift (core func $cm "attempt-write")))
-    (func (export "close-writable") (canon lift (core func $cm "close-writable")))
+    (func (export "drop-writable") (canon lift (core func $cm "drop-writable")))
   )
   (component $D
     (import "c" (instance $c
       (export "start-future" (func (result (future u8))))
       (export "attempt-write" (func (result u32)))
-      (export "close-writable" (func))
+      (export "drop-writable" (func))
     ))
 
     (core module $Memory (memory (export "mem") 1))
@@ -70,25 +70,25 @@
     (core module $Core
       (import "" "mem" (memory 1))
       (import "" "future.read" (func $future.read (param i32 i32) (result i32)))
-      (import "" "future.close-readable" (func $future.close-readable (param i32)))
+      (import "" "future.drop-readable" (func $future.drop-readable (param i32)))
       (import "" "start-future" (func $start-future (result i32)))
       (import "" "attempt-write" (func $attempt-write (result i32)))
-      (import "" "close-writable" (func $close-writable))
+      (import "" "drop-writable" (func $drop-writable))
 
-      (func $close-readable-future-before-read (export "close-readable-future-before-read") (result i32)
+      (func $drop-readable-future-before-read (export "drop-readable-future-before-read") (result i32)
         ;; call 'start-future' to get the future we'll be working with
         (local $fr i32)
         (local.set $fr (call $start-future))
         (if (i32.ne (i32.const 1) (local.get $fr))
           (then unreachable))
 
-        ;; ok to immediately close the readable end
-        (call $future.close-readable (local.get $fr))
+        ;; ok to immediately drop the readable end
+        (call $future.drop-readable (local.get $fr))
 
-        ;; the callee will see that we closed the readable end when it tries to write
+        ;; the callee will see that we dropped the readable end when it tries to write
         (call $attempt-write)
       )
-      (func $close-writable-future-before-write (export "close-writable-future-before-write")
+      (func $drop-writable-future-before-write (export "drop-writable-future-before-write")
         ;; call 'start-future' to get the future we'll be working with
         (local $fr i32)
         (local.set $fr (call $start-future))
@@ -96,33 +96,33 @@
           (then unreachable))
 
         ;; boom
-        (call $close-writable)
+        (call $drop-writable)
       )
     )
     (type $FT (future u8))
     (canon future.new $FT (core func $future.new))
     (canon future.read $FT async (memory $memory "mem") (core func $future.read))
-    (canon future.close-readable $FT (core func $future.close-readable))
+    (canon future.drop-readable $FT (core func $future.drop-readable))
     (canon lower (func $c "start-future") (core func $start-future'))
     (canon lower (func $c "attempt-write") (core func $attempt-write'))
-    (canon lower (func $c "close-writable") (core func $close-writable'))
+    (canon lower (func $c "drop-writable") (core func $drop-writable'))
     (core instance $core (instantiate $Core (with "" (instance
       (export "mem" (memory $memory "mem"))
       (export "future.new" (func $future.new))
       (export "future.read" (func $future.read))
-      (export "future.close-readable" (func $future.close-readable))
+      (export "future.drop-readable" (func $future.drop-readable))
       (export "start-future" (func $start-future'))
       (export "attempt-write" (func $attempt-write'))
-      (export "close-writable" (func $close-writable'))
+      (export "drop-writable" (func $drop-writable'))
     ))))
-    (func (export "close-readable-future-before-read") (result u32) (canon lift (core func $core "close-readable-future-before-read")))
-    (func (export "close-writable-future-before-write") (canon lift (core func $core "close-writable-future-before-write")))
+    (func (export "drop-readable-future-before-read") (result u32) (canon lift (core func $core "drop-readable-future-before-read")))
+    (func (export "drop-writable-future-before-write") (canon lift (core func $core "drop-writable-future-before-write")))
   )
   (instance $c (instantiate $C))
   (instance $d (instantiate $D (with "c" (instance $c))))
-  (func (export "close-writable-future-before-write") (alias export $d "close-writable-future-before-write"))
-  (func (export "close-readable-future-before-read") (alias export $d "close-readable-future-before-read"))
+  (func (export "drop-writable-future-before-write") (alias export $d "drop-writable-future-before-write"))
+  (func (export "drop-readable-future-before-read") (alias export $d "drop-readable-future-before-read"))
 )
 
-(assert_return (invoke "close-readable-future-before-read") (u32.const 42))
-(assert_trap (invoke "close-writable-future-before-write") "cannot close future write end without first writing a value")
+(assert_return (invoke "drop-readable-future-before-read") (u32.const 42))
+(assert_trap (invoke "drop-writable-future-before-write") "cannot drop future write end without first writing a value")

--- a/tests/misc_testsuite/component-model-async/futures.wast
+++ b/tests/misc_testsuite/component-model-async/futures.wast
@@ -70,22 +70,22 @@
   (core instance $i (instantiate $m (with "" (instance (export "future.cancel-write" (func $future-cancel-write))))))
 )
 
-;; future.close-readable
+;; future.drop-readable
 (component
   (core module $m
-    (import "" "future.close-readable" (func $future-close-readable (param i32)))
+    (import "" "future.drop-readable" (func $future-drop-readable (param i32)))
   )
   (type $future-type (future u8))
-  (core func $future-close-readable (canon future.close-readable $future-type))
-  (core instance $i (instantiate $m (with "" (instance (export "future.close-readable" (func $future-close-readable))))))
+  (core func $future-drop-readable (canon future.drop-readable $future-type))
+  (core instance $i (instantiate $m (with "" (instance (export "future.drop-readable" (func $future-drop-readable))))))
 )
 
-;; future.close-writable
+;; future.drop-writable
 (component
   (core module $m
-    (import "" "future.close-writable" (func $future-close-writable (param i32)))
+    (import "" "future.drop-writable" (func $future-drop-writable (param i32)))
   )
   (type $future-type (future u8))
-  (core func $future-close-writable (canon future.close-writable $future-type))
-  (core instance $i (instantiate $m (with "" (instance (export "future.close-writable" (func $future-close-writable))))))
+  (core func $future-drop-writable (canon future.drop-writable $future-type))
+  (core instance $i (instantiate $m (with "" (instance (export "future.drop-writable" (func $future-drop-writable))))))
 )

--- a/tests/misc_testsuite/component-model-async/streams.wast
+++ b/tests/misc_testsuite/component-model-async/streams.wast
@@ -70,22 +70,22 @@
   (core instance $i (instantiate $m (with "" (instance (export "stream.cancel-write" (func $stream-cancel-write))))))
 )
 
-;; stream.close-readable
+;; stream.drop-readable
 (component
   (core module $m
-    (import "" "stream.close-readable" (func $stream-close-readable (param i32)))
+    (import "" "stream.drop-readable" (func $stream-drop-readable (param i32)))
   )
   (type $stream-type (stream u8))
-  (core func $stream-close-readable (canon stream.close-readable $stream-type))
-  (core instance $i (instantiate $m (with "" (instance (export "stream.close-readable" (func $stream-close-readable))))))
+  (core func $stream-drop-readable (canon stream.drop-readable $stream-type))
+  (core instance $i (instantiate $m (with "" (instance (export "stream.drop-readable" (func $stream-drop-readable))))))
 )
 
-;; stream.close-writable
+;; stream.drop-writable
 (component
   (core module $m
-    (import "" "stream.close-writable" (func $stream-close-writable (param i32)))
+    (import "" "stream.drop-writable" (func $stream-drop-writable (param i32)))
   )
   (type $stream-type (stream u8))
-  (core func $stream-close-writable (canon stream.close-writable $stream-type))
-  (core instance $i (instantiate $m (with "" (instance (export "stream.close-writable" (func $stream-close-writable))))))
+  (core func $stream-drop-writable (canon stream.drop-writable $stream-type))
+  (core instance $i (instantiate $m (with "" (instance (export "stream.drop-writable" (func $stream-drop-writable))))))
 )


### PR DESCRIPTION
This updates `wasmtime-environ`, `wasmtime-cranelift`, and `wasmtime` to to use (some of) the new ABI defined in
https://github.com/WebAssembly/component-model/pull/524.  It covers everything in that PR _except_ the lifting and lowering changes to `future.{read,write}`, which we decided are more trouble than they're worth.

Still to do: add tests for the following items (Luke has volunteered to do this):

> * When a `future` is "done" (by a `COMPLETED` read/write or by the writable end receiving `DROPPED`), the only valid operation is `future.drop-{readable,writable}`.  `future.{read,write}` or lifting traps.
> * Because there's no great reason for streams to be more permissive than futures in this regard, streams are also given a "done" state with the same trapping rules as futures, but the stream "done" state is only set when `DROPPED` is received.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
