### PR TITLE
Simplify some generics in type signatures

### DIFF
--- a/crates/misc/component-async-tests/src/resource_stream.rs
+++ b/crates/misc/component-async-tests/src/resource_stream.rs
@@ -65,7 +65,7 @@ impl bindings::local::local::resource_stream::HostConcurrent for Ctx {
 
         let (tx, rx) = accessor.with(|mut view| {
             let instance = view.instance();
-            instance.stream::<_, _, Option<_>, _, _>(&mut view)
+            instance.stream::<_, _, Option<_>>(&mut view)
         })?;
         accessor.spawn(Task { tx, count });
         Ok(rx.into())

--- a/crates/misc/component-async-tests/tests/scenario/streams.rs
+++ b/crates/misc/component-async-tests/tests/scenario/streams.rs
@@ -46,46 +46,46 @@ pub async fn async_watch_streams() -> Result<()> {
     let instance = linker.instantiate_async(&mut store, &component).await?;
 
     // Test watching and then dropping the read end of a stream.
-    let (tx, rx) = instance.stream::<u8, Option<_>, Option<_>, _, _>(&mut store)?;
+    let (tx, rx) = instance.stream::<u8, Option<_>, Option<_>>(&mut store)?;
     let watch = tx.watch_reader().0;
     drop(rx);
     instance.run(&mut store, watch).await?;
 
     // Test dropping and then watching the read end of a stream.
-    let (tx, rx) = instance.stream::<u8, Option<_>, Option<_>, _, _>(&mut store)?;
+    let (tx, rx) = instance.stream::<u8, Option<_>, Option<_>>(&mut store)?;
     drop(rx);
     instance.run(&mut store, tx.watch_reader().0).await?;
 
     // Test watching and then dropping the write end of a stream.
-    let (tx, rx) = instance.stream::<u8, Option<_>, Option<_>, _, _>(&mut store)?;
+    let (tx, rx) = instance.stream::<u8, Option<_>, Option<_>>(&mut store)?;
     let watch = rx.watch_writer().0;
     drop(tx);
     instance.run(&mut store, watch).await?;
 
     // Test dropping and then watching the write end of a stream.
-    let (tx, rx) = instance.stream::<u8, Option<_>, Option<_>, _, _>(&mut store)?;
+    let (tx, rx) = instance.stream::<u8, Option<_>, Option<_>>(&mut store)?;
     drop(tx);
     instance.run(&mut store, rx.watch_writer().0).await?;
 
     // Test watching and then dropping the read end of a future.
-    let (tx, rx) = instance.future::<u8, _, _>(|| 42, &mut store)?;
+    let (tx, rx) = instance.future::<u8>(|| 42, &mut store)?;
     let watch = tx.watch_reader().0;
     drop(rx);
     instance.run(&mut store, watch).await?;
 
     // Test dropping and then watching the read end of a future.
-    let (tx, rx) = instance.future::<u8, _, _>(|| 42, &mut store)?;
+    let (tx, rx) = instance.future::<u8>(|| 42, &mut store)?;
     drop(rx);
     instance.run(&mut store, tx.watch_reader().0).await?;
 
     // Test watching and then dropping the write end of a future.
-    let (tx, rx) = instance.future::<u8, _, _>(|| 42, &mut store)?;
+    let (tx, rx) = instance.future::<u8>(|| 42, &mut store)?;
     let watch = rx.watch_writer().0;
     drop(tx);
     instance.run(&mut store, watch).await?;
 
     // Test dropping and then watching the write end of a future.
-    let (tx, rx) = instance.future::<u8, _, _>(|| 42, &mut store)?;
+    let (tx, rx) = instance.future::<u8>(|| 42, &mut store)?;
     drop(tx);
     instance.run(&mut store, rx.watch_writer().0).await?;
 
@@ -293,7 +293,7 @@ pub async fn test_closed_streams(watch: bool) -> Result<()> {
 
     // Next, test stream host->guest
     {
-        let (tx, rx) = instance.stream::<_, _, Vec<_>, _, _>(&mut store)?;
+        let (tx, rx) = instance.stream::<_, _, Vec<_>>(&mut store)?;
 
         let mut futures = FuturesUnordered::new();
         futures.push(

--- a/crates/misc/component-async-tests/tests/scenario/transmit.rs
+++ b/crates/misc/component-async-tests/tests/scenario/transmit.rs
@@ -358,9 +358,8 @@ async fn test_transmit_with<Test: TransmitTest + 'static>(component: &str) -> Re
         ReadNone(Option<StreamReader<Option<String>>>),
     }
 
-    let (control_tx, control_rx) = instance.stream::<_, _, Option<_>, _, _>(&mut store)?;
-    let (caller_stream_tx, caller_stream_rx) =
-        instance.stream::<_, _, Option<_>, _, _>(&mut store)?;
+    let (control_tx, control_rx) = instance.stream::<_, _, Option<_>>(&mut store)?;
+    let (caller_stream_tx, caller_stream_rx) = instance.stream::<_, _, Option<_>>(&mut store)?;
     let (caller_future1_tx, caller_future1_rx) = instance.future(|| unreachable!(), &mut store)?;
     let (_caller_future2_tx, caller_future2_rx) = instance.future(|| unreachable!(), &mut store)?;
 

--- a/crates/wasi-http/src/p3/host/types.rs
+++ b/crates/wasi-http/src/p3/host/types.rs
@@ -790,7 +790,7 @@ where
         store.with(|mut view| {
             let instance = view.instance();
             let (contents_tx, contents_rx) = instance
-                .stream::<_, _, Vec<_>, _, _>(&mut view)
+                .stream::<_, _, Vec<_>>(&mut view)
                 .context("failed to create stream")?;
             let (trailers_tx, trailers_rx) = instance
                 .future(|| Ok(None), &mut view)
@@ -1107,7 +1107,7 @@ where
         store.with(|mut view| {
             let instance = view.instance();
             let (contents_tx, contents_rx) = instance
-                .stream::<_, _, Vec<_>, _, _>(&mut view)
+                .stream::<_, _, Vec<_>>(&mut view)
                 .context("failed to create stream")?;
             let (trailers_tx, trailers_rx) = instance
                 .future(|| Ok(None), &mut view)

--- a/crates/wasi/src/p3/cli/host.rs
+++ b/crates/wasi/src/p3/cli/host.rs
@@ -171,7 +171,7 @@ where
         store.with(|mut view| {
             let instance = view.instance();
             let (tx, rx) = instance
-                .stream::<_, _, Vec<_>, _, _>(&mut view)
+                .stream::<_, _, Vec<_>>(&mut view)
                 .context("failed to create stream")?;
             let stdin = view.get().cli().stdin.reader();
             view.spawn(InputTask { input: stdin, tx });

--- a/crates/wasi/src/p3/filesystem/host.rs
+++ b/crates/wasi/src/p3/filesystem/host.rs
@@ -61,7 +61,7 @@ where
         store.with(|mut view| {
             let instance = view.instance();
             let (data_tx, data_rx) = instance
-                .stream::<_, _, Vec<_>, _, _>(&mut view)
+                .stream::<_, _, Vec<_>>(&mut view)
                 .context("failed to create stream")?;
             let (res_tx, res_rx) = instance
                 .future(|| unreachable!(), &mut view)
@@ -150,7 +150,7 @@ where
     ) -> wasmtime::Result<Result<(), ErrorCode>> {
         let mut buf = Vec::with_capacity(8096);
         let (fd, fut) = store.with(|mut view| {
-            let data = data.into_reader::<Vec<u8>, _, _>(&mut view);
+            let data = data.into_reader::<Vec<u8>>(&mut view);
             let fut = data.read(buf);
             let fd = get_descriptor(view.get().table(), &fd)?.clone();
             anyhow::Ok((fd.clone(), fut))
@@ -198,7 +198,7 @@ where
     ) -> wasmtime::Result<Result<(), ErrorCode>> {
         let mut buf = Vec::with_capacity(8096);
         let (fd, fut) = store.with(|mut view| {
-            let data = data.into_reader::<Vec<u8>, _, _>(&mut view);
+            let data = data.into_reader::<Vec<u8>>(&mut view);
             let fut = data.read(buf);
             let fd = get_descriptor(view.get().table(), &fd)?.clone();
             anyhow::Ok((fd, fut))
@@ -318,7 +318,7 @@ where
         store.with(|mut view| {
             let instance = view.instance();
             let (data_tx, data_rx) = instance
-                .stream::<_, _, Vec<_>, _, _>(&mut view)
+                .stream::<_, _, Vec<_>>(&mut view)
                 .context("failed to create stream")?;
             let (res_tx, res_rx) = instance
                 .future(|| unreachable!(), &mut view)

--- a/crates/wasi/src/p3/sockets/host/types/tcp.rs
+++ b/crates/wasi/src/p3/sockets/host/types/tcp.rs
@@ -289,7 +289,7 @@ where
             };
             let instance = view.instance();
             let (tx, rx) = instance
-                .stream::<_, _, Vec<_>, _, _>(&mut view)
+                .stream::<_, _, Vec<_>>(&mut view)
                 .context("failed to create stream")?;
             let &TcpSocket {
                 listen_backlog_size,
@@ -379,7 +379,7 @@ where
     ) -> wasmtime::Result<Result<(), ErrorCode>> {
         let mut buf = Vec::with_capacity(8096);
         let (stream, fut) = match store.with(|mut view| {
-            let data = data.into_reader::<Vec<u8>, _, _>(&mut view);
+            let data = data.into_reader::<Vec<u8>>(&mut view);
             let fut = data.read(buf);
             let mut binding = view.get();
             let sock = get_socket(binding.table(), &socket)?;
@@ -440,7 +440,7 @@ where
         store.with(|mut view| {
             let instance = view.instance();
             let (data_tx, data_rx) = instance
-                .stream::<_, _, Vec<_>, _, _>(&mut view)
+                .stream::<_, _, Vec<_>>(&mut view)
                 .context("failed to create stream")?;
             let (res_tx, res_rx) = instance
                 .future(|| unreachable!(), &mut view)


### PR DESCRIPTION
Much of this is relic of historic designs and no longer needed, so try to clean up some things here and there.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
