### PR TITLE
Reduce usage of `for<'a>` in trait bounds

### DIFF
--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -1304,7 +1304,7 @@ impl Instance {
     ) -> Result<V>
     where
         U: 'static,
-        F: for<'a> FnOnce(&'a mut Accessor<U>) -> Pin<Box<dyn Future<Output = V> + Send + 'a>>
+        F: FnOnce(&mut Accessor<U>) -> Pin<Box<dyn Future<Output = V> + Send + '_>>
             + Send
             + 'static,
     {
@@ -1320,7 +1320,7 @@ impl Instance {
     ) -> Pin<Box<dyn Future<Output = V> + Send + 'static>>
     where
         U: 'static,
-        F: for<'a> FnOnce(&'a mut Accessor<U>) -> Pin<Box<dyn Future<Output = V> + Send + 'a>>
+        F: FnOnce(&mut Accessor<U>) -> Pin<Box<dyn Future<Output = V> + Send + '_>>
             + Send
             + 'static,
     {
@@ -2461,10 +2461,7 @@ impl Instance {
     ) -> Pin<Box<dyn Future<Output = Result<R>> + Send + 'static>>
     where
         T: 'static,
-        F: for<'a> Fn(
-                &'a mut Accessor<T>,
-                P,
-            ) -> Pin<Box<dyn Future<Output = Result<R>> + Send + 'a>>
+        F: Fn(&mut Accessor<T>, P) -> Pin<Box<dyn Future<Output = Result<R>> + Send + '_>>
             + Send
             + Sync
             + 'static,

--- a/crates/wasmtime/src/runtime/component/func/host.rs
+++ b/crates/wasmtime/src/runtime/component/func/host.rs
@@ -39,8 +39,8 @@ impl core::fmt::Debug for HostFunc {
 impl HostFunc {
     fn from_canonical<T: 'static, F, P, R>(func: F) -> Arc<HostFunc>
     where
-        F: for<'a> Fn(
-                StoreContextMut<'a, T>,
+        F: Fn(
+                StoreContextMut<'_, T>,
                 Instance,
                 P,
             ) -> Pin<Box<dyn Future<Output = Result<R>> + Send + 'static>>
@@ -75,10 +75,7 @@ impl HostFunc {
     pub(crate) fn from_concurrent<T: 'static, F, P, R>(func: F) -> Arc<HostFunc>
     where
         T: 'static,
-        F: for<'a> Fn(
-                &'a mut Accessor<T>,
-                P,
-            ) -> Pin<Box<dyn Future<Output = Result<R>> + Send + 'a>>
+        F: Fn(&mut Accessor<T>, P) -> Pin<Box<dyn Future<Output = Result<R>> + Send + '_>>
             + Send
             + Sync
             + 'static,
@@ -105,8 +102,8 @@ impl HostFunc {
         storage_len: usize,
     ) -> bool
     where
-        F: for<'a> Fn(
-                StoreContextMut<'a, T>,
+        F: Fn(
+                StoreContextMut<'_, T>,
                 Instance,
                 P,
             ) -> Pin<Box<dyn Future<Output = Result<R>> + Send + 'static>>
@@ -139,13 +136,12 @@ impl HostFunc {
 
     fn new_dynamic_canonical<T: 'static, F>(func: F) -> Arc<HostFunc>
     where
-        F: for<'a> Fn(
-                StoreContextMut<'a, T>,
+        F: Fn(
+                StoreContextMut<'_, T>,
                 Instance,
                 Vec<Val>,
                 usize,
-            )
-                -> Pin<Box<dyn Future<Output = Result<Vec<Val>>> + Send + 'static>>
+            ) -> Pin<Box<dyn Future<Output = Result<Vec<Val>>> + Send + 'static>>
             + Send
             + Sync
             + 'static,
@@ -253,8 +249,8 @@ unsafe fn call_host<T, Params, Return, F>(
     closure: F,
 ) -> Result<()>
 where
-    F: for<'a> Fn(
-            StoreContextMut<'a, T>,
+    F: Fn(
+            StoreContextMut<'_, T>,
             Instance,
             Params,
         ) -> Pin<Box<dyn Future<Output = Result<Return>> + Send + 'static>>
@@ -709,8 +705,8 @@ unsafe fn call_host_dynamic<T, F>(
     closure: F,
 ) -> Result<()>
 where
-    F: for<'a> Fn(
-            StoreContextMut<'a, T>,
+    F: Fn(
+            StoreContextMut<'_, T>,
             Instance,
             Vec<Val>,
             usize,
@@ -937,8 +933,8 @@ extern "C" fn dynamic_entrypoint<T: 'static, F>(
     storage_len: usize,
 ) -> bool
 where
-    F: for<'a> Fn(
-            StoreContextMut<'a, T>,
+    F: Fn(
+            StoreContextMut<'_, T>,
             Instance,
             Vec<Val>,
             usize,


### PR DESCRIPTION
This is generally not-well-known syntax and it's additionally not always required, so try to avoid it where rustc inference can kick in instead.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
