### PR TITLE
combine fiber abstractions from `async_.rs` and `concurrent.rs`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ cranelift/isle/veri/veri_engine/test_output
 crates/explorer/node_modules
 tests/all/pulley_provenance_test.cwasm
 tests/all/pulley_provenance_test_component.cwasm
+tests/all/pulley_provenance_test_async_component.cwasm
 /artifacts
 testcase*.wat
 testcase*.wasm

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5263,7 +5263,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen"
 version = "0.42.1"
-source = "git+https://github.com/dicej/wit-bindgen?branch=no-reads-writes-after-dropped#491f066406a1b39100e8656615e4862325f6664e"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#cfb16fdd361c4acab53c449107201b8627ba2da7"
 dependencies = [
  "wit-bindgen-rt 0.42.1",
  "wit-bindgen-rust-macro",
@@ -5272,7 +5272,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-core"
 version = "0.42.1"
-source = "git+https://github.com/dicej/wit-bindgen?branch=no-reads-writes-after-dropped#491f066406a1b39100e8656615e4862325f6664e"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#cfb16fdd361c4acab53c449107201b8627ba2da7"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -5300,7 +5300,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-rt"
 version = "0.42.1"
-source = "git+https://github.com/dicej/wit-bindgen?branch=no-reads-writes-after-dropped#491f066406a1b39100e8656615e4862325f6664e"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#cfb16fdd361c4acab53c449107201b8627ba2da7"
 dependencies = [
  "bitflags 2.6.0",
  "futures",
@@ -5310,7 +5310,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-rust"
 version = "0.42.1"
-source = "git+https://github.com/dicej/wit-bindgen?branch=no-reads-writes-after-dropped#491f066406a1b39100e8656615e4862325f6664e"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#cfb16fdd361c4acab53c449107201b8627ba2da7"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -5325,7 +5325,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-rust-macro"
 version = "0.42.1"
-source = "git+https://github.com/dicej/wit-bindgen?branch=no-reads-writes-after-dropped#491f066406a1b39100e8656615e4862325f6664e"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#cfb16fdd361c4acab53c449107201b8627ba2da7"
 dependencies = [
  "anyhow",
  "prettyplease",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -632,12 +632,9 @@ lto = true
 # wasm-wave = { git = "https://github.com/bytecodealliance/wasm-tools" }
 # wasm-compose = { git = "https://github.com/bytecodealliance/wasm-tools" }
 # wasm-metadata = { git = "https://github.com/bytecodealliance/wasm-tools" }
-# wit-bindgen = { git = "https://github.com/bytecodealliance/wit-bindgen" }
-# wit-bindgen-rt = { git = "https://github.com/bytecodealliance/wit-bindgen" }
-# wit-bindgen-rust-macro = { git = "https://github.com/bytecodealliance/wit-bindgen" }
-wit-bindgen = { git = "https://github.com/dicej/wit-bindgen", branch = "no-reads-writes-after-dropped" }
-wit-bindgen-rt = { git = "https://github.com/dicej/wit-bindgen", branch = "no-reads-writes-after-dropped" }
-wit-bindgen-rust-macro = { git = "https://github.com/dicej/wit-bindgen", branch = "no-reads-writes-after-dropped" }
+wit-bindgen = { git = "https://github.com/bytecodealliance/wit-bindgen" }
+wit-bindgen-rt = { git = "https://github.com/bytecodealliance/wit-bindgen" }
+wit-bindgen-rust-macro = { git = "https://github.com/bytecodealliance/wit-bindgen" }
 
 # wasmparser = { path = '../wasm-tools/crates/wasmparser' }
 # wat = { path = '../wasm-tools/crates/wat' }

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -61,7 +61,7 @@ semver = { workspace = true, optional = true }
 smallvec = { workspace = true, optional = true }
 hashbrown = { workspace = true, features = ["default-hasher"] }
 bitflags = { workspace = true }
-futures = { workspace = true, features = ["alloc"], optional = true }
+futures = { workspace = true, default_features = false, features = ["alloc"], optional = true }
 bytes = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies.windows-sys]
@@ -198,7 +198,6 @@ async = [
   "dep:futures",
   "wasmtime-component-macro?/async",
   "runtime",
-  "futures/std",  
 ]
 
 # Enables support for the pooling instance allocation strategy

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -195,8 +195,10 @@ async = [
   "dep:wasmtime-fiber",
   "dep:async-trait",
   "dep:trait-variant",
+  "dep:futures",
   "wasmtime-component-macro?/async",
   "runtime",
+  "futures/std",  
 ]
 
 # Enables support for the pooling instance allocation strategy

--- a/crates/wasmtime/src/runtime.rs
+++ b/crates/wasmtime/src/runtime.rs
@@ -34,6 +34,8 @@ pub(crate) mod code_memory;
 #[cfg(feature = "debug-builtins")]
 pub(crate) mod debug;
 pub(crate) mod externals;
+#[cfg(feature = "async")]
+pub(crate) mod fiber;
 pub(crate) mod gc;
 pub(crate) mod instance;
 pub(crate) mod instantiate;

--- a/crates/wasmtime/src/runtime/component/func.rs
+++ b/crates/wasmtime/src/runtime/component/func.rs
@@ -664,7 +664,7 @@ impl Func {
         let mut store = store.as_context_mut();
         assert!(
             store.0.async_support(),
-            "cannot use `call_async` without enabling async support in the config"
+            "cannot use `post_return_async` without enabling async support in the config"
         );
         // Future optimization opportunity: conditionally use a fiber here since
         // some func's post_return will not need the async context (i.e. end up

--- a/crates/wasmtime/src/runtime/component/instance.rs
+++ b/crates/wasmtime/src/runtime/component/instance.rs
@@ -946,21 +946,12 @@ impl<T: 'static> InstancePre<T> {
     where
         T: Send,
     {
-        let store = store.as_context_mut();
+        let mut store = store.as_context_mut();
         assert!(
             store.0.async_support(),
             "must use sync instantiation when async support is disabled"
         );
-        #[cfg(feature = "component-model-async")]
-        {
-            crate::component::concurrent::on_fiber(store, move |store| self.instantiate_impl(store))
-                .await?
-        }
-        #[cfg(not(feature = "component-model-async"))]
-        {
-            let mut store = store;
-            store.on_fiber(|store| self.instantiate_impl(store)).await?
-        }
+        store.on_fiber(|store| self.instantiate_impl(store)).await?
     }
 
     fn instantiate_impl(&self, mut store: impl AsContextMut<Data = T>) -> Result<Instance> {

--- a/crates/wasmtime/src/runtime/component/linker.rs
+++ b/crates/wasmtime/src/runtime/component/linker.rs
@@ -7,6 +7,8 @@ use crate::component::types;
 use crate::component::{
     Component, ComponentNamedList, Instance, InstancePre, Lift, Lower, ResourceType, Val,
 };
+#[cfg(feature = "async")]
+use crate::fiber::AsyncCx;
 use crate::hash_map::HashMap;
 use crate::prelude::*;
 use crate::{AsContextMut, Engine, Module, StoreContextMut};
@@ -443,18 +445,9 @@ impl<T: 'static> LinkerInstance<'_, T> {
         );
 
         let ff = move |mut store: StoreContextMut<'_, T>, params: Params| -> Result<Return> {
-            #[cfg(feature = "component-model-async")]
-            {
-                let async_cx = crate::component::concurrent::AsyncCx::new(&mut store.0);
-                let mut future = Pin::from(f(store.as_context_mut(), params));
-                unsafe { async_cx.block_on(future.as_mut()) }?
-            }
-            #[cfg(not(feature = "component-model-async"))]
-            {
-                let async_cx = store.as_context_mut().0.async_cx().expect("async cx");
-                let future = f(store.as_context_mut(), params);
-                unsafe { async_cx.block_on(Pin::from(future)) }?
-            }
+            let async_cx = AsyncCx::new(&mut store.0);
+            let mut future = Pin::from(f(store.as_context_mut(), params));
+            async_cx.block_on(future.as_mut())?
         };
         self.func_wrap(name, ff)
     }
@@ -618,18 +611,9 @@ impl<T: 'static> LinkerInstance<'_, T> {
             "cannot use `func_new_async` without enabling async support in the config"
         );
         let ff = move |mut store: StoreContextMut<'_, T>, params: &[Val], results: &mut [Val]| {
-            #[cfg(feature = "component-model-async")]
-            {
-                let async_cx = crate::component::concurrent::AsyncCx::new(&mut store.0);
-                let mut future = Pin::from(f(store.as_context_mut(), params, results));
-                unsafe { async_cx.block_on(future.as_mut()) }?
-            }
-            #[cfg(not(feature = "component-model-async"))]
-            {
-                let async_cx = store.as_context_mut().0.async_cx().expect("async cx");
-                let future = f(store.as_context_mut(), params, results);
-                unsafe { async_cx.block_on(Pin::from(future)) }?
-            }
+            let async_cx = AsyncCx::new(&mut store.0);
+            let mut future = Pin::from(f(store.as_context_mut(), params, results));
+            async_cx.block_on(future.as_mut())?
         };
         self.func_new(name, ff)
     }
@@ -727,22 +711,9 @@ impl<T: 'static> LinkerInstance<'_, T> {
         let dtor = Arc::new(crate::func::HostFunc::wrap_inner(
             &self.engine,
             move |mut cx: crate::Caller<'_, T>, (param,): (u32,)| {
-                #[cfg(feature = "component-model-async")]
-                {
-                    let async_cx =
-                        crate::component::concurrent::AsyncCx::new(&mut cx.as_context_mut().0);
-                    let mut future = Pin::from(dtor(cx.as_context_mut(), param));
-                    unsafe { async_cx.block_on(future.as_mut()) }?
-                }
-                #[cfg(not(feature = "component-model-async"))]
-                {
-                    let async_cx = cx.as_context_mut().0.async_cx().expect("async cx");
-                    let future = dtor(cx.as_context_mut(), param);
-                    match unsafe { async_cx.block_on(Pin::from(future)) } {
-                        Ok(Ok(())) => Ok(()),
-                        Ok(Err(trap)) | Err(trap) => Err(trap),
-                    }
-                }
+                let async_cx = AsyncCx::new(&mut cx.as_context_mut().0);
+                let mut future = Pin::from(dtor(cx.as_context_mut(), param));
+                async_cx.block_on(future.as_mut())?
             },
         ));
         self.insert(name, Definition::Resource(ty, dtor))?;

--- a/crates/wasmtime/src/runtime/externals/table.rs
+++ b/crates/wasmtime/src/runtime/externals/table.rs
@@ -104,25 +104,14 @@ impl Table {
         ty: TableType,
         init: Ref,
     ) -> Result<Table> {
-        let store = store.as_context_mut();
+        let mut store = store.as_context_mut();
         assert!(
             store.0.async_support(),
             "cannot use `new_async` without enabling async support on the config"
         );
-        #[cfg(feature = "component-model-async")]
-        {
-            crate::component::concurrent::on_fiber(store, move |store| {
-                Table::_new(store.0, ty, init)
-            })
+        store
+            .on_fiber(|store| Table::_new(store.0, ty, init))
             .await?
-        }
-        #[cfg(not(feature = "component-model-async"))]
-        {
-            let mut store = store;
-            store
-                .on_fiber(|store| Table::_new(store.0, ty, init))
-                .await?
-        }
     }
 
     fn _new(store: &mut StoreOpaque, ty: TableType, init: Ref) -> Result<Table> {
@@ -308,25 +297,14 @@ impl Table {
         delta: u64,
         init: Ref,
     ) -> Result<u64> {
-        let store = store.as_context_mut();
+        let mut store = store.as_context_mut();
         assert!(
             store.0.async_support(),
             "cannot use `grow_async` without enabling async support on the config"
         );
-        #[cfg(feature = "component-model-async")]
-        {
-            crate::component::concurrent::on_fiber(store, move |store| {
-                self.grow(store, delta, init)
-            })
+        store
+            .on_fiber(|store| self.grow(store, delta, init))
             .await?
-        }
-        #[cfg(not(feature = "component-model-async"))]
-        {
-            let mut store = store;
-            store
-                .on_fiber(|store| self.grow(store, delta, init))
-                .await?
-        }
     }
 
     /// Copy `len` elements from `src_table[src_index..]` into

--- a/crates/wasmtime/src/runtime/fiber.rs
+++ b/crates/wasmtime/src/runtime/fiber.rs
@@ -1,0 +1,696 @@
+#![deny(unsafe_op_in_unsafe_fn)]
+
+use {
+    crate::{
+        Engine,
+        store::{Executor, StoreOpaque},
+        vm::{
+            AsyncWasmCallState, Interpreter, SendSyncPtr, VMStore,
+            mpk::{self, ProtectionMask},
+        },
+    },
+    anyhow::{Result, anyhow},
+    futures::channel::oneshot,
+    std::{
+        future, mem,
+        ops::Range,
+        pin::Pin,
+        ptr::{self, NonNull},
+        task::{Context, Poll},
+    },
+    wasmtime_environ::TripleExt,
+    wasmtime_fiber::{Fiber, Suspend},
+};
+
+/// Helper struct for reseting a raw pointer to its original value on drop.
+struct Reset<T: Copy>(*mut T, T);
+
+impl<T: Copy> Drop for Reset<T> {
+    fn drop(&mut self) {
+        unsafe {
+            *self.0 = self.1;
+        }
+    }
+}
+
+/// Represents the context of a `Future::poll` operation which involves resuming
+/// a fiber.
+///
+/// See `self::poll_fn` for details.
+#[derive(Clone, Copy)]
+struct PollContext {
+    future_context: *mut Context<'static>,
+    guard_range_start: *mut u8,
+    guard_range_end: *mut u8,
+}
+
+impl Default for PollContext {
+    fn default() -> PollContext {
+        PollContext {
+            future_context: ptr::null_mut(),
+            guard_range_start: ptr::null_mut(),
+            guard_range_end: ptr::null_mut(),
+        }
+    }
+}
+
+/// Represents the state of a currently executing fiber which has been resumed
+/// via `self::poll_fn`.
+pub(crate) struct AsyncState {
+    /// The `Suspend` for the current fiber (or null if no such fiber is running).
+    ///
+    /// See `StoreFiber` for an explanation of the signature types we use here.
+    current_suspend: *mut Suspend<Result<()>, StoreFiberYield, Result<()>>,
+
+    /// The current Wasm executor.
+    ///
+    /// Each fiber has its own executor, and we update this pointer to point to
+    /// the appropriate one whenever we switch fibers.
+    pub(crate) current_executor: *mut Executor,
+
+    /// See `PollContext`
+    current_poll_cx: PollContext,
+
+    /// The last fiber stack that was in use by the store.
+    ///
+    /// We use this to cache and reuse stacks as a performance optimization.
+    // TODO: With stack switching and the Component Model Async ABI, there may
+    // be multiple concurrent fibers in play; consider caching more than one
+    // stack at a time and making the number tunable via `Config`.
+    pub(crate) last_fiber_stack: Option<wasmtime_fiber::FiberStack>,
+}
+
+impl Default for AsyncState {
+    fn default() -> Self {
+        Self {
+            current_suspend: ptr::null_mut(),
+            current_executor: ptr::null_mut(),
+            current_poll_cx: PollContext::default(),
+            last_fiber_stack: None,
+        }
+    }
+}
+
+impl AsyncState {
+    pub(crate) fn async_guard_range(&self) -> Range<*mut u8> {
+        let context = self.current_poll_cx;
+        context.guard_range_start..context.guard_range_end
+    }
+}
+
+// Lots of pesky unsafe cells and pointers in this structure. This means we need
+// to declare explicitly that we use this in a threadsafe fashion.
+unsafe impl Send for AsyncState {}
+unsafe impl Sync for AsyncState {}
+
+/// Used to "stackfully" poll a future by suspending the current fiber
+/// repeatedly in a loop until the future completes.
+pub(crate) struct AsyncCx {
+    current_suspend: *mut *mut wasmtime_fiber::Suspend<Result<()>, StoreFiberYield, Result<()>>,
+    current_stack_limit: *mut usize,
+    current_poll_cx: *mut PollContext,
+}
+
+impl AsyncCx {
+    /// Create a new `AsyncCx`.
+    ///
+    /// This will panic if called outside the scope of a `self::poll_fn` call.
+    /// Consider using `Self::try_new` instead to avoid panicking.
+    pub(crate) fn new(store: &mut StoreOpaque) -> Self {
+        Self::try_new(store).unwrap()
+    }
+
+    /// Create a new `AsyncCx`.
+    ///
+    /// This will return `None` if called outside the scope of a `self::poll_fn`
+    /// call.
+    pub(crate) fn try_new(store: &mut StoreOpaque) -> Option<Self> {
+        let current_poll_cx = unsafe { &raw mut (*store.async_state()).current_poll_cx };
+        if unsafe { (*current_poll_cx).future_context.is_null() } {
+            None
+        } else {
+            Some(Self {
+                current_suspend: unsafe { &raw mut (*store.async_state()).current_suspend },
+                current_stack_limit: store.vm_store_context().stack_limit.get(),
+                current_poll_cx,
+            })
+        }
+    }
+
+    /// Poll the specified future using `Self::current_poll_cx`.
+    ///
+    /// This will panic if called recursively using the same `AsyncState`.
+    fn poll<U>(&self, mut future: Pin<&mut (dyn Future<Output = U> + Send)>) -> Poll<U> {
+        unsafe {
+            let poll_cx = *self.current_poll_cx;
+            let _reset = Reset(self.current_poll_cx, poll_cx);
+            *self.current_poll_cx = PollContext::default();
+            assert!(!poll_cx.future_context.is_null());
+            future.as_mut().poll(&mut *poll_cx.future_context)
+        }
+    }
+
+    /// Blocks on the asynchronous computation represented by `future` and
+    /// produces the result here, in-line.
+    ///
+    /// This function is designed to only work when it's currently executing on
+    /// a native fiber. This fiber provides the ability for us to handle the
+    /// future's `Pending` state as "jump back to whomever called the fiber in
+    /// an asynchronous fashion and propagate `Pending`". This tight coupling
+    /// with `on_fiber` below is what powers the asynchronicity of calling wasm.
+    ///
+    /// This function takes a `future` and will (appear to) synchronously wait
+    /// on the result. While this function is executing it will fiber switch
+    /// to-and-from the original frame calling `on_fiber` which should be a
+    /// guarantee due to how async stores are configured.
+    ///
+    /// The return value here is either the output of the future `T`, or a trap
+    /// which represents that the asynchronous computation was cancelled. It is
+    /// not recommended to catch the trap and try to keep executing wasm, so
+    /// we've tried to liberally document this.
+    ///
+    /// Note that this function suspends (if needed) with
+    /// `StoreFiberYield::KeepStore`, indicating that the store must not be used
+    /// (and that no other fibers may be resumed) until this fiber resumes.
+    /// Therefore, it is not appropriate for use in e.g. guest calls to
+    /// async-lowered imports implemented as host functions, since it will
+    /// prevent any other tasks from being run.  Use `Instance::suspend` to
+    /// suspend and release the store to allow other tasks to run before this
+    /// fiber is resumed.
+    pub(crate) fn block_on<U>(
+        &self,
+        mut future: Pin<&mut (dyn Future<Output = U> + Send)>,
+    ) -> Result<U> {
+        loop {
+            match self.poll(future.as_mut()) {
+                Poll::Ready(v) => break Ok(v),
+                Poll::Pending => {
+                    self.suspend(StoreFiberYield::KeepStore)?;
+                }
+            }
+        }
+    }
+
+    /// Suspend the current fiber, optionally transfering exclusive access to
+    /// the store back to the code which resumed it.
+    pub(crate) fn suspend(&self, yield_: StoreFiberYield) -> Result<()> {
+        unsafe { suspend_fiber(self.current_suspend, self.current_stack_limit, yield_) }
+    }
+}
+
+/// Indicates whether or not a fiber needs to retain exclusive access to its
+/// store across a suspend/resume interval.
+pub(crate) enum StoreFiberYield {
+    /// Indicates the fiber needs to retain exclusive access, meaning the store
+    /// should not be used outside of the fiber until after the fiber either
+    /// suspends with `ReleaseStore` or resolves.
+    KeepStore,
+    /// Indicates the fiber does _not_ need exclusive access across the
+    /// suspend/resume interval, meaning the store may be used as needed until
+    /// the fiber is resumed.
+    #[cfg_attr(not(feature = "component-model-async"), allow(dead_code))]
+    ReleaseStore,
+}
+
+pub(crate) struct StoreFiber<'a> {
+    /// The raw `wasmtime_fiber::Fiber`.
+    ///
+    /// Note that using `StoreFiberYield` as the `Yield` type parameter allows
+    /// the fiber to indicate whether it needs exclusive access to the store
+    /// across suspend points (in which case it will pass `KeepStore` when
+    /// suspending , meaning the store must not be used at all until the fiber
+    /// is resumed again) or whether it is giving up exclusive access (in which
+    /// case it will pass `ReleaseStore` when yielding, meaning exclusive access
+    /// may be given to another fiber that runs concurrently.
+    ///
+    /// Note also that every `StoreFiber` is implicitly granted exclusive access
+    /// to the store when it is resumed.
+    pub(crate) fiber: Option<Fiber<'a, Result<()>, StoreFiberYield, Result<()>>>,
+    /// See `FiberResumeState`
+    state: Option<FiberResumeState>,
+    /// The Wasmtime `Engine` to which this fiber belongs.
+    engine: Engine,
+    /// The current `Suspend` for this fiber (or null if it's not currently
+    /// running).
+    suspend: *mut *mut Suspend<Result<()>, StoreFiberYield, Result<()>>,
+    executor_ptr: *mut *mut Executor,
+    executor: Executor,
+}
+
+impl StoreFiber<'_> {
+    pub(crate) fn guard_range(&self) -> (Option<SendSyncPtr<u8>>, Option<SendSyncPtr<u8>>) {
+        self.fiber
+            .as_ref()
+            .unwrap()
+            .stack()
+            .guard_range()
+            .map(|r| {
+                (
+                    NonNull::new(r.start).map(SendSyncPtr::new),
+                    NonNull::new(r.end).map(SendSyncPtr::new),
+                )
+            })
+            .unwrap_or((None, None))
+    }
+}
+
+// Here we run the risk of dropping an in-progress fiber, and if we were to do
+// nothing then the fiber would leak all its owned stack resources.
+//
+// To handle this we implement `Drop` here and, if the fiber isn't done, resume
+// execution of the fiber saying "hey please stop you're interrupted". Our
+// `Trap` created here (which has the stack trace of whomever dropped us) should
+// then get propagate all the way back up to the original fiber start, finishing
+// execution.
+//
+// We don't actually care about the fiber's return value here (no one's around
+// to look at it), we just assert the fiber finished to completion.
+impl Drop for StoreFiber<'_> {
+    fn drop(&mut self) {
+        if self.fiber.is_none() {
+            return;
+        }
+
+        if !self.fiber.as_ref().unwrap().done() {
+            // SAFETY: We must temporarily grant the fiber exclusive access to
+            // its store until resolves, meaning this function must only be
+            // called from a context where that's sound.  As of this writing,
+            // the only place unresolved fibers are dropped is in
+            // `ComponentStoreData::drop_fibers` which does in fact have `&mut
+            // StoreOpaque`.
+            let result = unsafe { resume_fiber_raw(self, Err(anyhow!("future dropped"))) };
+            debug_assert!(result.is_ok());
+        }
+
+        self.state.take().unwrap().dispose();
+
+        unsafe {
+            self.engine
+                .allocator()
+                .deallocate_fiber_stack(self.fiber.take().unwrap().into_stack());
+        }
+    }
+}
+
+// This is surely the most dangerous `unsafe impl Send` in the entire
+// crate. There are two members in `FiberFuture` which cause it to not be
+// `Send`. One is `current_poll_cx` and is entirely uninteresting.  This is just
+// used to manage `Context` pointers across `await` points in the future, and
+// requires raw pointers to get it to happen easily.  Nothing too weird about
+// the `Send`-ness, values aren't actually crossing threads.
+//
+// The really interesting piece is `fiber`. Now the "fiber" here is actual
+// honest-to-god Rust code which we're moving around. What we're doing is the
+// equivalent of moving our thread's stack to another OS thread. Turns out we,
+// in general, have no idea what's on the stack and would generally have no way
+// to verify that this is actually safe to do!
+//
+// Thankfully, though, Wasmtime has the power. Without being glib it's actually
+// worth examining what's on the stack. It's unfortunately not super-local to
+// this function itself. Our closure to `Fiber::new` runs `func`, which is given
+// to us from the outside. Thankfully, though, we have tight control over
+// this. Usage of `on_fiber` or `Instance::resume_fiber` is typically done
+// *just* before entering WebAssembly itself, so we'll have a few stack frames
+// of Rust code (all in Wasmtime itself) before we enter wasm.
+//
+// Once we've entered wasm, well then we have a whole bunch of wasm frames on
+// the stack. We've got this nifty thing called Cranelift, though, which allows
+// us to also have complete control over everything on the stack!
+//
+// Finally, when wasm switches back to the fiber's starting pointer (this future
+// we're returning) then it means wasm has reentered Rust.  Suspension can only
+// happen via either `block_on` or `Instance::suspend`. This, conveniently, also
+// happens entirely in Wasmtime controlled code!
+//
+// There's an extremely important point that should be called out here.
+// User-provided futures **are not on the stack** during suspension points. This
+// is extremely crucial because we in general cannot reason about Send/Sync for
+// stack-local variables since rustc doesn't analyze them at all. With our
+// construction, though, we are guaranteed that Wasmtime owns all stack frames
+// between the stack of a fiber and when the fiber suspends (and it could move
+// across threads). At this time the only user-provided piece of data on the
+// stack is the future itself given to us. Lo-and-behold as you might notice the
+// future is required to be `Send`!
+//
+// What this all boils down to is that we, as the authors of Wasmtime, need to
+// be extremely careful that on the async fiber stack we only store Send
+// things. For example we can't start using `Rc` willy nilly by accident and
+// leave a copy in TLS somewhere. (similarly we have to be ready for TLS to
+// change while we're executing wasm code between suspension points).
+//
+// While somewhat onerous it shouldn't be too too hard (the TLS bit is the
+// hardest bit so far). This does mean, though, that no user should ever have to
+// worry about the `Send`-ness of Wasmtime. If rustc says it's ok, then it's ok.
+//
+// With all that in mind we unsafely assert here that Wasmtime is correct. We
+// declare the fiber as only containing Send data on its stack, despite not
+// knowing for sure at compile time that this is correct. That's what `unsafe`
+// in Rust is all about, though, right?
+unsafe impl Send for StoreFiber<'_> {}
+// SAFETY: TODO
+unsafe impl Sync for StoreFiber<'_> {}
+
+/// State of the world when a fiber last suspended.
+///
+/// This structure represents global state that a fiber clobbers during its
+/// execution. For example TLS variables are updated, system resources like MPK
+/// masks are updated, etc. The purpose of this structure is to track all of
+/// this state and appropriately save/restore it around fiber suspension points.
+struct FiberResumeState {
+    /// Saved list of `CallThreadState` activations that are stored on a fiber
+    /// stack.
+    ///
+    /// This is a linked list that references stack-stored nodes on the fiber
+    /// stack that is currently suspended. The `AsyncWasmCallState` type
+    /// documents this more thoroughly but the general gist is that when we this
+    /// fiber is resumed this linked list needs to be pushed on to the current
+    /// thread's linked list of activations.
+    tls: crate::runtime::vm::AsyncWasmCallState,
+
+    /// Saved MPK protection mask, if enabled.
+    ///
+    /// When MPK is enabled then executing WebAssembly will modify the
+    /// processor's current mask of addressable protection keys. This means that
+    /// our current state may get clobbered when a fiber suspends. To ensure
+    /// that this function preserves context it will, when MPK is enabled, save
+    /// the current mask when this function is called and then restore the mask
+    /// when the function returns (aka the fiber suspends).
+    mpk: Option<ProtectionMask>,
+}
+
+impl FiberResumeState {
+    unsafe fn replace(self) -> PriorFiberResumeState {
+        let tls = unsafe { self.tls.push() };
+        let mpk = swap_mpk_states(self.mpk);
+        PriorFiberResumeState { tls, mpk }
+    }
+
+    fn dispose(self) {
+        self.tls.assert_null();
+    }
+}
+
+struct PriorFiberResumeState {
+    tls: crate::runtime::vm::PreviousAsyncWasmCallState,
+    mpk: Option<ProtectionMask>,
+}
+
+impl PriorFiberResumeState {
+    unsafe fn replace(self) -> FiberResumeState {
+        let tls = unsafe { self.tls.restore() };
+        let mpk = swap_mpk_states(self.mpk);
+        FiberResumeState { tls, mpk }
+    }
+}
+
+fn swap_mpk_states(mask: Option<ProtectionMask>) -> Option<ProtectionMask> {
+    mask.map(|mask| {
+        let current = mpk::current_mask();
+        mpk::allow(mask);
+        current
+    })
+}
+
+/// Resume the specified fiber, granting it exclusive access to the store with
+/// which it was created.
+///
+/// This will return `Ok(result)` if the fiber resolved, where `result` is the
+/// returned value; it will return `Err(yield_)` if the fiber suspended, where
+/// `yield_` indicates whether it released access to the store or not.  See
+/// `StoreFiber::fiber` for details.
+///
+/// SAFETY: The caller must confer exclusive access to the store to the fiber
+/// until the fiber is either dropped, resolved, or forgotten, or until it
+/// releases the store when suspending.
+unsafe fn resume_fiber_raw<'a>(
+    fiber: &mut StoreFiber<'a>,
+    result: Result<()>,
+) -> Result<Result<()>, StoreFiberYield> {
+    struct Restore<'a, 'b> {
+        fiber: &'b mut StoreFiber<'a>,
+        state: Option<PriorFiberResumeState>,
+    }
+
+    impl Drop for Restore<'_, '_> {
+        fn drop(&mut self) {
+            unsafe {
+                self.fiber.state = Some(self.state.take().unwrap().replace());
+            }
+        }
+    }
+    unsafe {
+        let _reset_executor = Reset(fiber.executor_ptr, *fiber.executor_ptr);
+        *fiber.executor_ptr = &raw mut fiber.executor;
+        let _reset_suspend = Reset(fiber.suspend, *fiber.suspend);
+        let prev = fiber.state.take().unwrap().replace();
+        let restore = Restore {
+            fiber,
+            state: Some(prev),
+        };
+        restore.fiber.fiber.as_ref().unwrap().resume(result)
+    }
+}
+
+/// Create a new `StoreFiber` which runs the specified closure.
+pub(crate) fn make_fiber<'a>(
+    store: &mut dyn VMStore,
+    fun: impl FnOnce(&mut dyn VMStore) -> Result<()> + 'a,
+) -> Result<StoreFiber<'a>> {
+    let engine = store.engine().clone();
+    #[cfg(has_host_compiler_backend)]
+    let executor = if cfg!(feature = "pulley") && engine.target().is_pulley() {
+        Executor::Interpreter(Interpreter::new(&engine))
+    } else {
+        Executor::Native
+    };
+    #[cfg(not(has_host_compiler_backend))]
+    let executor = {
+        debug_assert!(engine.target().is_pulley());
+        Executor::Interpreter(Interpreter::new(&engine))
+    };
+    let stack = store.store_opaque_mut().allocate_fiber_stack()?;
+    let suspend = unsafe { &raw mut (*store.store_opaque_mut().async_state()).current_suspend };
+    let executor_ptr =
+        unsafe { &raw mut (*store.store_opaque_mut().async_state()).current_executor };
+    let track_pkey_context_switch = store.has_pkey();
+    let store = &raw mut *store;
+    Ok(StoreFiber {
+        fiber: Some(Fiber::new(stack, move |result: Result<()>, suspend| {
+            if result.is_err() {
+                result
+            } else {
+                // SAFETY: Per the documented contract for
+                // `resume_fiber_raw`, we've been given exclusive access to
+                // the store until we exit or yield it back to the resumer.
+                let store_ref = unsafe { &mut *store };
+                let suspend_ptr = unsafe {
+                    &raw mut (*store_ref.store_opaque_mut().async_state()).current_suspend
+                };
+                // Configure our store's suspension context for the rest of the
+                // execution of this fiber. Note that a raw pointer is stored here
+                // which is only valid for the duration of this closure.
+                // Consequently we at least replace it with the previous value when
+                // we're done. This reset is also required for correctness because
+                // otherwise our value will overwrite another active fiber's value.
+                // There should be a test that segfaults in `async_functions.rs` if
+                // this `Reset` is removed.
+                //
+                // SAFETY: The resumer is responsible for setting
+                // `current_suspend` to a valid pointer.
+                let _reset = Reset(suspend_ptr, unsafe { *suspend_ptr });
+                unsafe { *suspend_ptr = suspend };
+                fun(store_ref)
+            }
+        })?),
+        state: Some(FiberResumeState {
+            tls: crate::runtime::vm::AsyncWasmCallState::new(),
+            mpk: if track_pkey_context_switch {
+                Some(ProtectionMask::all())
+            } else {
+                None
+            },
+        }),
+        engine,
+        suspend,
+        executor_ptr,
+        executor,
+    })
+}
+
+/// See `resume_fiber_raw`
+pub(crate) unsafe fn resume_fiber(
+    fiber: &mut StoreFiber,
+    result: Result<()>,
+) -> Result<Result<()>, StoreFiberYield> {
+    match unsafe { resume_fiber_raw(fiber, result) } {
+        Ok(result) => Ok(result),
+        Err(yield_) => {
+            // If `Err` is returned that means the fiber suspended, so we
+            // propagate that here.
+            //
+            // An additional safety check is performed when leaving this
+            // function to help bolster the guarantees of `unsafe impl Send`
+            // above. Notably this future may get re-polled on a different
+            // thread. Wasmtime's thread-local state points to the stack,
+            // however, meaning that it would be incorrect to leave a pointer in
+            // TLS when this function returns. This function performs a runtime
+            // assert to verify that this is the case, notably that the one TLS
+            // pointer Wasmtime uses is not pointing anywhere within the
+            // stack. If it is then that's a bug indicating that TLS management
+            // in Wasmtime is incorrect.
+            if let Some(range) = fiber.fiber.as_ref().unwrap().stack().range() {
+                AsyncWasmCallState::assert_current_state_not_in_range(range);
+            }
+
+            Err(yield_)
+        }
+    }
+}
+
+/// Suspend the current fiber, optionally returning exclusive access to the
+/// specified store to the code which resumed the fiber.
+///
+/// SAFETY: `suspend` must be a valid pointer.  Additionally, if a store pointer
+/// is provided, the fiber must give up access to the store until it is given
+/// back access when next resumed.
+unsafe fn suspend_fiber(
+    suspend: *mut *mut Suspend<Result<()>, StoreFiberYield, Result<()>>,
+    stack_limit: *mut usize,
+    yield_: StoreFiberYield,
+) -> Result<()> {
+    // Take our current `Suspend` context which was configured as soon as our
+    // fiber started. Note that we must load it at the front here and save it on
+    // our stack frame. While we're polling the future other fibers may be
+    // started for recursive computations, and the current suspend context is
+    // only preserved at the edges of the fiber, not during the fiber itself.
+    //
+    // For a little bit of extra safety we also replace the current value with
+    // null to try to catch any accidental bugs on our part early.  This is all
+    // pretty unsafe so we're trying to be careful...
+    //
+    // Note that there should be a segfaulting test in `async_functions.rs` if
+    // this `Reset` is removed.
+    unsafe {
+        let reset_suspend = Reset(suspend, *suspend);
+        *suspend = ptr::null_mut();
+        let _reset_stack_limit = Reset(stack_limit, *stack_limit);
+        assert!(!(reset_suspend.1).is_null());
+        (*reset_suspend.1).suspend(yield_)
+    }
+}
+
+/// Run the specified function on a newly-created fiber and `.await` its
+/// completion.
+pub(crate) async fn on_fiber<R: Send + 'static>(
+    store: &mut StoreOpaque,
+    func: impl FnOnce(&mut StoreOpaque) -> R + Send,
+) -> Result<R> {
+    on_fiber_raw(store.traitobj_mut(), move |store| {
+        func((*store).store_opaque_mut())
+    })
+    .await
+}
+
+/// Wrap the specified function in a fiber and return it.
+fn prepare_fiber<'a, R: Send + 'static>(
+    store: &mut dyn VMStore,
+    func: impl FnOnce(&mut dyn VMStore) -> R + Send + 'a,
+) -> Result<(StoreFiber<'a>, oneshot::Receiver<R>)> {
+    let (tx, rx) = oneshot::channel();
+    let fiber = make_fiber(store, {
+        move |store| {
+            _ = tx.send(func(store));
+            Ok(())
+        }
+    })?;
+    Ok((fiber, rx))
+}
+
+/// Run the specified function on a newly-created fiber and `.await` its
+/// completion.
+async fn on_fiber_raw<R: Send + 'static>(
+    store: &mut StoreOpaque,
+    func: impl FnOnce(&mut dyn VMStore) -> R + Send,
+) -> Result<R> {
+    let config = store.engine().config();
+    debug_assert!(store.async_support());
+    debug_assert!(config.async_stack_size > 0);
+
+    let (fiber, mut rx) = prepare_fiber(store.traitobj_mut(), func)?;
+
+    let guard_range = fiber.guard_range();
+    let mut fiber = Some(fiber);
+    let mut fiber = poll_fn(store, guard_range, move || {
+        // SAFETY: We confer exclusive access to the store to the fiber here,
+        // only taking it back when the fiber resolves.
+        match unsafe { resume_fiber(fiber.as_mut().unwrap(), Ok(())) } {
+            Ok(result) => Poll::Ready(result.map(|()| fiber.take().unwrap())),
+            Err(_) => Poll::Pending,
+        }
+    })
+    .await?;
+
+    let stack = fiber.fiber.take().map(|f| f.into_stack());
+    drop(fiber);
+    if let Some(stack) = stack {
+        store.deallocate_fiber_stack(stack);
+    }
+
+    Ok(rx.try_recv().unwrap().unwrap())
+}
+
+/// Wrap the specified function in a future which, when polled, will store a
+/// pointer to the `Context` in the `AsyncState::current_poll_cx` field for the
+/// specified store and then call the function.
+///
+/// This is intended for use with functions that resume fibers which may need to
+/// poll futures using the stored `Context` pointer.
+pub(crate) async fn poll_fn<R>(
+    store: &mut StoreOpaque,
+    guard_range: (Option<SendSyncPtr<u8>>, Option<SendSyncPtr<u8>>),
+    mut fun: impl FnMut() -> Poll<R>,
+) -> R {
+    #[derive(Clone, Copy)]
+    struct PollCx(*mut PollContext);
+
+    unsafe impl Send for PollCx {}
+
+    let poll_cx = PollCx(unsafe { &raw mut (*store.async_state()).current_poll_cx });
+    future::poll_fn({
+        move |cx| {
+            let _reset = Reset(poll_cx.0, unsafe { *poll_cx.0 });
+            let guard_range_start = guard_range.0.map(|v| v.as_ptr()).unwrap_or(ptr::null_mut());
+            let guard_range_end = guard_range.1.map(|v| v.as_ptr()).unwrap_or(ptr::null_mut());
+            // We need to carry over this `cx` into our fiber's runtime for when
+            // it tries to poll sub-futures that are created. Doing this must be
+            // done unsafely, however, since `cx` is only alive for this one
+            // singular function call. Here we do a `transmute` to extend the
+            // lifetime of `Context` so it can be stored in our `Store`, and
+            // then we replace the current polling context with this one.
+            //
+            // Note that the replace is done for weird situations where futures
+            // might be switching contexts and there's multiple wasmtime futures
+            // in a chain of futures.
+            //
+            // On exit from this function, though, we reset the polling context
+            // back to what it was to signify that `Store` no longer has access
+            // to this pointer.
+            //
+            // SAFETY: We store the pointer to the `Context` only for the
+            // duration of this call and then reset it to its previous value
+            // afterward, thereby ensuring `fun` never sees a stale pointer.
+            unsafe {
+                *poll_cx.0 = PollContext {
+                    future_context: mem::transmute::<&mut Context<'_>, *mut Context<'static>>(cx),
+                    guard_range_start,
+                    guard_range_end,
+                };
+            }
+            #[allow(dropping_copy_types)]
+            drop(poll_cx);
+
+            fun()
+        }
+    })
+    .await
+}

--- a/crates/wasmtime/src/runtime/fiber.rs
+++ b/crates/wasmtime/src/runtime/fiber.rs
@@ -10,14 +10,14 @@ use {
         },
     },
     anyhow::{Result, anyhow},
-    futures::channel::oneshot,
-    std::{
+    core::{
         future, mem,
         ops::Range,
         pin::Pin,
         ptr::{self, NonNull},
         task::{Context, Poll},
     },
+    futures::channel::oneshot,
     wasmtime_environ::TripleExt,
     wasmtime_fiber::{Fiber, Suspend},
 };

--- a/crates/wasmtime/src/runtime/func/typed.rs
+++ b/crates/wasmtime/src/runtime/func/typed.rs
@@ -147,23 +147,13 @@ where
         if Self::need_gc_before_call_raw(store.0, &params) {
             store.gc_async(None).await?;
         }
-        #[cfg(feature = "component-model-async")]
-        {
-            crate::component::concurrent::on_fiber(store, |store| {
+
+        store
+            .on_fiber(|store| {
                 let func = self.func.vm_func_ref(store.0);
                 unsafe { Self::call_raw(store, &self.ty, func, params) }
             })
             .await?
-        }
-        #[cfg(not(feature = "component-model-async"))]
-        {
-            store
-                .on_fiber(|store| {
-                    let func = self.func.vm_func_ref(store.0);
-                    unsafe { Self::call_raw(store, &self.ty, func, params) }
-                })
-                .await?
-        }
     }
 
     #[inline]

--- a/crates/wasmtime/src/runtime/instance.rs
+++ b/crates/wasmtime/src/runtime/instance.rs
@@ -233,19 +233,9 @@ impl Instance {
             "must use sync instantiation when async support is disabled",
         );
 
-        #[cfg(feature = "component-model-async")]
-        {
-            crate::component::concurrent::on_fiber(store.as_context_mut(), move |store| {
-                Self::new_started_impl(store, module, imports)
-            })
+        store
+            .on_fiber(|store| Self::new_started_impl(store, module, imports))
             .await?
-        }
-        #[cfg(not(feature = "component-model-async"))]
-        {
-            store
-                .on_fiber(|store| Self::new_started_impl(store, module, imports))
-                .await?
-        }
     }
 
     /// Internal function to create an instance which doesn't have its `start`

--- a/crates/wasmtime/src/runtime/linker.rs
+++ b/crates/wasmtime/src/runtime/linker.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "async")]
+use crate::fiber::AsyncCx;
 use crate::func::HostFunc;
 use crate::hash_map::{Entry, HashMap};
 use crate::instance::InstancePre;
@@ -471,28 +473,11 @@ impl<T> Linker<T> {
         );
         assert!(ty.comes_from_same_engine(self.engine()));
         self.func_new(module, name, ty, move |mut caller, params, results| {
-            #[cfg(feature = "component-model-async")]
-            {
-                let async_cx = crate::component::concurrent::AsyncCx::new(&mut caller.store.0);
-                let mut future = Pin::from(func(caller, params, results));
-                match unsafe { async_cx.block_on(future.as_mut()) } {
-                    Ok(Ok(())) => Ok(()),
-                    Ok(Err(trap)) | Err(trap) => Err(trap),
-                }
-            }
-            #[cfg(not(feature = "component-model-async"))]
-            {
-                let async_cx = caller
-                    .store
-                    .as_context_mut()
-                    .0
-                    .async_cx()
-                    .expect("Attempt to spawn new function on dying fiber");
-                let future = func(caller, params, results);
-                match unsafe { async_cx.block_on(Pin::from(future)) } {
-                    Ok(Ok(())) => Ok(()),
-                    Ok(Err(trap)) | Err(trap) => Err(trap),
-                }
+            let async_cx = AsyncCx::new(&mut caller.store.0);
+            let mut future = Pin::from(func(caller, params, results));
+            match async_cx.block_on(future.as_mut()) {
+                Ok(Ok(())) => Ok(()),
+                Ok(Err(trap)) | Err(trap) => Err(trap),
             }
         })
     }
@@ -590,29 +575,12 @@ impl<T> Linker<T> {
         let func = HostFunc::wrap_inner(
             &self.engine,
             move |mut caller: Caller<'_, T>, args: Params| {
-                #[cfg(feature = "component-model-async")]
-                {
-                    let async_cx = crate::component::concurrent::AsyncCx::new(&mut caller.store.0);
-                    let mut future = Pin::from(func(caller, args));
+                let async_cx = AsyncCx::new(&mut caller.store.0);
+                let mut future = Pin::from(func(caller, args));
 
-                    match unsafe { async_cx.block_on(future.as_mut()) } {
-                        Ok(ret) => ret.into_fallible(),
-                        Err(e) => Args::fallible_from_error(e),
-                    }
-                }
-                #[cfg(not(feature = "component-model-async"))]
-                {
-                    let async_cx = caller
-                        .store
-                        .as_context_mut()
-                        .0
-                        .async_cx()
-                        .expect("Attempt to start async function on dying fiber");
-                    let future = func(caller, args);
-                    match unsafe { async_cx.block_on(Pin::from(future)) } {
-                        Ok(ret) => ret.into_fallible(),
-                        Err(e) => Args::fallible_from_error(e),
-                    }
+                match async_cx.block_on(future.as_mut()) {
+                    Ok(ret) => ret.into_fallible(),
+                    Err(e) => Args::fallible_from_error(e),
                 }
             },
         );

--- a/crates/wasmtime/src/runtime/memory.rs
+++ b/crates/wasmtime/src/runtime/memory.rs
@@ -277,21 +277,12 @@ impl Memory {
         mut store: impl AsContextMut<Data: Send>,
         ty: MemoryType,
     ) -> Result<Memory> {
-        let store = store.as_context_mut();
+        let mut store = store.as_context_mut();
         assert!(
             store.0.async_support(),
             "cannot use `new_async` without enabling async support on the config"
         );
-        #[cfg(feature = "component-model-async")]
-        {
-            crate::component::concurrent::on_fiber(store, move |store| Self::_new(store.0, ty))
-                .await?
-        }
-        #[cfg(not(feature = "component-model-async"))]
-        {
-            let mut store = store;
-            store.on_fiber(|store| Self::_new(store.0, ty)).await?
-        }
+        store.on_fiber(|store| Self::_new(store.0, ty)).await?
     }
 
     /// Helper function for attaching the memory to a "frankenstein" instance
@@ -640,21 +631,12 @@ impl Memory {
         mut store: impl AsContextMut<Data: Send>,
         delta: u64,
     ) -> Result<u64> {
-        let store = store.as_context_mut();
+        let mut store = store.as_context_mut();
         assert!(
             store.0.async_support(),
             "cannot use `grow_async` without enabling async support on the config"
         );
-        #[cfg(feature = "component-model-async")]
-        {
-            crate::component::concurrent::on_fiber(store, move |store| self.grow(store, delta))
-                .await?
-        }
-        #[cfg(not(feature = "component-model-async"))]
-        {
-            let mut store = store;
-            store.on_fiber(|store| self.grow(store, delta)).await?
-        }
+        store.on_fiber(|store| self.grow(store, delta)).await?
     }
 
     fn wasmtime_memory(&self, store: &mut StoreOpaque) -> *mut crate::runtime::vm::Memory {

--- a/crates/wasmtime/src/runtime/store/async_.rs
+++ b/crates/wasmtime/src/runtime/store/async_.rs
@@ -1,16 +1,13 @@
 #[cfg(feature = "call-hook")]
 use crate::CallHook;
+use crate::fiber::{self, AsyncCx};
 use crate::prelude::*;
-use crate::runtime::vm::mpk::{self, ProtectionMask};
-use crate::store::{ResourceLimiterInner, StoreInner, StoreOpaque};
-use crate::{Engine, Store, StoreContextMut, UpdateDeadline};
+use crate::store::{ResourceLimiterInner, StoreInner, StoreOpaque, StoreToken};
+use crate::{AsContextMut, Store, StoreContextMut, UpdateDeadline};
 use anyhow::Context as _;
-use core::cell::UnsafeCell;
 use core::future::Future;
 use core::ops::Range;
-use core::pin::{Pin, pin};
-use core::ptr;
-use core::task::{Context, Poll};
+use core::pin::Pin;
 
 /// An object that can take callbacks when the runtime enters or exits hostcalls.
 #[cfg(feature = "call-hook")]
@@ -19,47 +16,6 @@ pub trait CallHookHandler<T>: Send {
     /// A callback to run when wasmtime is about to enter a host call, or when about to
     /// exit the hostcall.
     async fn handle_call_event(&self, t: StoreContextMut<'_, T>, ch: CallHook) -> Result<()>;
-}
-
-pub struct AsyncState {
-    current_suspend: UnsafeCell<*mut wasmtime_fiber::Suspend<Result<()>, (), Result<()>>>,
-    current_poll_cx: UnsafeCell<PollContext>,
-    /// The last fiber stack that was in use by this store.
-    last_fiber_stack: Option<wasmtime_fiber::FiberStack>,
-}
-
-impl Default for AsyncState {
-    fn default() -> AsyncState {
-        AsyncState {
-            current_suspend: UnsafeCell::new(ptr::null_mut()),
-            current_poll_cx: UnsafeCell::new(PollContext::default()),
-            last_fiber_stack: None,
-        }
-    }
-}
-
-// Lots of pesky unsafe cells and pointers in this structure. This means we need
-// to declare explicitly that we use this in a threadsafe fashion.
-unsafe impl Send for AsyncState {}
-unsafe impl Sync for AsyncState {}
-
-#[derive(Clone, Copy)]
-struct PollContext {
-    future_context: *mut Context<'static>,
-    #[cfg_attr(feature = "component-model-async", allow(dead_code))]
-    guard_range_start: *mut u8,
-    #[cfg_attr(feature = "component-model-async", allow(dead_code))]
-    guard_range_end: *mut u8,
-}
-
-impl Default for PollContext {
-    fn default() -> PollContext {
-        PollContext {
-            future_context: core::ptr::null_mut(),
-            guard_range_start: core::ptr::null_mut(),
-            guard_range_end: core::ptr::null_mut(),
-        }
-    }
 }
 
 impl<T> Store<T> {
@@ -228,24 +184,11 @@ impl<T> StoreInner<T> {
         &'a mut self,
         mk_future: impl FnOnce(&'a mut Self) -> F,
     ) -> Result<F::Output> {
-        #[cfg(feature = "component-model-async")]
-        {
-            let async_cx = crate::component::concurrent::AsyncCx::try_new(self)
-                .context("couldn't create AsyncCx to block on async operation")?;
-            let future = mk_future(self);
-            let mut future = core::pin::pin!(future);
-            unsafe { Ok(async_cx.block_on(future.as_mut())?) }
-        }
-        #[cfg(not(feature = "component-model-async"))]
-        {
-            let cx = self
-                .inner
-                .async_cx()
-                .context("async_cx is not present to block on async operation")?;
-            let future = mk_future(self);
-            let mut future = core::pin::pin!(future);
-            unsafe { cx.block_on(future.as_mut()) }
-        }
+        let async_cx = AsyncCx::try_new(self)
+            .context("couldn't create AsyncCx to block on async operation")?;
+        let future = mk_future(self);
+        let mut future = core::pin::pin!(future);
+        Ok(async_cx.block_on(future.as_mut())?)
     }
 }
 
@@ -256,368 +199,11 @@ impl StoreOpaque {
     /// This function will convert the synchronous `func` into an asynchronous
     /// future. This is done by running `func` in a fiber on a separate native
     /// stack which can be suspended and resumed from.
-    ///
-    /// Most of the nitty-gritty here is how we juggle the various contexts
-    /// necessary to suspend the fiber later on and poll sub-futures. It's hoped
-    /// that the various comments are illuminating as to what's going on here.
-    pub(crate) async fn on_fiber<R>(
+    pub(crate) async fn on_fiber<R: Send + 'static>(
         &mut self,
         func: impl FnOnce(&mut Self) -> R + Send,
     ) -> Result<R> {
-        let config = self.engine().config();
-        debug_assert!(self.async_support());
-        debug_assert!(config.async_stack_size > 0);
-
-        let mut slot = None;
-        let mut future = {
-            let current_poll_cx = self.async_state.current_poll_cx.get();
-            let current_suspend = self.async_state.current_suspend.get();
-            let stack = self.allocate_fiber_stack()?;
-            let track_pkey_context_switch = self.pkey.is_some();
-
-            let engine = self.engine().clone();
-            let slot = &mut slot;
-            let this = &mut *self;
-            let fiber = wasmtime_fiber::Fiber::new(stack, move |keep_going, suspend| {
-                // First check and see if we were interrupted/dropped, and only
-                // continue if we haven't been.
-                keep_going?;
-
-                // Configure our store's suspension context for the rest of the
-                // execution of this fiber. Note that a raw pointer is stored here
-                // which is only valid for the duration of this closure.
-                // Consequently we at least replace it with the previous value when
-                // we're done. This reset is also required for correctness because
-                // otherwise our value will overwrite another active fiber's value.
-                // There should be a test that segfaults in `async_functions.rs` if
-                // this `Replace` is removed.
-                unsafe {
-                    let _reset = Reset(current_suspend, *current_suspend);
-                    *current_suspend = suspend;
-
-                    *slot = Some(func(this));
-                    Ok(())
-                }
-            })?;
-
-            // Once we have the fiber representing our synchronous computation, we
-            // wrap that in a custom future implementation which does the
-            // translation from the future protocol to our fiber API.
-            FiberFuture {
-                fiber: Some(fiber),
-                current_poll_cx,
-                engine,
-                fiber_resume_state: Some(FiberResumeState {
-                    tls: crate::runtime::vm::AsyncWasmCallState::new(),
-                    mpk: if track_pkey_context_switch {
-                        Some(ProtectionMask::all())
-                    } else {
-                        None
-                    },
-                }),
-            }
-        };
-        (&mut future).await?;
-        let stack = future.fiber.take().map(|f| f.into_stack());
-        drop(future);
-        if let Some(stack) = stack {
-            self.deallocate_fiber_stack(stack);
-        }
-
-        return Ok(slot.unwrap());
-
-        struct FiberFuture<'a> {
-            fiber: Option<wasmtime_fiber::Fiber<'a, Result<()>, (), Result<()>>>,
-            current_poll_cx: *mut PollContext,
-            engine: Engine,
-            // See comments in `FiberResumeState` for this
-            fiber_resume_state: Option<FiberResumeState>,
-        }
-
-        // This is surely the most dangerous `unsafe impl Send` in the entire
-        // crate. There are two members in `FiberFuture` which cause it to not
-        // be `Send`. One is `current_poll_cx` and is entirely uninteresting.
-        // This is just used to manage `Context` pointers across `await` points
-        // in the future, and requires raw pointers to get it to happen easily.
-        // Nothing too weird about the `Send`-ness, values aren't actually
-        // crossing threads.
-        //
-        // The really interesting piece is `fiber`. Now the "fiber" here is
-        // actual honest-to-god Rust code which we're moving around. What we're
-        // doing is the equivalent of moving our thread's stack to another OS
-        // thread. Turns out we, in general, have no idea what's on the stack
-        // and would generally have no way to verify that this is actually safe
-        // to do!
-        //
-        // Thankfully, though, Wasmtime has the power. Without being glib it's
-        // actually worth examining what's on the stack. It's unfortunately not
-        // super-local to this function itself. Our closure to `Fiber::new` runs
-        // `func`, which is given to us from the outside. Thankfully, though, we
-        // have tight control over this. Usage of `on_fiber` is typically done
-        // *just* before entering WebAssembly itself, so we'll have a few stack
-        // frames of Rust code (all in Wasmtime itself) before we enter wasm.
-        //
-        // Once we've entered wasm, well then we have a whole bunch of wasm
-        // frames on the stack. We've got this nifty thing called Cranelift,
-        // though, which allows us to also have complete control over everything
-        // on the stack!
-        //
-        // Finally, when wasm switches back to the fiber's starting pointer
-        // (this future we're returning) then it means wasm has reentered Rust.
-        // Suspension can only happen via the `block_on` function of an
-        // `AsyncCx`. This, conveniently, also happens entirely in Wasmtime
-        // controlled code!
-        //
-        // There's an extremely important point that should be called out here.
-        // User-provided futures **are not on the stack** during suspension
-        // points. This is extremely crucial because we in general cannot reason
-        // about Send/Sync for stack-local variables since rustc doesn't analyze
-        // them at all. With our construction, though, we are guaranteed that
-        // Wasmtime owns all stack frames between the stack of a fiber and when
-        // the fiber suspends (and it could move across threads). At this time
-        // the only user-provided piece of data on the stack is the future
-        // itself given to us. Lo-and-behold as you might notice the future is
-        // required to be `Send`!
-        //
-        // What this all boils down to is that we, as the authors of Wasmtime,
-        // need to be extremely careful that on the async fiber stack we only
-        // store Send things. For example we can't start using `Rc` willy nilly
-        // by accident and leave a copy in TLS somewhere. (similarly we have to
-        // be ready for TLS to change while we're executing wasm code between
-        // suspension points).
-        //
-        // While somewhat onerous it shouldn't be too too hard (the TLS bit is
-        // the hardest bit so far). This does mean, though, that no user should
-        // ever have to worry about the `Send`-ness of Wasmtime. If rustc says
-        // it's ok, then it's ok.
-        //
-        // With all that in mind we unsafely assert here that wasmtime is
-        // correct. We declare the fiber as only containing Send data on its
-        // stack, despite not knowing for sure at compile time that this is
-        // correct. That's what `unsafe` in Rust is all about, though, right?
-        unsafe impl Send for FiberFuture<'_> {}
-
-        impl FiberFuture<'_> {
-            fn fiber(&self) -> &wasmtime_fiber::Fiber<'_, Result<()>, (), Result<()>> {
-                self.fiber.as_ref().unwrap()
-            }
-
-            /// This is a helper function to call `resume` on the underlying
-            /// fiber while correctly managing Wasmtime's state that the fiber
-            /// may clobber.
-            ///
-            /// ## Return Value
-            ///
-            /// * `Ok(Ok(()))` - the fiber successfully completed and yielded a
-            ///    successful result.
-            /// * `Ok(Err(e))` - the fiber successfully completed and yielded
-            ///   an error as a result of computation.
-            /// * `Err(())` - the fiber has not finished and it is suspended.
-            fn resume(&mut self, val: Result<()>) -> Result<Result<()>, ()> {
-                unsafe {
-                    let prev = self.fiber_resume_state.take().unwrap().replace();
-                    let restore = Restore {
-                        fiber: self,
-                        prior_fiber_state: Some(prev),
-                    };
-                    return restore.fiber.fiber().resume(val);
-                }
-
-                struct Restore<'a, 'b> {
-                    fiber: &'a mut FiberFuture<'b>,
-                    prior_fiber_state: Option<PriorFiberResumeState>,
-                }
-
-                impl Drop for Restore<'_, '_> {
-                    fn drop(&mut self) {
-                        unsafe {
-                            self.fiber.fiber_resume_state =
-                                Some(self.prior_fiber_state.take().unwrap().replace());
-                        }
-                    }
-                }
-            }
-        }
-
-        impl Future for FiberFuture<'_> {
-            type Output = Result<()>;
-
-            fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
-                // We need to carry over this `cx` into our fiber's runtime
-                // for when it tries to poll sub-futures that are created. Doing
-                // this must be done unsafely, however, since `cx` is only alive
-                // for this one singular function call. Here we do a `transmute`
-                // to extend the lifetime of `Context` so it can be stored in
-                // our `Store`, and then we replace the current polling context
-                // with this one.
-                //
-                // Note that the replace is done for weird situations where
-                // futures might be switching contexts and there's multiple
-                // wasmtime futures in a chain of futures.
-                //
-                // On exit from this function, though, we reset the polling
-                // context back to what it was to signify that `Store` no longer
-                // has access to this pointer.
-                let guard = self
-                    .fiber()
-                    .stack()
-                    .guard_range()
-                    .unwrap_or(core::ptr::null_mut()..core::ptr::null_mut());
-                unsafe {
-                    let _reset = Reset(self.current_poll_cx, *self.current_poll_cx);
-                    *self.current_poll_cx = PollContext {
-                        future_context: core::mem::transmute::<
-                            &mut Context<'_>,
-                            *mut Context<'static>,
-                        >(cx),
-                        guard_range_start: guard.start,
-                        guard_range_end: guard.end,
-                    };
-
-                    // After that's set up we resume execution of the fiber, which
-                    // may also start the fiber for the first time. This either
-                    // returns `Ok` saying the fiber finished (yay!) or it
-                    // returns `Err` with the payload passed to `suspend`, which
-                    // in our case is `()`.
-                    match self.resume(Ok(())) {
-                        Ok(result) => Poll::Ready(result),
-
-                        // If `Err` is returned that means the fiber polled a
-                        // future but it said "Pending", so we propagate that
-                        // here.
-                        //
-                        // An additional safety check is performed when leaving
-                        // this function to help bolster the guarantees of
-                        // `unsafe impl Send` above. Notably this future may get
-                        // re-polled on a different thread. Wasmtime's
-                        // thread-local state points to the stack, however,
-                        // meaning that it would be incorrect to leave a pointer
-                        // in TLS when this function returns. This function
-                        // performs a runtime assert to verify that this is the
-                        // case, notably that the one TLS pointer Wasmtime uses
-                        // is not pointing anywhere within the stack. If it is
-                        // then that's a bug indicating that TLS management in
-                        // Wasmtime is incorrect.
-                        Err(()) => {
-                            if let Some(range) = self.fiber().stack().range() {
-                                crate::runtime::vm::AsyncWasmCallState::assert_current_state_not_in_range(range);
-                            }
-                            Poll::Pending
-                        }
-                    }
-                }
-            }
-        }
-
-        // Dropping futures is pretty special in that it means the future has
-        // been requested to be cancelled. Here we run the risk of dropping an
-        // in-progress fiber, and if we were to do nothing then the fiber would
-        // leak all its owned stack resources.
-        //
-        // To handle this we implement `Drop` here and, if the fiber isn't done,
-        // resume execution of the fiber saying "hey please stop you're
-        // interrupted". Our `Trap` created here (which has the stack trace
-        // of whomever dropped us) will then get propagated in whatever called
-        // `block_on`, and the idea is that the trap propagates all the way back
-        // up to the original fiber start, finishing execution.
-        //
-        // We don't actually care about the fiber's return value here (no one's
-        // around to look at it), we just assert the fiber finished to
-        // completion.
-        impl Drop for FiberFuture<'_> {
-            fn drop(&mut self) {
-                if self.fiber.is_none() {
-                    return;
-                }
-
-                if !self.fiber().done() {
-                    let result = self.resume(Err(anyhow!("future dropped")));
-                    // This resumption with an error should always complete the
-                    // fiber. While it's technically possible for host code to
-                    // catch the trap and re-resume, we'd ideally like to
-                    // signal that to callers that they shouldn't be doing
-                    // that.
-                    debug_assert!(result.is_ok());
-
-                    // Note that `result` is `Ok(r)` where `r` is either
-                    // `Ok(())` or `Err(e)`. If it's an error that's disposed of
-                    // here. It's expected to be a propagation of the `future
-                    // dropped` error created above.
-                }
-
-                self.fiber_resume_state.take().unwrap().dispose();
-
-                unsafe {
-                    self.engine
-                        .allocator()
-                        .deallocate_fiber_stack(self.fiber.take().unwrap().into_stack());
-                }
-            }
-        }
-
-        /// State of the world when a fiber last suspended.
-        ///
-        /// This structure represents global state that a fiber clobbers during
-        /// its execution. For example TLS variables are updated, system
-        /// resources like MPK masks are updated, etc. The purpose of this
-        /// structure is to track all of this state and appropriately
-        /// save/restore it around fiber suspension points.
-        struct FiberResumeState {
-            /// Saved list of `CallThreadState` activations that are stored on a
-            /// fiber stack.
-            ///
-            /// This is a linked list that references stack-stored nodes on the
-            /// fiber stack that is currently suspended. The
-            /// `AsyncWasmCallState` type documents this more thoroughly but the
-            /// general gist is that when we this fiber is resumed this linked
-            /// list needs to be pushed on to the current thread's linked list
-            /// of activations.
-            tls: crate::runtime::vm::AsyncWasmCallState,
-
-            /// Saved MPK protection mask, if enabled.
-            ///
-            /// When MPK is enabled then executing WebAssembly will modify the
-            /// processor's current mask of addressable protection keys. This
-            /// means that our current state may get clobbered when a fiber
-            /// suspends. To ensure that this function preserves context it
-            /// will, when MPK is enabled, save the current mask when this
-            /// function is called and then restore the mask when the function
-            /// returns (aka the fiber suspends).
-            mpk: Option<ProtectionMask>,
-        }
-
-        impl FiberResumeState {
-            unsafe fn replace(self) -> PriorFiberResumeState {
-                let tls = self.tls.push();
-                let mpk = swap_mpk_states(self.mpk);
-                PriorFiberResumeState { tls, mpk }
-            }
-
-            fn dispose(self) {
-                self.tls.assert_null();
-            }
-        }
-
-        struct PriorFiberResumeState {
-            tls: crate::runtime::vm::PreviousAsyncWasmCallState,
-            mpk: Option<ProtectionMask>,
-        }
-
-        impl PriorFiberResumeState {
-            unsafe fn replace(self) -> FiberResumeState {
-                let tls = self.tls.restore();
-                let mpk = swap_mpk_states(self.mpk);
-                FiberResumeState { tls, mpk }
-            }
-        }
-
-        fn swap_mpk_states(mask: Option<ProtectionMask>) -> Option<ProtectionMask> {
-            mask.map(|mask| {
-                let current = mpk::current_mask();
-                mpk::allow(mask);
-                current
-            })
-        }
+        fiber::on_fiber(self, func).await
     }
 
     #[cfg(feature = "gc")]
@@ -678,30 +264,6 @@ impl StoreOpaque {
         log::trace!("End trace GC roots")
     }
 
-    /// Yields the async context, assuming that we are executing on a fiber and
-    /// that fiber is not in the process of dying. This function will return
-    /// None in the latter case (the fiber is dying), and panic if
-    /// `async_support()` is false.
-    #[inline]
-    pub fn async_cx(&self) -> Option<AsyncCx> {
-        assert!(self.async_support());
-
-        let poll_cx_box_ptr = self.async_state.current_poll_cx.get();
-        if poll_cx_box_ptr.is_null() {
-            return None;
-        }
-
-        let poll_cx_inner_ptr = unsafe { *poll_cx_box_ptr };
-        if poll_cx_inner_ptr.future_context.is_null() {
-            return None;
-        }
-
-        Some(AsyncCx {
-            current_suspend: self.async_state.current_suspend.get(),
-            current_poll_cx: unsafe { &raw mut (*poll_cx_box_ptr).future_context },
-        })
-    }
-
     /// Yields execution to the caller on out-of-gas or epoch interruption.
     ///
     /// This only works on async futures and stores, and assumes that we're
@@ -718,21 +280,23 @@ impl StoreOpaque {
         // to clean up this fiber. Do so by raising a trap which will
         // abort all wasm and get caught on the other side to clean
         // things up.
-        unsafe {
-            self.async_cx()
-                .expect("attempted to pull async context during shutdown")
-                .block_on(Pin::new_unchecked(&mut future))
-        }
+        AsyncCx::try_new(self)
+            .expect("attempted to pull async context during shutdown")
+            .block_on(unsafe { Pin::new_unchecked(&mut future) })
     }
 
-    fn allocate_fiber_stack(&mut self) -> Result<wasmtime_fiber::FiberStack> {
+    pub(crate) fn async_guard_range(&mut self) -> Range<*mut u8> {
+        unsafe { (*self.async_state()).async_guard_range() }
+    }
+
+    pub(crate) fn allocate_fiber_stack(&mut self) -> Result<wasmtime_fiber::FiberStack> {
         if let Some(stack) = self.async_state.last_fiber_stack.take() {
             return Ok(stack);
         }
         self.engine().allocator().allocate_fiber_stack()
     }
 
-    fn deallocate_fiber_stack(&mut self, stack: wasmtime_fiber::FiberStack) {
+    pub(crate) fn deallocate_fiber_stack(&mut self, stack: wasmtime_fiber::FiberStack) {
         self.flush_fiber_stack();
         self.async_state.last_fiber_stack = Some(stack);
     }
@@ -746,113 +310,20 @@ impl StoreOpaque {
             }
         }
     }
-
-    pub(crate) fn async_guard_range(&mut self) -> Range<*mut u8> {
-        #[cfg(feature = "component-model-async")]
-        {
-            unsafe { (*self.concurrent_async_state()).async_guard_range() }
-        }
-        #[cfg(not(feature = "component-model-async"))]
-        unsafe {
-            let ptr = self.async_state.current_poll_cx.get();
-            (*ptr).guard_range_start..(*ptr).guard_range_end
-        }
-    }
 }
 
 impl<T> StoreContextMut<'_, T> {
     /// Executes a synchronous computation `func` asynchronously on a new fiber.
-    pub(crate) async fn on_fiber<R>(
+    pub(crate) async fn on_fiber<R: Send + 'static>(
         &mut self,
         func: impl FnOnce(&mut StoreContextMut<'_, T>) -> R + Send,
     ) -> Result<R>
     where
         T: Send + 'static,
     {
+        let token = StoreToken::new(self.as_context_mut());
         self.0
-            .on_fiber(|opaque| {
-                let store = unsafe { opaque.traitobj().cast::<StoreInner<T>>().as_mut() };
-                func(&mut StoreContextMut(store))
-            })
+            .on_fiber(|opaque| func(&mut token.as_context_mut(opaque.traitobj_mut())))
             .await
-    }
-}
-
-pub struct AsyncCx {
-    current_suspend: *mut *mut wasmtime_fiber::Suspend<Result<()>, (), Result<()>>,
-    current_poll_cx: *mut *mut Context<'static>,
-}
-
-impl AsyncCx {
-    /// Blocks on the asynchronous computation represented by `future` and
-    /// produces the result here, in-line.
-    ///
-    /// This function is designed to only work when it's currently executing on
-    /// a native fiber. This fiber provides the ability for us to handle the
-    /// future's `Pending` state as "jump back to whomever called the fiber in
-    /// an asynchronous fashion and propagate `Pending`". This tight coupling
-    /// with `on_fiber` below is what powers the asynchronicity of calling wasm.
-    /// Note that the asynchronous part only applies to host functions, wasm
-    /// itself never really does anything asynchronous at this time.
-    ///
-    /// This function takes a `future` and will (appear to) synchronously wait
-    /// on the result. While this function is executing it will fiber switch
-    /// to-and-from the original frame calling `on_fiber` which should be a
-    /// guarantee due to how async stores are configured.
-    ///
-    /// The return value here is either the output of the future `T`, or a trap
-    /// which represents that the asynchronous computation was cancelled. It is
-    /// not recommended to catch the trap and try to keep executing wasm, so
-    /// we've tried to liberally document this.
-    pub unsafe fn block_on<F>(&self, future: F) -> Result<F::Output>
-    where
-        F: Future + Send,
-    {
-        let mut future = pin!(future);
-
-        // Take our current `Suspend` context which was configured as soon as
-        // our fiber started. Note that we must load it at the front here and
-        // save it on our stack frame. While we're polling the future other
-        // fibers may be started for recursive computations, and the current
-        // suspend context is only preserved at the edges of the fiber, not
-        // during the fiber itself.
-        //
-        // For a little bit of extra safety we also replace the current value
-        // with null to try to catch any accidental bugs on our part early.
-        // This is all pretty unsafe so we're trying to be careful...
-        //
-        // Note that there should be a segfaulting test  in `async_functions.rs`
-        // if this `Reset` is removed.
-        let suspend = *self.current_suspend;
-        let _reset = Reset(self.current_suspend, suspend);
-        *self.current_suspend = ptr::null_mut();
-        assert!(!suspend.is_null());
-
-        loop {
-            let future_result = {
-                let poll_cx = *self.current_poll_cx;
-                let _reset = Reset(self.current_poll_cx, poll_cx);
-                *self.current_poll_cx = ptr::null_mut();
-                assert!(!poll_cx.is_null());
-                future.as_mut().poll(&mut *poll_cx)
-            };
-
-            match future_result {
-                Poll::Ready(t) => break Ok(t),
-                Poll::Pending => {}
-            }
-
-            (*suspend).suspend(())?;
-        }
-    }
-}
-
-struct Reset<T: Copy>(*mut T, T);
-
-impl<T: Copy> Drop for Reset<T> {
-    fn drop(&mut self) {
-        unsafe {
-            *self.0 = self.1;
-        }
     }
 }


### PR DESCRIPTION
A long time ago, when I first started implementing CM async, I cut-and-pasted `async_.rs`'s `FiberFuture` as `StoreFiber` and heavily modified it.  Both have evolved separately since then, and now that the CM async work has generally stabilized it's time to unify them.

This creates a new `runtime::fiber` submodule which `async_.rs` and `concurrent.rs` share.  The central type is `StoreFiber`, which is a more versatile version of `FiberFuture`, supporting fibers which can either retain exclusive access to the store across suspend points or release it, allowing the store to be used by the root event loop and/or other fibers to run before the original fiber resumes.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
