### PR TITLE
Beef up documentation on `Accessor`

### DIFF
--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -294,7 +294,7 @@ where
 /// literally store these values. The basic problem is that when a concurrent
 /// host future is being polled it has access to `&mut T` (and the whole
 /// `Store`) but when it's not being polled it does not have access to these
-/// avlues. This reflects how the store is only ever polling one future at a
+/// values. This reflects how the store is only ever polling one future at a
 /// time so the store is effectively being passed between futures.
 ///
 /// Rust's `Future` trait, however, has no means of passing a `Store`


### PR DESCRIPTION
Notably document how using an `Accessor` as part of a `Drop` implementation will probably not work, nor is it expected to work. I'm not sure there's anything we can do about this unfortunately, so we'll kind of just have to hope that no one does it.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
