### PR TITLE
address CM async miri violations

### DIFF
--- a/ci/miri-provenance-test.sh
+++ b/ci/miri-provenance-test.sh
@@ -8,18 +8,19 @@
 set -ex
 
 compile() {
-  cargo run --no-default-features --features compile,pulley,wat,gc-drc,component-model \
+  cargo run --no-default-features --features compile,pulley,wat,gc-drc,component-model,component-model-async \
     compile --target pulley64 $1 \
     -o ${1%.wat}.cwasm \
     -O memory-reservation=$((1 << 20)) \
     -O memory-guard-size=0 \
     -O signals-based-traps=n \
-    -W function-references
+    -W function-references,component-model-async,component-model-async-stackful,component-model-async-builtins,component-model-error-context
 }
 
 compile ./tests/all/pulley_provenance_test.wat
 compile ./tests/all/pulley_provenance_test_component.wat
+compile ./tests/all/pulley_provenance_test_async_component.wat
 
 MIRIFLAGS="$MIRIFLAGS -Zmiri-disable-isolation -Zmiri-permissive-provenance" \
   cargo miri test --test all -- \
-    --ignored pulley_provenance_test "$@"
+    --ignored "$@"

--- a/ci/miri-provenance-test.sh
+++ b/ci/miri-provenance-test.sh
@@ -23,4 +23,4 @@ compile ./tests/all/pulley_provenance_test_async_component.wat
 
 MIRIFLAGS="$MIRIFLAGS -Zmiri-disable-isolation -Zmiri-permissive-provenance" \
   cargo miri test --test all -- \
-    --ignored "$@"
+    --ignored pulley_provenance_test "$@"

--- a/crates/wasmtime/src/runtime/store/async_.rs
+++ b/crates/wasmtime/src/runtime/store/async_.rs
@@ -750,7 +750,7 @@ impl StoreOpaque {
     pub(crate) fn async_guard_range(&mut self) -> Range<*mut u8> {
         #[cfg(feature = "component-model-async")]
         {
-            self.concurrent_async_state().async_guard_range()
+            unsafe { (*self.concurrent_async_state()).async_guard_range() }
         }
         #[cfg(not(feature = "component-model-async"))]
         unsafe {

--- a/tests/all/pulley.rs
+++ b/tests/all/pulley.rs
@@ -385,6 +385,105 @@ fn pulley_provenance_test_components() -> Result<()> {
     Ok(())
 }
 
+async fn sleep(duration: std::time::Duration) {
+    // TODO: We should be able to use `tokio::time::sleep` here, but as of this
+    // writing the miri-compatible version of `wasmtime-fiber` uses threads
+    // behind the scenes, which means thread-local storage is not preserved when
+    // we switch fibers, and that confuses Tokio.  If we ever fix that we can
+    // stop using our own, special version of `sleep` and switch back to the
+    // Tokio version.
+
+    use std::{
+        future,
+        sync::{
+            Arc, Mutex,
+            atomic::{AtomicU32, Ordering::SeqCst},
+        },
+        task::Poll,
+        thread,
+    };
+
+    let state = Arc::new(AtomicU32::new(0));
+    let waker = Arc::new(Mutex::new(None));
+    future::poll_fn(move |cx| match state.load(SeqCst) {
+        0 => {
+            state.store(1, SeqCst);
+            let state = state.clone();
+            *waker.lock().unwrap() = Some(cx.waker().clone());
+            let waker = waker.clone();
+            thread::spawn(move || {
+                thread::sleep(duration);
+                state.store(2, SeqCst);
+                let waker = waker.lock().unwrap().clone().unwrap();
+                waker.wake();
+            });
+            Poll::Pending
+        }
+        1 => {
+            *waker.lock().unwrap() = Some(cx.waker().clone());
+            Poll::Pending
+        }
+        2 => Poll::Ready(()),
+        _ => unreachable!(),
+    })
+    .await;
+}
+
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn pulley_provenance_test_async_components() -> Result<()> {
+    let mut config = provenance_test_config();
+    config.async_support(true);
+    config.wasm_component_model_async(true);
+    config.wasm_component_model_async_stackful(true);
+    config.wasm_component_model_async_builtins(true);
+    config.wasm_component_model_error_context(true);
+    let engine = Engine::new(&config)?;
+    let component = if cfg!(miri) {
+        unsafe {
+            Component::deserialize_file(
+                &engine,
+                "./tests/all/pulley_provenance_test_async_component.cwasm",
+            )?
+        }
+    } else {
+        Component::from_file(
+            &engine,
+            "./tests/all/pulley_provenance_test_async_component.wat",
+        )?
+    };
+    {
+        let mut store = Store::new(&engine, ());
+        let mut linker = component::Linker::new(&engine);
+        linker.root().func_wrap_concurrent("sleep", |_, ()| {
+            Box::pin(async {
+                sleep(std::time::Duration::from_millis(10)).await;
+                Ok(())
+            })
+        })?;
+
+        let instance = linker.instantiate_async(&mut store, &component).await?;
+
+        let run = instance.get_typed_func::<(), ()>(&mut store, "run-stackless")?;
+        let run = run.call_concurrent(&mut store, ());
+        instance.run(&mut store, run).await??;
+
+        let run = instance.get_typed_func::<(), ()>(&mut store, "run-stackful")?;
+        let run = run.call_concurrent(&mut store, ());
+        instance.run(&mut store, run).await??;
+
+        let run = instance.get_typed_func::<(), ()>(&mut store, "run-stackless-stackless")?;
+        let run = run.call_concurrent(&mut store, ());
+        instance.run(&mut store, run).await??;
+
+        let run = instance.get_typed_func::<(), ()>(&mut store, "run-stackful-stackful")?;
+        let run = run.call_concurrent(&mut store, ());
+        instance.run(&mut store, run).await??;
+    }
+
+    Ok(())
+}
+
 #[test]
 #[cfg(not(miri))]
 fn enabling_debug_info_doesnt_break_anything() -> Result<()> {

--- a/tests/all/pulley.rs
+++ b/tests/all/pulley.rs
@@ -82,7 +82,6 @@ fn provenance_test_config() -> Config {
     config.memory_reservation(1 << 20);
     config.memory_guard_size(0);
     config.signals_based_traps(false);
-    config.async_support(true);
     config.wasm_component_model_async(true);
     config.wasm_component_model_async_stackful(true);
     config.wasm_component_model_async_builtins(true);
@@ -114,9 +113,9 @@ fn provenance_test_config() -> Config {
 /// and instructions. The goal is to kind of do a dry run of interesting
 /// shapes/sizes of what you can do with core wasm and ensure MIRI gives us a
 /// clean bill of health.
-#[tokio::test]
+#[test]
 #[cfg_attr(miri, ignore)]
-async fn pulley_provenance_test() -> Result<()> {
+fn pulley_provenance_test() -> Result<()> {
     let config = provenance_test_config();
     let engine = Engine::new(&config)?;
     let module = if cfg!(miri) {
@@ -137,8 +136,7 @@ async fn pulley_provenance_test() -> Result<()> {
         results[2] = Val::I32(3);
         Ok(())
     });
-    let instance =
-        Instance::new_async(&mut store, &module, &[host_wrap.into(), host_new.into()]).await?;
+    let instance = Instance::new(&mut store, &module, &[host_wrap.into(), host_new.into()])?;
 
     for func in [
         "call-wasm",
@@ -151,7 +149,7 @@ async fn pulley_provenance_test() -> Result<()> {
         let func = instance
             .get_typed_func::<(), (i32, i32, i32)>(&mut store, func)
             .unwrap();
-        let results = func.call_async(&mut store, ()).await?;
+        let results = func.call(&mut store, ())?;
         assert_eq!(results, (1, 2, 3));
     }
 
@@ -159,51 +157,45 @@ async fn pulley_provenance_test() -> Result<()> {
     for func in ["call_ref-wasm", "return_call_ref-wasm"] {
         println!("testing func {func:?}");
         let func = instance.get_typed_func::<Func, (i32, i32, i32)>(&mut store, func)?;
-        let results = func.call_async(&mut store, funcref).await?;
+        let results = func.call(&mut store, funcref)?;
         assert_eq!(results, (1, 2, 3));
     }
 
     let trap = instance
         .get_typed_func::<(), ()>(&mut store, "unreachable")?
-        .call_async(&mut store, ())
-        .await
+        .call(&mut store, ())
         .unwrap_err()
         .downcast::<Trap>()?;
     assert_eq!(trap, Trap::UnreachableCodeReached);
 
     let trap = instance
         .get_typed_func::<(), i32>(&mut store, "divide-by-zero")?
-        .call_async(&mut store, ())
-        .await
+        .call(&mut store, ())
         .unwrap_err()
         .downcast::<Trap>()?;
     assert_eq!(trap, Trap::IntegerDivisionByZero);
 
     instance
         .get_typed_func::<(), ()>(&mut store, "memory-intrinsics")?
-        .call_async(&mut store, ())
-        .await?;
+        .call(&mut store, ())?;
     instance
         .get_typed_func::<(), ()>(&mut store, "table-intrinsics")?
-        .call_async(&mut store, ())
-        .await?;
+        .call(&mut store, ())?;
 
-    let funcref = Func::wrap_async(&mut store, move |mut caller: Caller<'_, ()>, ()| {
-        Box::new(async move {
-            let func = instance.get_typed_func::<(), (i32, i32, i32)>(&mut caller, "call-wasm")?;
-            func.call_async(&mut caller, ()).await
-        })
+    let funcref = Func::wrap(&mut store, move |mut caller: Caller<'_, ()>| {
+        let func = instance.get_typed_func::<(), (i32, i32, i32)>(&mut caller, "call-wasm")?;
+        func.call(&mut caller, ())
     });
     let func = instance.get_typed_func::<Func, (i32, i32, i32)>(&mut store, "call_ref-wasm")?;
-    let results = func.call_async(&mut store, funcref).await?;
+    let results = func.call(&mut store, funcref)?;
     assert_eq!(results, (1, 2, 3));
 
     Ok(())
 }
 
-#[tokio::test]
+#[test]
 #[cfg_attr(miri, ignore)]
-async fn pulley_provenance_test_components() -> Result<()> {
+fn pulley_provenance_test_components() -> Result<()> {
     let config = provenance_test_config();
     let engine = Engine::new(&config)?;
     let component = if cfg!(miri) {
@@ -252,7 +244,7 @@ async fn pulley_provenance_test_components() -> Result<()> {
         linker
             .root()
             .func_wrap("host-list", |_, (value,): (Vec<String>,)| Ok((value,)))?;
-        let instance = linker.instantiate_async(&mut store, &component).await?;
+        let instance = linker.instantiate(&mut store, &component)?;
 
         let guest_u32 = instance.get_typed_func::<(u32,), (u32,)>(&mut store, "guest-u32")?;
         let guest_enum = instance.get_typed_func::<(E,), (E,)>(&mut store, "guest-enum")?;
@@ -267,50 +259,45 @@ async fn pulley_provenance_test_components() -> Result<()> {
         let guest_list =
             instance.get_typed_func::<(&[&str],), (Vec<String>,)>(&mut store, "guest-list")?;
 
-        let (result,) = guest_u32.call_async(&mut store, (42,)).await?;
+        let (result,) = guest_u32.call(&mut store, (42,))?;
         assert_eq!(result, 42);
-        guest_u32.post_return_async(&mut store).await?;
+        guest_u32.post_return(&mut store)?;
 
-        let (result,) = guest_enum.call_async(&mut store, (E::B,)).await?;
+        let (result,) = guest_enum.call(&mut store, (E::B,))?;
         assert_eq!(result, E::B);
-        guest_enum.post_return_async(&mut store).await?;
+        guest_enum.post_return(&mut store)?;
 
-        let (result,) = guest_option.call_async(&mut store, (None,)).await?;
+        let (result,) = guest_option.call(&mut store, (None,))?;
         assert_eq!(result, None);
-        guest_option.post_return_async(&mut store).await?;
-        let (result,) = guest_option.call_async(&mut store, (Some(200),)).await?;
+        guest_option.post_return(&mut store)?;
+        let (result,) = guest_option.call(&mut store, (Some(200),))?;
         assert_eq!(result, Some(200));
-        guest_option.post_return_async(&mut store).await?;
+        guest_option.post_return(&mut store)?;
 
-        let (result,) = guest_result.call_async(&mut store, (Ok(10),)).await?;
+        let (result,) = guest_result.call(&mut store, (Ok(10),))?;
         assert_eq!(result, Ok(10));
-        guest_result.post_return_async(&mut store).await?;
-        let (result,) = guest_result
-            .call_async(&mut store, (Err(i64::MIN),))
-            .await?;
+        guest_result.post_return(&mut store)?;
+        let (result,) = guest_result.call(&mut store, (Err(i64::MIN),))?;
         assert_eq!(result, Err(i64::MIN));
-        guest_result.post_return_async(&mut store).await?;
+        guest_result.post_return(&mut store)?;
 
-        let (result,) = guest_string.call_async(&mut store, ("",)).await?;
+        let (result,) = guest_string.call(&mut store, ("",))?;
         assert_eq!(result, "");
-        guest_string.post_return_async(&mut store).await?;
-        let (result,) = guest_string.call_async(&mut store, ("hello",)).await?;
+        guest_string.post_return(&mut store)?;
+        let (result,) = guest_string.call(&mut store, ("hello",))?;
         assert_eq!(result, "hello");
-        guest_string.post_return_async(&mut store).await?;
+        guest_string.post_return(&mut store)?;
 
-        let (result,) = guest_list.call_async(&mut store, (&[],)).await?;
+        let (result,) = guest_list.call(&mut store, (&[],))?;
         assert!(result.is_empty());
-        guest_list.post_return_async(&mut store).await?;
-        let (result,) = guest_list
-            .call_async(&mut store, (&["a", "", "b", "c"],))
-            .await?;
+        guest_list.post_return(&mut store)?;
+        let (result,) = guest_list.call(&mut store, (&["a", "", "b", "c"],))?;
         assert_eq!(result, ["a", "", "b", "c"]);
-        guest_list.post_return_async(&mut store).await?;
+        guest_list.post_return(&mut store)?;
 
         instance
             .get_typed_func::<(), ()>(&mut store, "resource-intrinsics")?
-            .call_async(&mut store, ())
-            .await?;
+            .call(&mut store, ())?;
     }
     {
         use wasmtime::component::Val;
@@ -340,7 +327,7 @@ async fn pulley_provenance_test_components() -> Result<()> {
             results[0] = args[0].clone();
             Ok(())
         })?;
-        let instance = linker.instantiate_async(&mut store, &component).await?;
+        let instance = linker.instantiate(&mut store, &component)?;
 
         let guest_u32 = instance.get_func(&mut store, "guest-u32").unwrap();
         let guest_enum = instance.get_func(&mut store, "guest-enum").unwrap();
@@ -350,71 +337,53 @@ async fn pulley_provenance_test_components() -> Result<()> {
         let guest_list = instance.get_func(&mut store, "guest-list").unwrap();
 
         let mut results = [Val::U32(0)];
-        guest_u32
-            .call_async(&mut store, &[Val::U32(42)], &mut results)
-            .await?;
+        guest_u32.call(&mut store, &[Val::U32(42)], &mut results)?;
         assert_eq!(results[0], Val::U32(42));
-        guest_u32.post_return_async(&mut store).await?;
+        guest_u32.post_return(&mut store)?;
 
-        guest_enum
-            .call_async(&mut store, &[Val::Enum("B".into())], &mut results)
-            .await?;
+        guest_enum.call(&mut store, &[Val::Enum("B".into())], &mut results)?;
         assert_eq!(results[0], Val::Enum("B".into()));
-        guest_enum.post_return_async(&mut store).await?;
+        guest_enum.post_return(&mut store)?;
 
-        guest_option
-            .call_async(&mut store, &[Val::Option(None)], &mut results)
-            .await?;
+        guest_option.call(&mut store, &[Val::Option(None)], &mut results)?;
         assert_eq!(results[0], Val::Option(None));
-        guest_option.post_return_async(&mut store).await?;
-        guest_option
-            .call_async(
-                &mut store,
-                &[Val::Option(Some(Box::new(Val::U8(201))))],
-                &mut results,
-            )
-            .await?;
+        guest_option.post_return(&mut store)?;
+        guest_option.call(
+            &mut store,
+            &[Val::Option(Some(Box::new(Val::U8(201))))],
+            &mut results,
+        )?;
         assert_eq!(results[0], Val::Option(Some(Box::new(Val::U8(201)))));
-        guest_option.post_return_async(&mut store).await?;
+        guest_option.post_return(&mut store)?;
 
-        guest_result
-            .call_async(
-                &mut store,
-                &[Val::Result(Ok(Some(Box::new(Val::U16(20)))))],
-                &mut results,
-            )
-            .await?;
+        guest_result.call(
+            &mut store,
+            &[Val::Result(Ok(Some(Box::new(Val::U16(20)))))],
+            &mut results,
+        )?;
         assert_eq!(results[0], Val::Result(Ok(Some(Box::new(Val::U16(20))))));
-        guest_result.post_return_async(&mut store).await?;
-        guest_result
-            .call_async(
-                &mut store,
-                &[Val::Result(Err(Some(Box::new(Val::S64(i64::MAX)))))],
-                &mut results,
-            )
-            .await?;
+        guest_result.post_return(&mut store)?;
+        guest_result.call(
+            &mut store,
+            &[Val::Result(Err(Some(Box::new(Val::S64(i64::MAX)))))],
+            &mut results,
+        )?;
         assert_eq!(
             results[0],
             Val::Result(Err(Some(Box::new(Val::S64(i64::MAX)))))
         );
-        guest_result.post_return_async(&mut store).await?;
+        guest_result.post_return(&mut store)?;
 
-        guest_string
-            .call_async(&mut store, &[Val::String("B".into())], &mut results)
-            .await?;
+        guest_string.call(&mut store, &[Val::String("B".into())], &mut results)?;
         assert_eq!(results[0], Val::String("B".into()));
-        guest_string.post_return_async(&mut store).await?;
-        guest_string
-            .call_async(&mut store, &[Val::String("".into())], &mut results)
-            .await?;
+        guest_string.post_return(&mut store)?;
+        guest_string.call(&mut store, &[Val::String("".into())], &mut results)?;
         assert_eq!(results[0], Val::String("".into()));
-        guest_string.post_return_async(&mut store).await?;
+        guest_string.post_return(&mut store)?;
 
-        guest_list
-            .call_async(&mut store, &[Val::List(Vec::new())], &mut results)
-            .await?;
+        guest_list.call(&mut store, &[Val::List(Vec::new())], &mut results)?;
         assert_eq!(results[0], Val::List(Vec::new()));
-        guest_list.post_return_async(&mut store).await?;
+        guest_list.post_return(&mut store)?;
     }
 
     Ok(())
@@ -467,7 +436,8 @@ async fn sleep(duration: std::time::Duration) {
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
 async fn pulley_provenance_test_async_components() -> Result<()> {
-    let config = provenance_test_config();
+    let mut config = provenance_test_config();
+    config.async_support(true);
     let engine = Engine::new(&config)?;
     let component = if cfg!(miri) {
         unsafe {

--- a/tests/all/pulley_provenance_test_async_component.wat
+++ b/tests/all/pulley_provenance_test_async_component.wat
@@ -1,0 +1,106 @@
+(component
+  (import "sleep" (func $sleep))
+
+  (component $A
+    (import "run-stackless" (func $run_stackless))
+    (import "run-stackful" (func $run_stackful))
+    (core module $libc (memory (export "memory") 1))
+    (core instance $libc (instantiate $libc))
+
+    (core func $task_return (canon task.return))
+    (core func $waitable_set_new (canon waitable-set.new))
+    (core func $waitable_set_wait (canon waitable-set.wait (memory $libc "memory")))
+    (core func $waitable_join (canon waitable.join))
+
+    (canon lower (func $run_stackless) async (core func $run_stackless))
+    (canon lower (func $run_stackful) async (core func $run_stackful))
+
+    (core module $m
+      (import "" "memory" (memory 1))
+      (import "" "task.return" (func $task_return))
+      (import "" "waitable-set.new" (func $waitable_set_new (result i32)))
+      (import "" "waitable-set.wait" (func $waitable_set_wait (param i32 i32) (result i32)))
+      (import "" "waitable.join" (func $waitable_join (param i32 i32)))
+      (import "" "run-stackless" (func $run_stackless (result i32)))
+      (import "" "run-stackful" (func $run_stackful (result i32)))
+
+      (global $set (mut i32) (i32.const 0))
+      (global $call (mut i32) (i32.const 0))
+
+      (func (export "run-stackless") (result i32)
+        (local $ret i32)
+        (local $status i32)
+        (local.set $ret (call $run_stackless))
+        (local.set $status (i32.and (local.get $ret) (i32.const 0xF)))
+        (global.set $call (i32.shr_u (local.get $ret) (i32.const 4)))
+        (if (result i32) (i32.eq (i32.const 1 (; STARTED ;)) (local.get $status))
+          (then
+            (global.set $set (call $waitable_set_new))
+            (call $waitable_join (global.get $call) (global.get $set))
+            (i32.or (i32.const 2 (; WAIT ;)) (i32.shl (global.get $set) (i32.const 4))))
+          (else
+            (if (result i32) (i32.eq (i32.const 2 (; RETURNED ;)) (local.get $status))
+               (then
+                 (call $task_return)
+                 (i32.const 0 (; EXIT ;)))
+               (else unreachable)))))
+
+      (func (export "run-stackful")
+        (local $ret i32)
+        (local $set i32)
+        (local $status i32)  
+        (local $call i32)
+        (local $event0 i32)
+        (local $event1 i32)
+        (local $event2 i32)
+        (local.set $ret (call $run_stackful))
+        (local.set $status (i32.and (local.get $ret) (i32.const 0xF)))
+        (local.set $call (i32.shr_u (local.get $ret) (i32.const 4)))
+        (if (i32.eq (i32.const 1 (; STARTED ;)) (local.get $status))
+          (then
+            (local.set $set (call $waitable_set_new))
+            (call $waitable_join (local.get $call) (local.get $set))
+            (local.set $event0 (call $waitable_set_wait (local.get $set) (i32.const 0)))
+            (if (i32.ne (i32.const 1 (; SUBTASK ;)) (local.get $event0))
+              (then unreachable))
+            (local.set $event1 (i32.load (i32.const 0)))
+            (local.set $event2 (i32.load (i32.const 4)))
+            (if (i32.ne (local.get $call) (local.get $event1))
+              (then unreachable))
+            (if (i32.ne (i32.const 2 (; RETURNED ;)) (local.get $event2))
+              (then unreachable)))
+          (else
+            (if (i32.ne (i32.const 2 (; RETURNED ;)) (local.get $status))
+               (then unreachable))))
+        (call $task_return))
+
+      (func (export "cb") (param $event0 i32) (param $event1 i32) (param $event2 i32) (result i32)
+        (local $status i32)
+        (if (i32.ne (i32.const 1 (; SUBTASK ;)) (local.get $event0))
+          (then unreachable))
+        (call $task_return)
+        (i32.const 0 (; EXIT ;))))
+
+    (core instance $i (instantiate $m
+      (with "" (instance
+        (export "memory" (memory $libc "memory"))
+        (export "task.return" (func $task_return))
+        (export "waitable-set.new" (func $waitable_set_new))
+        (export "waitable-set.wait" (func $waitable_set_wait))
+        (export "waitable.join" (func $waitable_join))
+        (export "run-stackless" (func $run_stackless))
+        (export "run-stackful" (func $run_stackful))))))
+
+    (func (export "run-stackless") (canon lift (core func $i "run-stackless") async (callback (func $i "cb"))))
+    (func (export "run-stackful") (canon lift (core func $i "run-stackful") async)))
+
+  (instance $a (instantiate $A
+    (with "run-stackless" (func $sleep))
+    (with "run-stackful" (func $sleep))))
+  (instance $b (instantiate $A
+    (with "run-stackless" (func $a "run-stackless"))
+    (with "run-stackful" (func $a "run-stackful"))))
+  (func (export "run-stackless") (alias export $a "run-stackless"))
+  (func (export "run-stackful") (alias export $a "run-stackful"))
+  (func (export "run-stackless-stackless") (alias export $b "run-stackless"))
+  (func (export "run-stackful-stackful") (alias export $b "run-stackful")))


### PR DESCRIPTION
add `pulley_provenance_test_async_components` test

set/restore executor before/after resuming fibers

fix provenance violations related to component async state pointer

Fixes #45

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
