### PR TITLE
Remove some usage of `Box::pin`

### DIFF
--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -1317,7 +1317,7 @@ impl Instance {
         self,
         mut store: impl AsContextMut<Data = U>,
         fun: F,
-    ) -> Pin<Box<dyn Future<Output = V> + Send + 'static>>
+    ) -> impl Future<Output = V> + 'static
     where
         U: 'static,
         F: for<'a> FnOnce(&'a mut Accessor<U>) -> Pin<Box<dyn Future<Output = V> + Send + 'a>>
@@ -1325,11 +1325,11 @@ impl Instance {
             + 'static,
     {
         let token = StoreToken::new(store.as_context_mut());
-        let mut accessor = Accessor::new(token, self);
-        let mut future = Box::pin(async move { fun(&mut accessor).await });
-        Box::pin(future::poll_fn(move |cx| {
-            self.poll_then_spawn(cx, future.as_mut())
-        }))
+        async move {
+            let mut accessor = Accessor::new(token, self);
+            let mut future = pin!(fun(&mut accessor));
+            future::poll_fn(move |cx| self.poll_then_spawn(cx, future.as_mut())).await
+        }
     }
 
     /// Spawn a background task to run as part of this instance's event loop.
@@ -2458,7 +2458,7 @@ impl Instance {
         store: StoreContextMut<T>,
         closure: Arc<F>,
         params: P,
-    ) -> Pin<Box<dyn Future<Output = Result<R>> + Send + 'static>>
+    ) -> impl Future<Output = Result<R>> + 'static
     where
         T: 'static,
         F: for<'a> Fn(
@@ -2472,11 +2472,11 @@ impl Instance {
         R: Send + Sync + 'static,
     {
         let token = StoreToken::new(store);
-        let mut accessor = Accessor::new(token, self);
-        let mut future = Box::pin(async move { closure(&mut accessor, params).await });
-        Box::pin(future::poll_fn(move |cx| {
-            self.poll_then_spawn(cx, future.as_mut())
-        }))
+        async move {
+            let mut accessor = Accessor::new(token, self);
+            let mut future = pin!(closure(&mut accessor, params));
+            future::poll_fn(move |cx| self.poll_then_spawn(cx, future.as_mut())).await
+        }
     }
 
     /// Poll the specified future once on behalf of a guest->host call using an
@@ -4488,29 +4488,32 @@ fn checked<F: Future + Send + 'static>(
     instance: Instance,
     fut: F,
 ) -> impl Future<Output = F::Output> + Send + 'static {
-    let mut fut = Box::pin(fut);
-    future::poll_fn(move |cx| {
-        let message = "\
-            `Future`s which depend on asynchronous component tasks, streams, or \
-            futures to complete may only be polled from the event loop of the \
-            instance from which they originated.  Please use \
-            `Instance::{run,run_with,spawn}` to poll or await them.\
-        ";
-        tls::try_get(|store| {
-            let matched = match store {
-                tls::TryGet::Some(store) => {
-                    store.concurrent_async_state().current_instance
-                        == Some(instance.id().instance())
-                }
-                tls::TryGet::Taken | tls::TryGet::None => false,
-            };
+    async move {
+        let mut fut = pin!(fut);
+        future::poll_fn(move |cx| {
+            let message = "\
+                `Future`s which depend on asynchronous component tasks, streams, or \
+                futures to complete may only be polled from the event loop of the \
+                instance from which they originated.  Please use \
+                `Instance::{run,run_with,spawn}` to poll or await them.\
+            ";
+            tls::try_get(|store| {
+                let matched = match store {
+                    tls::TryGet::Some(store) => {
+                        store.concurrent_async_state().current_instance
+                            == Some(instance.id().instance())
+                    }
+                    tls::TryGet::Taken | tls::TryGet::None => false,
+                };
 
-            if !matched {
-                panic!("{message}")
-            }
-        });
-        fut.as_mut().poll(cx)
-    })
+                if !matched {
+                    panic!("{message}")
+                }
+            });
+            fut.as_mut().poll(cx)
+        })
+        .await
+    }
 }
 
 /// Assert that `Instance::run[_with]` has not been called from within an

--- a/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
@@ -891,7 +891,9 @@ impl<B> StreamWriter<B> {
             self.write(buffer).then(|(me, buffer)| async move {
                 if let Some(me) = me {
                     if buffer.remaining().len() > 0 {
-                        me.write_all(buffer).await
+                        // Note the use of `Box::pin` which is required due to
+                        // the recursive nature of this function.
+                        Box::pin(me.write_all(buffer)).await
                     } else {
                         (Some(me), buffer)
                     }

--- a/crates/wasmtime/src/runtime/component/func/host.rs
+++ b/crates/wasmtime/src/runtime/component/func/host.rs
@@ -87,7 +87,7 @@ impl HostFunc {
     {
         let func = Arc::new(func);
         Self::from_canonical::<T, _, _, _>(move |store, instance, params| {
-            instance.wrap_call(store, func.clone(), params)
+            Box::pin(instance.wrap_call(store, func.clone(), params))
         })
     }
 
@@ -179,17 +179,17 @@ impl HostFunc {
     pub(crate) fn new_dynamic_concurrent<T: 'static, F>(func: F) -> Arc<HostFunc>
     where
         T: 'static,
-        F: for<'a> Fn(
-                &'a mut Accessor<T>,
+        F: Fn(
+                &mut Accessor<T>,
                 Vec<Val>,
-            ) -> Pin<Box<dyn Future<Output = Result<Vec<Val>>> + Send + 'a>>
+            ) -> Pin<Box<dyn Future<Output = Result<Vec<Val>>> + Send + '_>>
             + Send
             + Sync
             + 'static,
     {
         let func = Arc::new(func);
         Self::new_dynamic_canonical::<T, _>(move |store, instance, params, _| {
-            instance.wrap_call(store, func.clone(), params)
+            Box::pin(instance.wrap_call(store, func.clone(), params))
         })
     }
 


### PR DESCRIPTION
In a number of locations it's not necessary so instead use async blocks and `pin!` instead. Where necessary it's pushed to the boundaries of where it's required to make it more clear that only at the boundaries does `Pin<Box<...>>` come into play.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
