### PR TITLE
swap `stack_chain` fields in `CallThreadState::swap`

### DIFF
--- a/crates/wasmtime/src/runtime/vm/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers.rs
@@ -587,8 +587,8 @@ mod call_thread_state {
 
         #[cfg(feature = "async")]
         pub(crate) unsafe fn swap(&self) {
-            unsafe fn swap(a: &core::cell::UnsafeCell<usize>, b: &mut usize) {
-                *a.get() = core::mem::replace(b, *a.get());
+            unsafe fn swap<T: Clone>(a: &core::cell::UnsafeCell<T>, b: &mut T) {
+                *a.get() = core::mem::replace(b, (*a.get()).clone());
             }
 
             let cx = self.vm_store_context.as_ref();
@@ -604,6 +604,7 @@ mod call_thread_state {
                 &cx.last_wasm_entry_fp,
                 &mut (*self.old_state).last_wasm_entry_fp,
             );
+            swap(&cx.stack_chain, &mut (*self.old_state).stack_chain);
         }
     }
 }


### PR DESCRIPTION
The recently-merged core stack switching support added this new field, which we must save and restore when switching fibers.

Fixes #209

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
