### PR TITLE
remove unused `&mut Context` param from `poll_fn` callback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5207,7 +5207,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen"
 version = "0.42.1"
-source = "git+https://github.com/dicej/wit-bindgen?branch=future-and-stream-changes#cf6deea12419e06201b2977ff109374c89a380a8"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#34e399e30a2a6a5ed45721e4c22e08c4158d9162"
 dependencies = [
  "wit-bindgen-rt 0.42.1",
  "wit-bindgen-rust-macro",
@@ -5216,7 +5216,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-core"
 version = "0.42.1"
-source = "git+https://github.com/dicej/wit-bindgen?branch=future-and-stream-changes#cf6deea12419e06201b2977ff109374c89a380a8"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#34e399e30a2a6a5ed45721e4c22e08c4158d9162"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -5244,7 +5244,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-rt"
 version = "0.42.1"
-source = "git+https://github.com/dicej/wit-bindgen?branch=future-and-stream-changes#cf6deea12419e06201b2977ff109374c89a380a8"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#34e399e30a2a6a5ed45721e4c22e08c4158d9162"
 dependencies = [
  "bitflags 2.6.0",
  "futures",
@@ -5254,7 +5254,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-rust"
 version = "0.42.1"
-source = "git+https://github.com/dicej/wit-bindgen?branch=future-and-stream-changes#cf6deea12419e06201b2977ff109374c89a380a8"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#34e399e30a2a6a5ed45721e4c22e08c4158d9162"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -5269,7 +5269,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-rust-macro"
 version = "0.42.1"
-source = "git+https://github.com/dicej/wit-bindgen?branch=future-and-stream-changes#cf6deea12419e06201b2977ff109374c89a380a8"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#34e399e30a2a6a5ed45721e4c22e08c4158d9162"
 dependencies = [
  "anyhow",
  "prettyplease",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -630,9 +630,9 @@ wit-component = { git = "https://github.com/bytecodealliance/wasm-tools" }
 wasm-wave = { git = "https://github.com/bytecodealliance/wasm-tools" }
 wasm-compose = { git = "https://github.com/bytecodealliance/wasm-tools" }
 wasm-metadata = { git = "https://github.com/bytecodealliance/wasm-tools" }
-wit-bindgen = { git = "https://github.com/dicej/wit-bindgen", branch = "future-and-stream-changes" }
-wit-bindgen-rt = { git = "https://github.com/dicej/wit-bindgen", branch = "future-and-stream-changes" }
-wit-bindgen-rust-macro = { git = "https://github.com/dicej/wit-bindgen", branch = "future-and-stream-changes" }
+wit-bindgen = { git = "https://github.com/bytecodealliance/wit-bindgen" }
+wit-bindgen-rt = { git = "https://github.com/bytecodealliance/wit-bindgen" }
+wit-bindgen-rust-macro = { git = "https://github.com/bytecodealliance/wit-bindgen" }
 
 # wasmparser = { path = '../wasm-tools/crates/wasmparser' }
 # wat = { path = '../wasm-tools/crates/wat' }

--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -1618,7 +1618,7 @@ impl Instance {
         //
         // By the time the future returned by `poll_fn` completes, we'll have
         // exclusive access to it again.
-        let fiber = poll_fn(store, guard_range, move |_, mut store| {
+        let fiber = poll_fn(store, guard_range, move |mut store| {
             // SAFETY: We confer exclusive access to the store to the fiber
             // here, only taking it back when the fiber yields it to us or
             // exits.
@@ -4573,7 +4573,7 @@ async fn on_fiber_raw<R: Send + 'static>(
     let (mut fiber, mut rx) = prepare_fiber(store.traitobj_mut(), func)?;
 
     let guard_range = fiber.guard_range();
-    poll_fn(store, guard_range, move |_, mut store| {
+    poll_fn(store, guard_range, move |mut store| {
         // SAFETY: We confer exclusive access to the store to the fiber here,
         // only taking it back when the fiber yields it to us or exits.
         match unsafe { resume_fiber(&mut fiber, store.take(), Ok(())) } {
@@ -5077,7 +5077,7 @@ fn queue_call0<T: 'static>(
 async fn poll_fn<R>(
     store: &mut StoreOpaque,
     guard_range: (Option<SendSyncPtr<u8>>, Option<SendSyncPtr<u8>>),
-    mut fun: impl FnMut(&mut Context, Option<*mut dyn VMStore>) -> Result<R, Option<*mut dyn VMStore>>,
+    mut fun: impl FnMut(Option<*mut dyn VMStore>) -> Result<R, Option<*mut dyn VMStore>>,
 ) -> R {
     #[derive(Clone, Copy)]
     struct PollCx(*mut PollContext);
@@ -5105,7 +5105,7 @@ async fn poll_fn<R>(
             #[allow(dropping_copy_types)]
             drop(poll_cx);
 
-            match fun(cx, store.take().map(|s| s.0.as_ptr())) {
+            match fun(store.take().map(|s| s.0.as_ptr())) {
                 Ok(v) => Poll::Ready(v),
                 Err(s) => {
                     store = s.map(|s| VMStoreRawPtr(NonNull::new(s).unwrap()));


### PR DESCRIPTION
This would have been unsound to use under stack borrowing rules, and wasn't used anyway.

Also, I've switched the `wit-bindgen*` deps to point to the bytecodealliance repo rather than my fork now that the required PR has been merged.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
