### PR TITLE
make it easier to run `component-async-tests` with miri

### DIFF
--- a/crates/misc/component-async-tests/Cargo.toml
+++ b/crates/misc/component-async-tests/Cargo.toml
@@ -27,6 +27,7 @@ wasm-compose = { workspace = true }
 wasmparser = { workspace = true }
 wasmtime = { workspace = true, features = [
   "default",
+  "pulley",
   "cranelift",
   "component-model-async",
 ] }

--- a/crates/misc/component-async-tests/src/util.rs
+++ b/crates/misc/component-async-tests/src/util.rs
@@ -30,10 +30,8 @@ pub fn config() -> Config {
         config.memory_reservation(1 << 20);
         config.memory_guard_size(0);
         config.signals_based_traps(false);
-        config.debug_info(false);
     } else {
         config.cranelift_debug_verifier(true);
-        config.debug_info(true);
     }
     config.wasm_component_model(true);
     config.wasm_component_model_async(true);

--- a/crates/misc/component-async-tests/tests/scenario/backpressure.rs
+++ b/crates/misc/component-async-tests/tests/scenario/backpressure.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
-use tokio::fs;
 
-use component_async_tests::util::{compose, test_run};
+use component_async_tests::util::test_run;
 
 // No-op function; we only test this by composing it in `async_backpressure_caller`
 #[allow(
@@ -12,7 +11,9 @@ pub fn async_backpressure_callee() {}
 
 #[tokio::test]
 pub async fn async_backpressure_caller() -> Result<()> {
-    let caller = &fs::read(test_programs_artifacts::ASYNC_BACKPRESSURE_CALLER_COMPONENT).await?;
-    let callee = &fs::read(test_programs_artifacts::ASYNC_BACKPRESSURE_CALLEE_COMPONENT).await?;
-    test_run(&compose(caller, callee).await?).await
+    test_run(&[
+        test_programs_artifacts::ASYNC_BACKPRESSURE_CALLER_COMPONENT,
+        test_programs_artifacts::ASYNC_BACKPRESSURE_CALLEE_COMPONENT,
+    ])
+    .await
 }

--- a/crates/misc/component-async-tests/tests/scenario/error_context.rs
+++ b/crates/misc/component-async-tests/tests/scenario/error_context.rs
@@ -1,28 +1,22 @@
 use anyhow::Result;
-use tokio::fs;
 
-use component_async_tests::util::{compose, test_run};
+use component_async_tests::util::test_run;
 
 #[tokio::test]
 pub async fn async_error_context() -> Result<()> {
-    test_run(&fs::read(test_programs_artifacts::ASYNC_ERROR_CONTEXT_COMPONENT).await?).await
+    test_run(&[test_programs_artifacts::ASYNC_ERROR_CONTEXT_COMPONENT]).await
 }
 
 #[tokio::test]
 pub async fn async_error_context_callee() -> Result<()> {
-    test_run(&fs::read(test_programs_artifacts::ASYNC_ERROR_CONTEXT_COMPONENT).await?).await
+    test_run(&[test_programs_artifacts::ASYNC_ERROR_CONTEXT_COMPONENT]).await
 }
 
 #[tokio::test]
 pub async fn async_error_context_caller() -> Result<()> {
-    let caller = &fs::read(test_programs_artifacts::ASYNC_ERROR_CONTEXT_CALLER_COMPONENT).await?;
-    let callee = &fs::read(test_programs_artifacts::ASYNC_ERROR_CONTEXT_CALLEE_COMPONENT).await?;
-    test_run(&compose(caller, callee).await?).await
-}
-
-#[tokio::test]
-async fn async_error_context_roundtrip() -> Result<()> {
-    let caller = &fs::read(test_programs_artifacts::ASYNC_ERROR_CONTEXT_CALLER_COMPONENT).await?;
-    let callee = &fs::read(test_programs_artifacts::ASYNC_ERROR_CONTEXT_CALLEE_COMPONENT).await?;
-    test_run(&compose(caller, callee).await?).await
+    test_run(&[
+        test_programs_artifacts::ASYNC_ERROR_CONTEXT_CALLER_COMPONENT,
+        test_programs_artifacts::ASYNC_ERROR_CONTEXT_CALLEE_COMPONENT,
+    ])
+    .await
 }

--- a/crates/misc/component-async-tests/tests/scenario/post_return.rs
+++ b/crates/misc/component-async-tests/tests/scenario/post_return.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
-use tokio::fs;
 
-use component_async_tests::util::{compose, test_run};
+use component_async_tests::util::test_run;
 
 // No-op function; we only test this by composing it in `async_post_return_caller`
 #[allow(
@@ -12,7 +11,9 @@ pub fn async_post_return_callee() {}
 
 #[tokio::test]
 pub async fn async_post_return_caller() -> Result<()> {
-    let caller = &fs::read(test_programs_artifacts::ASYNC_POST_RETURN_CALLER_COMPONENT).await?;
-    let callee = &fs::read(test_programs_artifacts::ASYNC_POST_RETURN_CALLEE_COMPONENT).await?;
-    test_run(&compose(caller, callee).await?).await
+    test_run(&[
+        test_programs_artifacts::ASYNC_POST_RETURN_CALLER_COMPONENT,
+        test_programs_artifacts::ASYNC_POST_RETURN_CALLEE_COMPONENT,
+    ])
+    .await
 }

--- a/crates/misc/component-async-tests/tests/scenario/read_resource_stream.rs
+++ b/crates/misc/component-async-tests/tests/scenario/read_resource_stream.rs
@@ -1,9 +1,8 @@
 use anyhow::Result;
-use tokio::fs;
 
 use component_async_tests::util::test_run;
 
 #[tokio::test]
 pub async fn async_read_resource_stream() -> Result<()> {
-    test_run(&fs::read(test_programs_artifacts::ASYNC_READ_RESOURCE_STREAM_COMPONENT).await?).await
+    test_run(&[test_programs_artifacts::ASYNC_READ_RESOURCE_STREAM_COMPONENT]).await
 }

--- a/crates/misc/component-async-tests/tests/scenario/unit_stream.rs
+++ b/crates/misc/component-async-tests/tests/scenario/unit_stream.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
-use tokio::fs;
 
-use component_async_tests::util::{compose, test_run_with_count};
+use component_async_tests::util::test_run_with_count;
 
 // No-op function; we only test this by composing it in `async_unit_stream_caller`
 #[allow(
@@ -12,7 +11,12 @@ pub fn async_unit_stream_callee() {}
 
 #[tokio::test]
 pub async fn async_unit_stream_caller() -> Result<()> {
-    let caller = &fs::read(test_programs_artifacts::ASYNC_UNIT_STREAM_CALLER_COMPONENT).await?;
-    let callee = &fs::read(test_programs_artifacts::ASYNC_UNIT_STREAM_CALLEE_COMPONENT).await?;
-    test_run_with_count(&compose(caller, callee).await?, 1).await
+    test_run_with_count(
+        &[
+            test_programs_artifacts::ASYNC_UNIT_STREAM_CALLER_COMPONENT,
+            test_programs_artifacts::ASYNC_UNIT_STREAM_CALLEE_COMPONENT,
+        ],
+        1,
+    )
+    .await
 }

--- a/crates/misc/component-async-tests/tests/scenario/yield_.rs
+++ b/crates/misc/component-async-tests/tests/scenario/yield_.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
-use tokio::fs;
 
-use component_async_tests::util::{compose, test_run};
+use component_async_tests::util::test_run;
 
 // No-op function; we only test this by composing it in
 // `async_yield_callee_synchronous` and `async_yield_callee_stackful`
@@ -13,15 +12,18 @@ pub fn async_yield_caller() {}
 
 #[tokio::test]
 pub async fn async_yield_callee_synchronous() -> Result<()> {
-    let caller = &fs::read(test_programs_artifacts::ASYNC_YIELD_CALLER_COMPONENT).await?;
-    let callee =
-        &fs::read(test_programs_artifacts::ASYNC_YIELD_CALLEE_SYNCHRONOUS_COMPONENT).await?;
-    test_run(&compose(caller, callee).await?).await
+    test_run(&[
+        test_programs_artifacts::ASYNC_YIELD_CALLER_COMPONENT,
+        test_programs_artifacts::ASYNC_YIELD_CALLEE_SYNCHRONOUS_COMPONENT,
+    ])
+    .await
 }
 
 #[tokio::test]
 pub async fn async_yield_callee_stackless() -> Result<()> {
-    let caller = &fs::read(test_programs_artifacts::ASYNC_YIELD_CALLER_COMPONENT).await?;
-    let callee = &fs::read(test_programs_artifacts::ASYNC_YIELD_CALLEE_STACKLESS_COMPONENT).await?;
-    test_run(&compose(caller, callee).await?).await
+    test_run(&[
+        test_programs_artifacts::ASYNC_YIELD_CALLER_COMPONENT,
+        test_programs_artifacts::ASYNC_YIELD_CALLEE_STACKLESS_COMPONENT,
+    ])
+    .await
 }


### PR DESCRIPTION
This refactors the test harness a bit to allow running them under miri by first setting `MIRI_TEST_CWASM_DIR` to point to a directory, then running the tests _without_ miri to populate that directory with .cwasm files as a side effect, and finally running the tests _with_ miri, in which case they'll use the already-generated .cwasm files.  This avoids the prohibitive cost of compiling significant amounts of guest code under miri.

For example:

```
mkdir cwasms
MIRI_TEST_CWASM_DIR=$(pwd)/cwasms
cargo test -p component-async-tests scenario::round_trip::async_round_trip_stackless -- --exact
MIRIFLAGS="-Zmiri-backtrace=full -Zmiri-disable-isolation -Zmiri-permissive-provenance"
cargo +nightly miri test -p component-async-tests scenario::round_trip::async_round_trip_stackless -- --exact
```

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
