### PR TITLE
Document why `Accessor` is `Send`/`Sync` regardless of `T`

### DIFF
--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -295,6 +295,33 @@ where
     instance: Instance,
 }
 
+// Note that it is intentional at this time that `Accessor` does not actually
+// store `&mut T` or anything similar. This distinctly enables the `Accessor`
+// structure to be both `Send` and `Sync` regardless of what `T` is (or `D` for
+// that matter). This is used to ergonomically simplify bindings where the
+// majority of the time `Accessor` is closed over in a future which then needs
+// to be `Send` and `Sync`. To avoid needing to write `T: Send` everywhere (as
+// you already have to write `T: 'static`...) it helps to avoid this.
+//
+// Note as well that `Accessor` doesn't actually store its data at all. Instead
+// it's more of a "proof" of what can be accessed from TLS. API design around
+// `Accessor` and functions like `Linker::func_wrap_concurrent` are
+// intentionally made to ensure that `Accessor` is ideally only used in the
+// context that TLS variables are actually set. For example host functions are
+// given `&mut Accessor`, not `Accessor`, and this prevents them from persisting
+// the value outside of a future. Within the future the TLS variables are all
+// guaranteed to be set.
+//
+// Finally though this is not an ironclad guarantee, but nor does it need to be.
+// The TLS APIs are designed to panic or otherwise model usage where they're
+// called recursively or similar. It's hoped that code cannot be constructed to
+// actually hit this at runtime but this is not a safety requirement at this
+// time.
+const _: () = {
+    const fn assert<T: Send + Sync>() {}
+    assert::<Accessor<UnsafeCell<u32>>>();
+};
+
 impl<T> Accessor<T> {
     /// Creates a new `Accessor` backed by the specified functions.
     ///


### PR DESCRIPTION
I tried recently to add `PhantomData<&'a mut T>` to this type (with a new lifetime parameter too) and ended up deciding against it. I wanted to document my rationale as to why though and how the ability for `Accessor` to be both `Send` and `Sync` regardless of `T` is a property we'll likely intentionally want to uphold for the public API.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
