### PR TITLE
Start to use `&Accessor<T, D>` more in concurrent code

### DIFF
--- a/crates/component-macro/tests/expanded/conventions_concurrent.rs
+++ b/crates/component-macro/tests/expanded/conventions_concurrent.rs
@@ -210,43 +210,43 @@ pub mod foo {
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
             pub trait HostConcurrent: wasmtime::component::HasData + Send {
                 fn kebab_case<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
                 fn foo<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     x: LudicrousSpeed,
                 ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
                 fn function_with_dashes<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
                 fn function_with_no_weird_characters<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
                 fn apple<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
                 fn apple_pear<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
                 fn apple_pear_grape<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
                 fn a0<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
@@ -256,23 +256,23 @@ pub mod foo {
                 /// APPLE-pear-GRAPE: func()
                 /// apple-PEAR-grape: func()
                 fn is_xml<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
                 fn explicit<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
                 fn explicit_kebab<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
                 /// Identifiers with the same name as keywords are quoted.
                 fn bool<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
@@ -292,7 +292,7 @@ pub mod foo {
                 let mut inst = linker.instance("foo:foo/conventions")?;
                 inst.func_wrap_concurrent(
                     "kebab-case",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::kebab_case(accessor).await;
@@ -303,7 +303,7 @@ pub mod foo {
                 inst.func_wrap_concurrent(
                     "foo",
                     move |
-                        caller: &mut wasmtime::component::Accessor<T>,
+                        caller: &wasmtime::component::Accessor<T>,
                         (arg0,): (LudicrousSpeed,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
@@ -315,7 +315,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "function-with-dashes",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::function_with_dashes(accessor)
@@ -326,7 +326,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "function-with-no-weird-characters",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::function_with_no_weird_characters(
@@ -339,7 +339,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "apple",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::apple(accessor).await;
@@ -349,7 +349,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "apple-pear",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::apple_pear(accessor).await;
@@ -359,7 +359,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "apple-pear-grape",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::apple_pear_grape(accessor)
@@ -370,7 +370,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "a0",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::a0(accessor).await;
@@ -380,7 +380,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "is-XML",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::is_xml(accessor).await;
@@ -390,7 +390,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "explicit",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::explicit(accessor).await;
@@ -400,7 +400,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "explicit-kebab",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::explicit_kebab(accessor)
@@ -411,7 +411,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "bool",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::bool(accessor).await;
@@ -632,14 +632,13 @@ pub mod exports {
                     }
                 }
                 impl Guest {
-                    pub fn call_kebab_case<S: wasmtime::AsContextMut>(
+                    pub async fn call_kebab_case<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -647,17 +646,17 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.kebab_case)
                         };
-                        callee.call_concurrent(store.as_context_mut(), ())
+                        let () = callee.call_concurrent(accessor, ()).await?;
+                        Ok(())
                     }
-                    pub fn call_foo<S: wasmtime::AsContextMut>(
+                    pub async fn call_foo<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: LudicrousSpeed,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -665,16 +664,16 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.foo)
                         };
-                        callee.call_concurrent(store.as_context_mut(), (arg0,))
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(())
                     }
-                    pub fn call_function_with_dashes<S: wasmtime::AsContextMut>(
+                    pub async fn call_function_with_dashes<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -682,18 +681,16 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.function_with_dashes)
                         };
-                        callee.call_concurrent(store.as_context_mut(), ())
+                        let () = callee.call_concurrent(accessor, ()).await?;
+                        Ok(())
                     }
-                    pub fn call_function_with_no_weird_characters<
-                        S: wasmtime::AsContextMut,
-                    >(
+                    pub async fn call_function_with_no_weird_characters<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -701,16 +698,16 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.function_with_no_weird_characters)
                         };
-                        callee.call_concurrent(store.as_context_mut(), ())
+                        let () = callee.call_concurrent(accessor, ()).await?;
+                        Ok(())
                     }
-                    pub fn call_apple<S: wasmtime::AsContextMut>(
+                    pub async fn call_apple<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -718,16 +715,16 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.apple)
                         };
-                        callee.call_concurrent(store.as_context_mut(), ())
+                        let () = callee.call_concurrent(accessor, ()).await?;
+                        Ok(())
                     }
-                    pub fn call_apple_pear<S: wasmtime::AsContextMut>(
+                    pub async fn call_apple_pear<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -735,16 +732,16 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.apple_pear)
                         };
-                        callee.call_concurrent(store.as_context_mut(), ())
+                        let () = callee.call_concurrent(accessor, ()).await?;
+                        Ok(())
                     }
-                    pub fn call_apple_pear_grape<S: wasmtime::AsContextMut>(
+                    pub async fn call_apple_pear_grape<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -752,16 +749,16 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.apple_pear_grape)
                         };
-                        callee.call_concurrent(store.as_context_mut(), ())
+                        let () = callee.call_concurrent(accessor, ()).await?;
+                        Ok(())
                     }
-                    pub fn call_a0<S: wasmtime::AsContextMut>(
+                    pub async fn call_a0<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -769,21 +766,21 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.a0)
                         };
-                        callee.call_concurrent(store.as_context_mut(), ())
+                        let () = callee.call_concurrent(accessor, ()).await?;
+                        Ok(())
                     }
                     /// Comment out identifiers that collide when mapped to snake_case, for now; see
                     ///  https://github.com/WebAssembly/component-model/issues/118
                     /// APPLE: func()
                     /// APPLE-pear-GRAPE: func()
                     /// apple-PEAR-grape: func()
-                    pub fn call_is_xml<S: wasmtime::AsContextMut>(
+                    pub async fn call_is_xml<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -791,16 +788,16 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.is_xml)
                         };
-                        callee.call_concurrent(store.as_context_mut(), ())
+                        let () = callee.call_concurrent(accessor, ()).await?;
+                        Ok(())
                     }
-                    pub fn call_explicit<S: wasmtime::AsContextMut>(
+                    pub async fn call_explicit<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -808,16 +805,16 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.explicit)
                         };
-                        callee.call_concurrent(store.as_context_mut(), ())
+                        let () = callee.call_concurrent(accessor, ()).await?;
+                        Ok(())
                     }
-                    pub fn call_explicit_kebab<S: wasmtime::AsContextMut>(
+                    pub async fn call_explicit_kebab<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -825,17 +822,17 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.explicit_kebab)
                         };
-                        callee.call_concurrent(store.as_context_mut(), ())
+                        let () = callee.call_concurrent(accessor, ()).await?;
+                        Ok(())
                     }
                     /// Identifiers with the same name as keywords are quoted.
-                    pub fn call_bool<S: wasmtime::AsContextMut>(
+                    pub async fn call_bool<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -843,7 +840,8 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.bool)
                         };
-                        callee.call_concurrent(store.as_context_mut(), ())
+                        let () = callee.call_concurrent(accessor, ()).await?;
+                        Ok(())
                     }
                 }
             }

--- a/crates/component-macro/tests/expanded/dead-code_concurrent.rs
+++ b/crates/component-macro/tests/expanded/dead-code_concurrent.rs
@@ -191,7 +191,7 @@ pub mod a {
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
             pub trait HostConcurrent: wasmtime::component::HasData + Send {
                 fn f<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = LiveType> + Send
                 where
                     Self: Sized;
@@ -211,7 +211,7 @@ pub mod a {
                 let mut inst = linker.instance("a:b/interface-with-live-type")?;
                 inst.func_wrap_concurrent(
                     "f",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::f(accessor).await;

--- a/crates/component-macro/tests/expanded/direct-import_concurrent.rs
+++ b/crates/component-macro/tests/expanded/direct-import_concurrent.rs
@@ -93,7 +93,7 @@ pub struct Foo {}
 #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
 pub trait FooImportsConcurrent: wasmtime::component::HasData + Send {
     fn foo<T: 'static>(
-        accessor: &mut wasmtime::component::Accessor<T, Self>,
+        accessor: &wasmtime::component::Accessor<T, Self>,
     ) -> impl ::core::future::Future<Output = ()> + Send
     where
         Self: Sized;
@@ -168,7 +168,7 @@ const _: () = {
             linker
                 .func_wrap_concurrent(
                     "foo",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as FooImportsConcurrent>::foo(accessor).await;

--- a/crates/component-macro/tests/expanded/flags_concurrent.rs
+++ b/crates/component-macro/tests/expanded/flags_concurrent.rs
@@ -290,43 +290,43 @@ pub mod foo {
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
             pub trait HostConcurrent: wasmtime::component::HasData + Send {
                 fn roundtrip_flag1<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     x: Flag1,
                 ) -> impl ::core::future::Future<Output = Flag1> + Send
                 where
                     Self: Sized;
                 fn roundtrip_flag2<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     x: Flag2,
                 ) -> impl ::core::future::Future<Output = Flag2> + Send
                 where
                     Self: Sized;
                 fn roundtrip_flag4<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     x: Flag4,
                 ) -> impl ::core::future::Future<Output = Flag4> + Send
                 where
                     Self: Sized;
                 fn roundtrip_flag8<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     x: Flag8,
                 ) -> impl ::core::future::Future<Output = Flag8> + Send
                 where
                     Self: Sized;
                 fn roundtrip_flag16<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     x: Flag16,
                 ) -> impl ::core::future::Future<Output = Flag16> + Send
                 where
                     Self: Sized;
                 fn roundtrip_flag32<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     x: Flag32,
                 ) -> impl ::core::future::Future<Output = Flag32> + Send
                 where
                     Self: Sized;
                 fn roundtrip_flag64<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     x: Flag64,
                 ) -> impl ::core::future::Future<Output = Flag64> + Send
                 where
@@ -347,10 +347,7 @@ pub mod foo {
                 let mut inst = linker.instance("foo:foo/flegs")?;
                 inst.func_wrap_concurrent(
                     "roundtrip-flag1",
-                    move |
-                        caller: &mut wasmtime::component::Accessor<T>,
-                        (arg0,): (Flag1,)|
-                    {
+                    move |caller: &wasmtime::component::Accessor<T>, (arg0,): (Flag1,)| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::roundtrip_flag1(
@@ -364,10 +361,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "roundtrip-flag2",
-                    move |
-                        caller: &mut wasmtime::component::Accessor<T>,
-                        (arg0,): (Flag2,)|
-                    {
+                    move |caller: &wasmtime::component::Accessor<T>, (arg0,): (Flag2,)| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::roundtrip_flag2(
@@ -381,10 +375,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "roundtrip-flag4",
-                    move |
-                        caller: &mut wasmtime::component::Accessor<T>,
-                        (arg0,): (Flag4,)|
-                    {
+                    move |caller: &wasmtime::component::Accessor<T>, (arg0,): (Flag4,)| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::roundtrip_flag4(
@@ -398,10 +389,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "roundtrip-flag8",
-                    move |
-                        caller: &mut wasmtime::component::Accessor<T>,
-                        (arg0,): (Flag8,)|
-                    {
+                    move |caller: &wasmtime::component::Accessor<T>, (arg0,): (Flag8,)| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::roundtrip_flag8(
@@ -415,10 +403,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "roundtrip-flag16",
-                    move |
-                        caller: &mut wasmtime::component::Accessor<T>,
-                        (arg0,): (Flag16,)|
-                    {
+                    move |caller: &wasmtime::component::Accessor<T>, (arg0,): (Flag16,)| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::roundtrip_flag16(
@@ -432,10 +417,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "roundtrip-flag32",
-                    move |
-                        caller: &mut wasmtime::component::Accessor<T>,
-                        (arg0,): (Flag32,)|
-                    {
+                    move |caller: &wasmtime::component::Accessor<T>, (arg0,): (Flag32,)| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::roundtrip_flag32(
@@ -449,10 +431,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "roundtrip-flag64",
-                    move |
-                        caller: &mut wasmtime::component::Accessor<T>,
-                        (arg0,): (Flag64,)|
-                    {
+                    move |caller: &wasmtime::component::Accessor<T>, (arg0,): (Flag64,)| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::roundtrip_flag64(
@@ -755,15 +734,14 @@ pub mod exports {
                     }
                 }
                 impl Guest {
-                    pub fn call_roundtrip_flag1<S: wasmtime::AsContextMut>(
+                    pub async fn call_roundtrip_flag1<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: Flag1,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<Flag1>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<Flag1>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -771,22 +749,17 @@ pub mod exports {
                                 (Flag1,),
                             >::new_unchecked(self.roundtrip_flag1)
                         };
-                        let future = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,));
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_roundtrip_flag2<S: wasmtime::AsContextMut>(
+                    pub async fn call_roundtrip_flag2<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: Flag2,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<Flag2>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<Flag2>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -794,22 +767,17 @@ pub mod exports {
                                 (Flag2,),
                             >::new_unchecked(self.roundtrip_flag2)
                         };
-                        let future = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,));
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_roundtrip_flag4<S: wasmtime::AsContextMut>(
+                    pub async fn call_roundtrip_flag4<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: Flag4,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<Flag4>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<Flag4>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -817,22 +785,17 @@ pub mod exports {
                                 (Flag4,),
                             >::new_unchecked(self.roundtrip_flag4)
                         };
-                        let future = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,));
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_roundtrip_flag8<S: wasmtime::AsContextMut>(
+                    pub async fn call_roundtrip_flag8<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: Flag8,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<Flag8>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<Flag8>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -840,22 +803,17 @@ pub mod exports {
                                 (Flag8,),
                             >::new_unchecked(self.roundtrip_flag8)
                         };
-                        let future = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,));
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_roundtrip_flag16<S: wasmtime::AsContextMut>(
+                    pub async fn call_roundtrip_flag16<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: Flag16,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<Flag16>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<Flag16>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -863,22 +821,17 @@ pub mod exports {
                                 (Flag16,),
                             >::new_unchecked(self.roundtrip_flag16)
                         };
-                        let future = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,));
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_roundtrip_flag32<S: wasmtime::AsContextMut>(
+                    pub async fn call_roundtrip_flag32<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: Flag32,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<Flag32>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<Flag32>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -886,22 +839,17 @@ pub mod exports {
                                 (Flag32,),
                             >::new_unchecked(self.roundtrip_flag32)
                         };
-                        let future = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,));
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_roundtrip_flag64<S: wasmtime::AsContextMut>(
+                    pub async fn call_roundtrip_flag64<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: Flag64,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<Flag64>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<Flag64>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -909,12 +857,8 @@ pub mod exports {
                                 (Flag64,),
                             >::new_unchecked(self.roundtrip_flag64)
                         };
-                        let future = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,));
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(ret0)
                     }
                 }
             }

--- a/crates/component-macro/tests/expanded/floats_concurrent.rs
+++ b/crates/component-macro/tests/expanded/floats_concurrent.rs
@@ -178,24 +178,24 @@ pub mod foo {
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
             pub trait HostConcurrent: wasmtime::component::HasData + Send {
                 fn f32_param<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     x: f32,
                 ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
                 fn f64_param<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     x: f64,
                 ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
                 fn f32_result<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = f32> + Send
                 where
                     Self: Sized;
                 fn f64_result<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = f64> + Send
                 where
                     Self: Sized;
@@ -215,10 +215,7 @@ pub mod foo {
                 let mut inst = linker.instance("foo:foo/floats")?;
                 inst.func_wrap_concurrent(
                     "f32-param",
-                    move |
-                        caller: &mut wasmtime::component::Accessor<T>,
-                        (arg0,): (f32,)|
-                    {
+                    move |caller: &wasmtime::component::Accessor<T>, (arg0,): (f32,)| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::f32_param(accessor, arg0)
@@ -229,10 +226,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "f64-param",
-                    move |
-                        caller: &mut wasmtime::component::Accessor<T>,
-                        (arg0,): (f64,)|
-                    {
+                    move |caller: &wasmtime::component::Accessor<T>, (arg0,): (f64,)| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::f64_param(accessor, arg0)
@@ -243,7 +237,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "f32-result",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::f32_result(accessor).await;
@@ -253,7 +247,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "f64-result",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::f64_result(accessor).await;
@@ -358,15 +352,14 @@ pub mod exports {
                     }
                 }
                 impl Guest {
-                    pub fn call_f32_param<S: wasmtime::AsContextMut>(
+                    pub async fn call_f32_param<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: f32,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -374,17 +367,17 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.f32_param)
                         };
-                        callee.call_concurrent(store.as_context_mut(), (arg0,))
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(())
                     }
-                    pub fn call_f64_param<S: wasmtime::AsContextMut>(
+                    pub async fn call_f64_param<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: f64,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -392,16 +385,16 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.f64_param)
                         };
-                        callee.call_concurrent(store.as_context_mut(), (arg0,))
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(())
                     }
-                    pub fn call_f32_result<S: wasmtime::AsContextMut>(
+                    pub async fn call_f32_result<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<f32>,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<f32>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -409,20 +402,16 @@ pub mod exports {
                                 (f32,),
                             >::new_unchecked(self.f32_result)
                         };
-                        let future = callee.call_concurrent(store.as_context_mut(), ());
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_f64_result<S: wasmtime::AsContextMut>(
+                    pub async fn call_f64_result<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<f64>,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<f64>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -430,11 +419,8 @@ pub mod exports {
                                 (f64,),
                             >::new_unchecked(self.f64_result)
                         };
-                        let future = callee.call_concurrent(store.as_context_mut(), ());
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
+                        Ok(ret0)
                     }
                 }
             }

--- a/crates/component-macro/tests/expanded/function-new_concurrent.rs
+++ b/crates/component-macro/tests/expanded/function-new_concurrent.rs
@@ -164,19 +164,19 @@ const _: () = {
             let indices = FooIndices::new(&instance.instance_pre(&store))?;
             indices.load(&mut store, instance)
         }
-        pub fn call_new<S: wasmtime::AsContextMut>(
+        pub async fn call_new<_T, _D>(
             &self,
-            mut store: S,
-        ) -> impl wasmtime::component::__internal::Future<
-            Output = wasmtime::Result<()>,
-        > + Send + 'static + use<S>
+            accessor: &wasmtime::component::Accessor<_T, _D>,
+        ) -> wasmtime::Result<()>
         where
-            <S as wasmtime::AsContext>::Data: Send + 'static,
+            _T: Send,
+            _D: wasmtime::component::HasData,
         {
             let callee = unsafe {
                 wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.new)
             };
-            callee.call_concurrent(store.as_context_mut(), ())
+            let () = callee.call_concurrent(accessor, ()).await?;
+            Ok(())
         }
     }
 };

--- a/crates/component-macro/tests/expanded/host-world_concurrent.rs
+++ b/crates/component-macro/tests/expanded/host-world_concurrent.rs
@@ -93,7 +93,7 @@ pub struct Host_ {}
 #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
 pub trait Host_ImportsConcurrent: wasmtime::component::HasData + Send {
     fn foo<T: 'static>(
-        accessor: &mut wasmtime::component::Accessor<T, Self>,
+        accessor: &wasmtime::component::Accessor<T, Self>,
     ) -> impl ::core::future::Future<Output = ()> + Send
     where
         Self: Sized;
@@ -168,7 +168,7 @@ const _: () = {
             linker
                 .func_wrap_concurrent(
                     "foo",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as Host_ImportsConcurrent>::foo(accessor).await;

--- a/crates/component-macro/tests/expanded/integers_concurrent.rs
+++ b/crates/component-macro/tests/expanded/integers_concurrent.rs
@@ -178,55 +178,55 @@ pub mod foo {
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
             pub trait HostConcurrent: wasmtime::component::HasData + Send {
                 fn a1<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     x: u8,
                 ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
                 fn a2<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     x: i8,
                 ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
                 fn a3<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     x: u16,
                 ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
                 fn a4<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     x: i16,
                 ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
                 fn a5<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     x: u32,
                 ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
                 fn a6<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     x: i32,
                 ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
                 fn a7<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     x: u64,
                 ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
                 fn a8<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     x: i64,
                 ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
                 fn a9<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     p1: u8,
                     p2: i8,
                     p3: u16,
@@ -239,47 +239,47 @@ pub mod foo {
                 where
                     Self: Sized;
                 fn r1<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = u8> + Send
                 where
                     Self: Sized;
                 fn r2<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = i8> + Send
                 where
                     Self: Sized;
                 fn r3<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = u16> + Send
                 where
                     Self: Sized;
                 fn r4<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = i16> + Send
                 where
                     Self: Sized;
                 fn r5<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = u32> + Send
                 where
                     Self: Sized;
                 fn r6<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = i32> + Send
                 where
                     Self: Sized;
                 fn r7<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = u64> + Send
                 where
                     Self: Sized;
                 fn r8<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = i64> + Send
                 where
                     Self: Sized;
                 fn pair_ret<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = (i64, u8)> + Send
                 where
                     Self: Sized;
@@ -299,7 +299,7 @@ pub mod foo {
                 let mut inst = linker.instance("foo:foo/integers")?;
                 inst.func_wrap_concurrent(
                     "a1",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (arg0,): (u8,)| {
+                    move |caller: &wasmtime::component::Accessor<T>, (arg0,): (u8,)| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::a1(accessor, arg0).await;
@@ -309,7 +309,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "a2",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (arg0,): (i8,)| {
+                    move |caller: &wasmtime::component::Accessor<T>, (arg0,): (i8,)| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::a2(accessor, arg0).await;
@@ -319,10 +319,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "a3",
-                    move |
-                        caller: &mut wasmtime::component::Accessor<T>,
-                        (arg0,): (u16,)|
-                    {
+                    move |caller: &wasmtime::component::Accessor<T>, (arg0,): (u16,)| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::a3(accessor, arg0).await;
@@ -332,10 +329,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "a4",
-                    move |
-                        caller: &mut wasmtime::component::Accessor<T>,
-                        (arg0,): (i16,)|
-                    {
+                    move |caller: &wasmtime::component::Accessor<T>, (arg0,): (i16,)| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::a4(accessor, arg0).await;
@@ -345,10 +339,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "a5",
-                    move |
-                        caller: &mut wasmtime::component::Accessor<T>,
-                        (arg0,): (u32,)|
-                    {
+                    move |caller: &wasmtime::component::Accessor<T>, (arg0,): (u32,)| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::a5(accessor, arg0).await;
@@ -358,10 +349,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "a6",
-                    move |
-                        caller: &mut wasmtime::component::Accessor<T>,
-                        (arg0,): (i32,)|
-                    {
+                    move |caller: &wasmtime::component::Accessor<T>, (arg0,): (i32,)| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::a6(accessor, arg0).await;
@@ -371,10 +359,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "a7",
-                    move |
-                        caller: &mut wasmtime::component::Accessor<T>,
-                        (arg0,): (u64,)|
-                    {
+                    move |caller: &wasmtime::component::Accessor<T>, (arg0,): (u64,)| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::a7(accessor, arg0).await;
@@ -384,10 +369,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "a8",
-                    move |
-                        caller: &mut wasmtime::component::Accessor<T>,
-                        (arg0,): (i64,)|
-                    {
+                    move |caller: &wasmtime::component::Accessor<T>, (arg0,): (i64,)| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::a8(accessor, arg0).await;
@@ -398,7 +380,7 @@ pub mod foo {
                 inst.func_wrap_concurrent(
                     "a9",
                     move |
-                        caller: &mut wasmtime::component::Accessor<T>,
+                        caller: &wasmtime::component::Accessor<T>,
                         (
                             arg0,
                             arg1,
@@ -430,7 +412,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "r1",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::r1(accessor).await;
@@ -440,7 +422,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "r2",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::r2(accessor).await;
@@ -450,7 +432,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "r3",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::r3(accessor).await;
@@ -460,7 +442,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "r4",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::r4(accessor).await;
@@ -470,7 +452,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "r5",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::r5(accessor).await;
@@ -480,7 +462,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "r6",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::r6(accessor).await;
@@ -490,7 +472,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "r7",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::r7(accessor).await;
@@ -500,7 +482,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "r8",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::r8(accessor).await;
@@ -510,7 +492,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "pair-ret",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::pair_ret(accessor).await;
@@ -733,15 +715,14 @@ pub mod exports {
                     }
                 }
                 impl Guest {
-                    pub fn call_a1<S: wasmtime::AsContextMut>(
+                    pub async fn call_a1<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: u8,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -749,17 +730,17 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.a1)
                         };
-                        callee.call_concurrent(store.as_context_mut(), (arg0,))
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(())
                     }
-                    pub fn call_a2<S: wasmtime::AsContextMut>(
+                    pub async fn call_a2<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: i8,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -767,17 +748,17 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.a2)
                         };
-                        callee.call_concurrent(store.as_context_mut(), (arg0,))
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(())
                     }
-                    pub fn call_a3<S: wasmtime::AsContextMut>(
+                    pub async fn call_a3<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: u16,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -785,17 +766,17 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.a3)
                         };
-                        callee.call_concurrent(store.as_context_mut(), (arg0,))
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(())
                     }
-                    pub fn call_a4<S: wasmtime::AsContextMut>(
+                    pub async fn call_a4<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: i16,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -803,17 +784,17 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.a4)
                         };
-                        callee.call_concurrent(store.as_context_mut(), (arg0,))
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(())
                     }
-                    pub fn call_a5<S: wasmtime::AsContextMut>(
+                    pub async fn call_a5<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: u32,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -821,17 +802,17 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.a5)
                         };
-                        callee.call_concurrent(store.as_context_mut(), (arg0,))
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(())
                     }
-                    pub fn call_a6<S: wasmtime::AsContextMut>(
+                    pub async fn call_a6<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: i32,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -839,17 +820,17 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.a6)
                         };
-                        callee.call_concurrent(store.as_context_mut(), (arg0,))
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(())
                     }
-                    pub fn call_a7<S: wasmtime::AsContextMut>(
+                    pub async fn call_a7<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: u64,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -857,17 +838,17 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.a7)
                         };
-                        callee.call_concurrent(store.as_context_mut(), (arg0,))
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(())
                     }
-                    pub fn call_a8<S: wasmtime::AsContextMut>(
+                    pub async fn call_a8<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: i64,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -875,11 +856,12 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.a8)
                         };
-                        callee.call_concurrent(store.as_context_mut(), (arg0,))
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(())
                     }
-                    pub fn call_a9<S: wasmtime::AsContextMut>(
+                    pub async fn call_a9<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: u8,
                         arg1: i8,
                         arg2: u16,
@@ -888,11 +870,10 @@ pub mod exports {
                         arg5: i32,
                         arg6: u64,
                         arg7: i64,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -900,20 +881,21 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.a9)
                         };
-                        callee
+                        let () = callee
                             .call_concurrent(
-                                store.as_context_mut(),
+                                accessor,
                                 (arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7),
                             )
+                            .await?;
+                        Ok(())
                     }
-                    pub fn call_r1<S: wasmtime::AsContextMut>(
+                    pub async fn call_r1<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<u8>,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<u8>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -921,20 +903,16 @@ pub mod exports {
                                 (u8,),
                             >::new_unchecked(self.r1)
                         };
-                        let future = callee.call_concurrent(store.as_context_mut(), ());
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_r2<S: wasmtime::AsContextMut>(
+                    pub async fn call_r2<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<i8>,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<i8>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -942,20 +920,16 @@ pub mod exports {
                                 (i8,),
                             >::new_unchecked(self.r2)
                         };
-                        let future = callee.call_concurrent(store.as_context_mut(), ());
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_r3<S: wasmtime::AsContextMut>(
+                    pub async fn call_r3<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<u16>,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<u16>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -963,20 +937,16 @@ pub mod exports {
                                 (u16,),
                             >::new_unchecked(self.r3)
                         };
-                        let future = callee.call_concurrent(store.as_context_mut(), ());
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_r4<S: wasmtime::AsContextMut>(
+                    pub async fn call_r4<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<i16>,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<i16>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -984,20 +954,16 @@ pub mod exports {
                                 (i16,),
                             >::new_unchecked(self.r4)
                         };
-                        let future = callee.call_concurrent(store.as_context_mut(), ());
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_r5<S: wasmtime::AsContextMut>(
+                    pub async fn call_r5<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<u32>,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<u32>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1005,20 +971,16 @@ pub mod exports {
                                 (u32,),
                             >::new_unchecked(self.r5)
                         };
-                        let future = callee.call_concurrent(store.as_context_mut(), ());
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_r6<S: wasmtime::AsContextMut>(
+                    pub async fn call_r6<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<i32>,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<i32>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1026,20 +988,16 @@ pub mod exports {
                                 (i32,),
                             >::new_unchecked(self.r6)
                         };
-                        let future = callee.call_concurrent(store.as_context_mut(), ());
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_r7<S: wasmtime::AsContextMut>(
+                    pub async fn call_r7<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<u64>,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<u64>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1047,20 +1005,16 @@ pub mod exports {
                                 (u64,),
                             >::new_unchecked(self.r7)
                         };
-                        let future = callee.call_concurrent(store.as_context_mut(), ());
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_r8<S: wasmtime::AsContextMut>(
+                    pub async fn call_r8<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<i64>,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<i64>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1068,20 +1022,16 @@ pub mod exports {
                                 (i64,),
                             >::new_unchecked(self.r8)
                         };
-                        let future = callee.call_concurrent(store.as_context_mut(), ());
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_pair_ret<S: wasmtime::AsContextMut>(
+                    pub async fn call_pair_ret<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<(i64, u8)>,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<(i64, u8)>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1089,11 +1039,8 @@ pub mod exports {
                                 ((i64, u8),),
                             >::new_unchecked(self.pair_ret)
                         };
-                        let future = callee.call_concurrent(store.as_context_mut(), ());
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
+                        Ok(ret0)
                     }
                 }
             }

--- a/crates/component-macro/tests/expanded/lists_concurrent.rs
+++ b/crates/component-macro/tests/expanded/lists_concurrent.rs
@@ -356,137 +356,137 @@ pub mod foo {
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
             pub trait HostConcurrent: wasmtime::component::HasData + Send {
                 fn list_u8_param<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<u8>,
                 ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
                 fn list_u16_param<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<u16>,
                 ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
                 fn list_u32_param<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<u32>,
                 ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
                 fn list_u64_param<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<u64>,
                 ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
                 fn list_s8_param<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<i8>,
                 ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
                 fn list_s16_param<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<i16>,
                 ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
                 fn list_s32_param<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<i32>,
                 ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
                 fn list_s64_param<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<i64>,
                 ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
                 fn list_f32_param<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<f32>,
                 ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
                 fn list_f64_param<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<f64>,
                 ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
                 fn list_u8_ret<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<u8>,
                 > + Send
                 where
                     Self: Sized;
                 fn list_u16_ret<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<u16>,
                 > + Send
                 where
                     Self: Sized;
                 fn list_u32_ret<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<u32>,
                 > + Send
                 where
                     Self: Sized;
                 fn list_u64_ret<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<u64>,
                 > + Send
                 where
                     Self: Sized;
                 fn list_s8_ret<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<i8>,
                 > + Send
                 where
                     Self: Sized;
                 fn list_s16_ret<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<i16>,
                 > + Send
                 where
                     Self: Sized;
                 fn list_s32_ret<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<i32>,
                 > + Send
                 where
                     Self: Sized;
                 fn list_s64_ret<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<i64>,
                 > + Send
                 where
                     Self: Sized;
                 fn list_f32_ret<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<f32>,
                 > + Send
                 where
                     Self: Sized;
                 fn list_f64_ret<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<f64>,
                 > + Send
                 where
                     Self: Sized;
                 fn tuple_list<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<(u8, i8)>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<(i64, u32)>,
@@ -494,7 +494,7 @@ pub mod foo {
                 where
                     Self: Sized;
                 fn string_list_arg<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     a: wasmtime::component::__internal::Vec<
                         wasmtime::component::__internal::String,
                     >,
@@ -502,7 +502,7 @@ pub mod foo {
                 where
                     Self: Sized;
                 fn string_list_ret<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<
                         wasmtime::component::__internal::String,
@@ -511,7 +511,7 @@ pub mod foo {
                 where
                     Self: Sized;
                 fn tuple_string_list<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<
                         (u8, wasmtime::component::__internal::String),
                     >,
@@ -523,7 +523,7 @@ pub mod foo {
                 where
                     Self: Sized;
                 fn string_list<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<
                         wasmtime::component::__internal::String,
                     >,
@@ -535,7 +535,7 @@ pub mod foo {
                 where
                     Self: Sized;
                 fn record_list<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<SomeRecord>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<OtherRecord>,
@@ -543,7 +543,7 @@ pub mod foo {
                 where
                     Self: Sized;
                 fn record_list_reverse<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<OtherRecord>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<SomeRecord>,
@@ -551,7 +551,7 @@ pub mod foo {
                 where
                     Self: Sized;
                 fn variant_list<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<SomeVariant>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<OtherVariant>,
@@ -559,7 +559,7 @@ pub mod foo {
                 where
                     Self: Sized;
                 fn load_store_everything<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     a: LoadStoreAllSizes,
                 ) -> impl ::core::future::Future<Output = LoadStoreAllSizes> + Send
                 where
@@ -581,7 +581,7 @@ pub mod foo {
                 inst.func_wrap_concurrent(
                     "list-u8-param",
                     move |
-                        caller: &mut wasmtime::component::Accessor<T>,
+                        caller: &wasmtime::component::Accessor<T>,
                         (arg0,): (wasmtime::component::__internal::Vec<u8>,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
@@ -595,7 +595,7 @@ pub mod foo {
                 inst.func_wrap_concurrent(
                     "list-u16-param",
                     move |
-                        caller: &mut wasmtime::component::Accessor<T>,
+                        caller: &wasmtime::component::Accessor<T>,
                         (arg0,): (wasmtime::component::__internal::Vec<u16>,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
@@ -609,7 +609,7 @@ pub mod foo {
                 inst.func_wrap_concurrent(
                     "list-u32-param",
                     move |
-                        caller: &mut wasmtime::component::Accessor<T>,
+                        caller: &wasmtime::component::Accessor<T>,
                         (arg0,): (wasmtime::component::__internal::Vec<u32>,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
@@ -623,7 +623,7 @@ pub mod foo {
                 inst.func_wrap_concurrent(
                     "list-u64-param",
                     move |
-                        caller: &mut wasmtime::component::Accessor<T>,
+                        caller: &wasmtime::component::Accessor<T>,
                         (arg0,): (wasmtime::component::__internal::Vec<u64>,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
@@ -637,7 +637,7 @@ pub mod foo {
                 inst.func_wrap_concurrent(
                     "list-s8-param",
                     move |
-                        caller: &mut wasmtime::component::Accessor<T>,
+                        caller: &wasmtime::component::Accessor<T>,
                         (arg0,): (wasmtime::component::__internal::Vec<i8>,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
@@ -651,7 +651,7 @@ pub mod foo {
                 inst.func_wrap_concurrent(
                     "list-s16-param",
                     move |
-                        caller: &mut wasmtime::component::Accessor<T>,
+                        caller: &wasmtime::component::Accessor<T>,
                         (arg0,): (wasmtime::component::__internal::Vec<i16>,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
@@ -665,7 +665,7 @@ pub mod foo {
                 inst.func_wrap_concurrent(
                     "list-s32-param",
                     move |
-                        caller: &mut wasmtime::component::Accessor<T>,
+                        caller: &wasmtime::component::Accessor<T>,
                         (arg0,): (wasmtime::component::__internal::Vec<i32>,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
@@ -679,7 +679,7 @@ pub mod foo {
                 inst.func_wrap_concurrent(
                     "list-s64-param",
                     move |
-                        caller: &mut wasmtime::component::Accessor<T>,
+                        caller: &wasmtime::component::Accessor<T>,
                         (arg0,): (wasmtime::component::__internal::Vec<i64>,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
@@ -693,7 +693,7 @@ pub mod foo {
                 inst.func_wrap_concurrent(
                     "list-f32-param",
                     move |
-                        caller: &mut wasmtime::component::Accessor<T>,
+                        caller: &wasmtime::component::Accessor<T>,
                         (arg0,): (wasmtime::component::__internal::Vec<f32>,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
@@ -707,7 +707,7 @@ pub mod foo {
                 inst.func_wrap_concurrent(
                     "list-f64-param",
                     move |
-                        caller: &mut wasmtime::component::Accessor<T>,
+                        caller: &wasmtime::component::Accessor<T>,
                         (arg0,): (wasmtime::component::__internal::Vec<f64>,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
@@ -720,7 +720,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "list-u8-ret",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::list_u8_ret(accessor).await;
@@ -730,7 +730,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "list-u16-ret",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::list_u16_ret(accessor).await;
@@ -740,7 +740,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "list-u32-ret",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::list_u32_ret(accessor).await;
@@ -750,7 +750,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "list-u64-ret",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::list_u64_ret(accessor).await;
@@ -760,7 +760,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "list-s8-ret",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::list_s8_ret(accessor).await;
@@ -770,7 +770,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "list-s16-ret",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::list_s16_ret(accessor).await;
@@ -780,7 +780,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "list-s32-ret",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::list_s32_ret(accessor).await;
@@ -790,7 +790,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "list-s64-ret",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::list_s64_ret(accessor).await;
@@ -800,7 +800,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "list-f32-ret",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::list_f32_ret(accessor).await;
@@ -810,7 +810,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "list-f64-ret",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::list_f64_ret(accessor).await;
@@ -821,7 +821,7 @@ pub mod foo {
                 inst.func_wrap_concurrent(
                     "tuple-list",
                     move |
-                        caller: &mut wasmtime::component::Accessor<T>,
+                        caller: &wasmtime::component::Accessor<T>,
                         (arg0,): (wasmtime::component::__internal::Vec<(u8, i8)>,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
@@ -835,7 +835,7 @@ pub mod foo {
                 inst.func_wrap_concurrent(
                     "string-list-arg",
                     move |
-                        caller: &mut wasmtime::component::Accessor<T>,
+                        caller: &wasmtime::component::Accessor<T>,
                         (
                             arg0,
                         ): (
@@ -857,7 +857,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "string-list-ret",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::string_list_ret(accessor)
@@ -869,7 +869,7 @@ pub mod foo {
                 inst.func_wrap_concurrent(
                     "tuple-string-list",
                     move |
-                        caller: &mut wasmtime::component::Accessor<T>,
+                        caller: &wasmtime::component::Accessor<T>,
                         (
                             arg0,
                         ): (
@@ -892,7 +892,7 @@ pub mod foo {
                 inst.func_wrap_concurrent(
                     "string-list",
                     move |
-                        caller: &mut wasmtime::component::Accessor<T>,
+                        caller: &wasmtime::component::Accessor<T>,
                         (
                             arg0,
                         ): (
@@ -912,7 +912,7 @@ pub mod foo {
                 inst.func_wrap_concurrent(
                     "record-list",
                     move |
-                        caller: &mut wasmtime::component::Accessor<T>,
+                        caller: &wasmtime::component::Accessor<T>,
                         (arg0,): (wasmtime::component::__internal::Vec<SomeRecord>,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
@@ -926,7 +926,7 @@ pub mod foo {
                 inst.func_wrap_concurrent(
                     "record-list-reverse",
                     move |
-                        caller: &mut wasmtime::component::Accessor<T>,
+                        caller: &wasmtime::component::Accessor<T>,
                         (arg0,): (wasmtime::component::__internal::Vec<OtherRecord>,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
@@ -943,7 +943,7 @@ pub mod foo {
                 inst.func_wrap_concurrent(
                     "variant-list",
                     move |
-                        caller: &mut wasmtime::component::Accessor<T>,
+                        caller: &wasmtime::component::Accessor<T>,
                         (arg0,): (wasmtime::component::__internal::Vec<SomeVariant>,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
@@ -957,7 +957,7 @@ pub mod foo {
                 inst.func_wrap_concurrent(
                     "load-store-everything",
                     move |
-                        caller: &mut wasmtime::component::Accessor<T>,
+                        caller: &wasmtime::component::Accessor<T>,
                         (arg0,): (LoadStoreAllSizes,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
@@ -1567,15 +1567,14 @@ pub mod exports {
                     }
                 }
                 impl Guest {
-                    pub fn call_list_u8_param<S: wasmtime::AsContextMut>(
+                    pub async fn call_list_u8_param<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: wasmtime::component::__internal::Vec<u8>,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1583,17 +1582,17 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.list_u8_param)
                         };
-                        callee.call_concurrent(store.as_context_mut(), (arg0,))
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(())
                     }
-                    pub fn call_list_u16_param<S: wasmtime::AsContextMut>(
+                    pub async fn call_list_u16_param<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: wasmtime::component::__internal::Vec<u16>,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1601,17 +1600,17 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.list_u16_param)
                         };
-                        callee.call_concurrent(store.as_context_mut(), (arg0,))
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(())
                     }
-                    pub fn call_list_u32_param<S: wasmtime::AsContextMut>(
+                    pub async fn call_list_u32_param<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: wasmtime::component::__internal::Vec<u32>,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1619,17 +1618,17 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.list_u32_param)
                         };
-                        callee.call_concurrent(store.as_context_mut(), (arg0,))
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(())
                     }
-                    pub fn call_list_u64_param<S: wasmtime::AsContextMut>(
+                    pub async fn call_list_u64_param<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: wasmtime::component::__internal::Vec<u64>,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1637,17 +1636,17 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.list_u64_param)
                         };
-                        callee.call_concurrent(store.as_context_mut(), (arg0,))
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(())
                     }
-                    pub fn call_list_s8_param<S: wasmtime::AsContextMut>(
+                    pub async fn call_list_s8_param<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: wasmtime::component::__internal::Vec<i8>,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1655,17 +1654,17 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.list_s8_param)
                         };
-                        callee.call_concurrent(store.as_context_mut(), (arg0,))
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(())
                     }
-                    pub fn call_list_s16_param<S: wasmtime::AsContextMut>(
+                    pub async fn call_list_s16_param<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: wasmtime::component::__internal::Vec<i16>,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1673,17 +1672,17 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.list_s16_param)
                         };
-                        callee.call_concurrent(store.as_context_mut(), (arg0,))
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(())
                     }
-                    pub fn call_list_s32_param<S: wasmtime::AsContextMut>(
+                    pub async fn call_list_s32_param<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: wasmtime::component::__internal::Vec<i32>,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1691,17 +1690,17 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.list_s32_param)
                         };
-                        callee.call_concurrent(store.as_context_mut(), (arg0,))
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(())
                     }
-                    pub fn call_list_s64_param<S: wasmtime::AsContextMut>(
+                    pub async fn call_list_s64_param<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: wasmtime::component::__internal::Vec<i64>,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1709,17 +1708,17 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.list_s64_param)
                         };
-                        callee.call_concurrent(store.as_context_mut(), (arg0,))
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(())
                     }
-                    pub fn call_list_f32_param<S: wasmtime::AsContextMut>(
+                    pub async fn call_list_f32_param<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: wasmtime::component::__internal::Vec<f32>,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1727,17 +1726,17 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.list_f32_param)
                         };
-                        callee.call_concurrent(store.as_context_mut(), (arg0,))
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(())
                     }
-                    pub fn call_list_f64_param<S: wasmtime::AsContextMut>(
+                    pub async fn call_list_f64_param<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: wasmtime::component::__internal::Vec<f64>,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1745,18 +1744,16 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.list_f64_param)
                         };
-                        callee.call_concurrent(store.as_context_mut(), (arg0,))
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(())
                     }
-                    pub fn call_list_u8_ret<S: wasmtime::AsContextMut>(
+                    pub async fn call_list_u8_ret<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<
-                            wasmtime::component::__internal::Vec<u8>,
-                        >,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<u8>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1764,22 +1761,16 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<u8>,),
                             >::new_unchecked(self.list_u8_ret)
                         };
-                        let future = callee.call_concurrent(store.as_context_mut(), ());
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_list_u16_ret<S: wasmtime::AsContextMut>(
+                    pub async fn call_list_u16_ret<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<
-                            wasmtime::component::__internal::Vec<u16>,
-                        >,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<u16>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1787,22 +1778,16 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<u16>,),
                             >::new_unchecked(self.list_u16_ret)
                         };
-                        let future = callee.call_concurrent(store.as_context_mut(), ());
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_list_u32_ret<S: wasmtime::AsContextMut>(
+                    pub async fn call_list_u32_ret<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<
-                            wasmtime::component::__internal::Vec<u32>,
-                        >,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<u32>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1810,22 +1795,16 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<u32>,),
                             >::new_unchecked(self.list_u32_ret)
                         };
-                        let future = callee.call_concurrent(store.as_context_mut(), ());
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_list_u64_ret<S: wasmtime::AsContextMut>(
+                    pub async fn call_list_u64_ret<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<
-                            wasmtime::component::__internal::Vec<u64>,
-                        >,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<u64>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1833,22 +1812,16 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<u64>,),
                             >::new_unchecked(self.list_u64_ret)
                         };
-                        let future = callee.call_concurrent(store.as_context_mut(), ());
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_list_s8_ret<S: wasmtime::AsContextMut>(
+                    pub async fn call_list_s8_ret<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<
-                            wasmtime::component::__internal::Vec<i8>,
-                        >,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<i8>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1856,22 +1829,16 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<i8>,),
                             >::new_unchecked(self.list_s8_ret)
                         };
-                        let future = callee.call_concurrent(store.as_context_mut(), ());
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_list_s16_ret<S: wasmtime::AsContextMut>(
+                    pub async fn call_list_s16_ret<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<
-                            wasmtime::component::__internal::Vec<i16>,
-                        >,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<i16>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1879,22 +1846,16 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<i16>,),
                             >::new_unchecked(self.list_s16_ret)
                         };
-                        let future = callee.call_concurrent(store.as_context_mut(), ());
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_list_s32_ret<S: wasmtime::AsContextMut>(
+                    pub async fn call_list_s32_ret<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<
-                            wasmtime::component::__internal::Vec<i32>,
-                        >,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<i32>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1902,22 +1863,16 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<i32>,),
                             >::new_unchecked(self.list_s32_ret)
                         };
-                        let future = callee.call_concurrent(store.as_context_mut(), ());
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_list_s64_ret<S: wasmtime::AsContextMut>(
+                    pub async fn call_list_s64_ret<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<
-                            wasmtime::component::__internal::Vec<i64>,
-                        >,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<i64>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1925,22 +1880,16 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<i64>,),
                             >::new_unchecked(self.list_s64_ret)
                         };
-                        let future = callee.call_concurrent(store.as_context_mut(), ());
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_list_f32_ret<S: wasmtime::AsContextMut>(
+                    pub async fn call_list_f32_ret<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<
-                            wasmtime::component::__internal::Vec<f32>,
-                        >,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<f32>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1948,22 +1897,16 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<f32>,),
                             >::new_unchecked(self.list_f32_ret)
                         };
-                        let future = callee.call_concurrent(store.as_context_mut(), ());
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_list_f64_ret<S: wasmtime::AsContextMut>(
+                    pub async fn call_list_f64_ret<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<
-                            wasmtime::component::__internal::Vec<f64>,
-                        >,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<f64>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1971,23 +1914,19 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<f64>,),
                             >::new_unchecked(self.list_f64_ret)
                         };
-                        let future = callee.call_concurrent(store.as_context_mut(), ());
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_tuple_list<S: wasmtime::AsContextMut>(
+                    pub async fn call_tuple_list<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: wasmtime::component::__internal::Vec<(u8, i8)>,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<
-                            wasmtime::component::__internal::Vec<(i64, u32)>,
-                        >,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<
+                        wasmtime::component::__internal::Vec<(i64, u32)>,
+                    >
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1995,24 +1934,19 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<(i64, u32)>,),
                             >::new_unchecked(self.tuple_list)
                         };
-                        let future = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,));
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_string_list_arg<S: wasmtime::AsContextMut>(
+                    pub async fn call_string_list_arg<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: wasmtime::component::__internal::Vec<
                             wasmtime::component::__internal::String,
                         >,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -2024,20 +1958,20 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.string_list_arg)
                         };
-                        callee.call_concurrent(store.as_context_mut(), (arg0,))
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(())
                     }
-                    pub fn call_string_list_ret<S: wasmtime::AsContextMut>(
+                    pub async fn call_string_list_ret<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<
-                            wasmtime::component::__internal::Vec<
-                                wasmtime::component::__internal::String,
-                            >,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<
+                        wasmtime::component::__internal::Vec<
+                            wasmtime::component::__internal::String,
                         >,
-                    > + Send + 'static + use<S>
+                    >
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -2049,27 +1983,23 @@ pub mod exports {
                                 ),
                             >::new_unchecked(self.string_list_ret)
                         };
-                        let future = callee.call_concurrent(store.as_context_mut(), ());
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_tuple_string_list<S: wasmtime::AsContextMut>(
+                    pub async fn call_tuple_string_list<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: wasmtime::component::__internal::Vec<
                             (u8, wasmtime::component::__internal::String),
                         >,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<
-                            wasmtime::component::__internal::Vec<
-                                (wasmtime::component::__internal::String, u8),
-                            >,
+                    ) -> wasmtime::Result<
+                        wasmtime::component::__internal::Vec<
+                            (wasmtime::component::__internal::String, u8),
                         >,
-                    > + Send + 'static + use<S>
+                    >
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -2085,28 +2015,23 @@ pub mod exports {
                                 ),
                             >::new_unchecked(self.tuple_string_list)
                         };
-                        let future = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,));
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_string_list<S: wasmtime::AsContextMut>(
+                    pub async fn call_string_list<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: wasmtime::component::__internal::Vec<
                             wasmtime::component::__internal::String,
                         >,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<
-                            wasmtime::component::__internal::Vec<
-                                wasmtime::component::__internal::String,
-                            >,
+                    ) -> wasmtime::Result<
+                        wasmtime::component::__internal::Vec<
+                            wasmtime::component::__internal::String,
                         >,
-                    > + Send + 'static + use<S>
+                    >
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -2122,24 +2047,19 @@ pub mod exports {
                                 ),
                             >::new_unchecked(self.string_list)
                         };
-                        let future = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,));
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_record_list<S: wasmtime::AsContextMut>(
+                    pub async fn call_record_list<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: wasmtime::component::__internal::Vec<SomeRecord>,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<
-                            wasmtime::component::__internal::Vec<OtherRecord>,
-                        >,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<
+                        wasmtime::component::__internal::Vec<OtherRecord>,
+                    >
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -2147,24 +2067,19 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<OtherRecord>,),
                             >::new_unchecked(self.record_list)
                         };
-                        let future = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,));
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_record_list_reverse<S: wasmtime::AsContextMut>(
+                    pub async fn call_record_list_reverse<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: wasmtime::component::__internal::Vec<OtherRecord>,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<
-                            wasmtime::component::__internal::Vec<SomeRecord>,
-                        >,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<
+                        wasmtime::component::__internal::Vec<SomeRecord>,
+                    >
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -2172,24 +2087,19 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<SomeRecord>,),
                             >::new_unchecked(self.record_list_reverse)
                         };
-                        let future = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,));
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_variant_list<S: wasmtime::AsContextMut>(
+                    pub async fn call_variant_list<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: wasmtime::component::__internal::Vec<SomeVariant>,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<
-                            wasmtime::component::__internal::Vec<OtherVariant>,
-                        >,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<
+                        wasmtime::component::__internal::Vec<OtherVariant>,
+                    >
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -2197,22 +2107,17 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<OtherVariant>,),
                             >::new_unchecked(self.variant_list)
                         };
-                        let future = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,));
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_load_store_everything<S: wasmtime::AsContextMut>(
+                    pub async fn call_load_store_everything<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: LoadStoreAllSizes,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<LoadStoreAllSizes>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<LoadStoreAllSizes>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -2220,12 +2125,8 @@ pub mod exports {
                                 (LoadStoreAllSizes,),
                             >::new_unchecked(self.load_store_everything)
                         };
-                        let future = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,));
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(ret0)
                     }
                 }
             }

--- a/crates/component-macro/tests/expanded/records_concurrent.rs
+++ b/crates/component-macro/tests/expanded/records_concurrent.rs
@@ -333,62 +333,62 @@ pub mod foo {
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
             pub trait HostConcurrent: wasmtime::component::HasData + Send {
                 fn tuple_arg<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     x: (char, u32),
                 ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
                 fn tuple_result<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = (char, u32)> + Send
                 where
                     Self: Sized;
                 fn empty_arg<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     x: Empty,
                 ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
                 fn empty_result<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = Empty> + Send
                 where
                     Self: Sized;
                 fn scalar_arg<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     x: Scalars,
                 ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
                 fn scalar_result<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = Scalars> + Send
                 where
                     Self: Sized;
                 fn flags_arg<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     x: ReallyFlags,
                 ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
                 fn flags_result<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = ReallyFlags> + Send
                 where
                     Self: Sized;
                 fn aggregate_arg<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     x: Aggregates,
                 ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
                 fn aggregate_result<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = Aggregates> + Send
                 where
                     Self: Sized;
                 fn typedef_inout<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     e: TupleTypedef2,
                 ) -> impl ::core::future::Future<Output = i32> + Send
                 where
@@ -410,7 +410,7 @@ pub mod foo {
                 inst.func_wrap_concurrent(
                     "tuple-arg",
                     move |
-                        caller: &mut wasmtime::component::Accessor<T>,
+                        caller: &wasmtime::component::Accessor<T>,
                         (arg0,): ((char, u32),)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
@@ -423,7 +423,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "tuple-result",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::tuple_result(accessor).await;
@@ -433,10 +433,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "empty-arg",
-                    move |
-                        caller: &mut wasmtime::component::Accessor<T>,
-                        (arg0,): (Empty,)|
-                    {
+                    move |caller: &wasmtime::component::Accessor<T>, (arg0,): (Empty,)| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::empty_arg(accessor, arg0)
@@ -447,7 +444,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "empty-result",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::empty_result(accessor).await;
@@ -458,7 +455,7 @@ pub mod foo {
                 inst.func_wrap_concurrent(
                     "scalar-arg",
                     move |
-                        caller: &mut wasmtime::component::Accessor<T>,
+                        caller: &wasmtime::component::Accessor<T>,
                         (arg0,): (Scalars,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
@@ -471,7 +468,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "scalar-result",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::scalar_result(accessor).await;
@@ -482,7 +479,7 @@ pub mod foo {
                 inst.func_wrap_concurrent(
                     "flags-arg",
                     move |
-                        caller: &mut wasmtime::component::Accessor<T>,
+                        caller: &wasmtime::component::Accessor<T>,
                         (arg0,): (ReallyFlags,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
@@ -495,7 +492,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "flags-result",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::flags_result(accessor).await;
@@ -506,7 +503,7 @@ pub mod foo {
                 inst.func_wrap_concurrent(
                     "aggregate-arg",
                     move |
-                        caller: &mut wasmtime::component::Accessor<T>,
+                        caller: &wasmtime::component::Accessor<T>,
                         (arg0,): (Aggregates,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
@@ -519,7 +516,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "aggregate-result",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::aggregate_result(accessor)
@@ -531,7 +528,7 @@ pub mod foo {
                 inst.func_wrap_concurrent(
                     "typedef-inout",
                     move |
-                        caller: &mut wasmtime::component::Accessor<T>,
+                        caller: &wasmtime::component::Accessor<T>,
                         (arg0,): (TupleTypedef2,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
@@ -909,15 +906,14 @@ pub mod exports {
                     }
                 }
                 impl Guest {
-                    pub fn call_tuple_arg<S: wasmtime::AsContextMut>(
+                    pub async fn call_tuple_arg<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: (char, u32),
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -925,16 +921,16 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.tuple_arg)
                         };
-                        callee.call_concurrent(store.as_context_mut(), (arg0,))
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(())
                     }
-                    pub fn call_tuple_result<S: wasmtime::AsContextMut>(
+                    pub async fn call_tuple_result<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<(char, u32)>,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<(char, u32)>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -942,21 +938,17 @@ pub mod exports {
                                 ((char, u32),),
                             >::new_unchecked(self.tuple_result)
                         };
-                        let future = callee.call_concurrent(store.as_context_mut(), ());
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_empty_arg<S: wasmtime::AsContextMut>(
+                    pub async fn call_empty_arg<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: Empty,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -964,16 +956,16 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.empty_arg)
                         };
-                        callee.call_concurrent(store.as_context_mut(), (arg0,))
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(())
                     }
-                    pub fn call_empty_result<S: wasmtime::AsContextMut>(
+                    pub async fn call_empty_result<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<Empty>,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<Empty>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -981,21 +973,17 @@ pub mod exports {
                                 (Empty,),
                             >::new_unchecked(self.empty_result)
                         };
-                        let future = callee.call_concurrent(store.as_context_mut(), ());
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_scalar_arg<S: wasmtime::AsContextMut>(
+                    pub async fn call_scalar_arg<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: Scalars,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1003,16 +991,16 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.scalar_arg)
                         };
-                        callee.call_concurrent(store.as_context_mut(), (arg0,))
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(())
                     }
-                    pub fn call_scalar_result<S: wasmtime::AsContextMut>(
+                    pub async fn call_scalar_result<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<Scalars>,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<Scalars>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1020,21 +1008,17 @@ pub mod exports {
                                 (Scalars,),
                             >::new_unchecked(self.scalar_result)
                         };
-                        let future = callee.call_concurrent(store.as_context_mut(), ());
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_flags_arg<S: wasmtime::AsContextMut>(
+                    pub async fn call_flags_arg<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: ReallyFlags,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1042,16 +1026,16 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.flags_arg)
                         };
-                        callee.call_concurrent(store.as_context_mut(), (arg0,))
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(())
                     }
-                    pub fn call_flags_result<S: wasmtime::AsContextMut>(
+                    pub async fn call_flags_result<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<ReallyFlags>,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<ReallyFlags>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1059,21 +1043,17 @@ pub mod exports {
                                 (ReallyFlags,),
                             >::new_unchecked(self.flags_result)
                         };
-                        let future = callee.call_concurrent(store.as_context_mut(), ());
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_aggregate_arg<S: wasmtime::AsContextMut>(
+                    pub async fn call_aggregate_arg<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: Aggregates,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1081,16 +1061,16 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.aggregate_arg)
                         };
-                        callee.call_concurrent(store.as_context_mut(), (arg0,))
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(())
                     }
-                    pub fn call_aggregate_result<S: wasmtime::AsContextMut>(
+                    pub async fn call_aggregate_result<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<Aggregates>,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<Aggregates>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1098,21 +1078,17 @@ pub mod exports {
                                 (Aggregates,),
                             >::new_unchecked(self.aggregate_result)
                         };
-                        let future = callee.call_concurrent(store.as_context_mut(), ());
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_typedef_inout<S: wasmtime::AsContextMut>(
+                    pub async fn call_typedef_inout<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: TupleTypedef2,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<i32>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<i32>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1120,12 +1096,8 @@ pub mod exports {
                                 (i32,),
                             >::new_unchecked(self.typedef_inout)
                         };
-                        let future = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,));
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(ret0)
                     }
                 }
             }

--- a/crates/component-macro/tests/expanded/rename_concurrent.rs
+++ b/crates/component-macro/tests/expanded/rename_concurrent.rs
@@ -198,7 +198,7 @@ pub mod foo {
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
             pub trait HostConcurrent: wasmtime::component::HasData + Send {
                 fn foo<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = Thing> + Send
                 where
                     Self: Sized;
@@ -218,7 +218,7 @@ pub mod foo {
                 let mut inst = linker.instance("foo:foo/red")?;
                 inst.func_wrap_concurrent(
                     "foo",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::foo(accessor).await;

--- a/crates/component-macro/tests/expanded/resources-export_concurrent.rs
+++ b/crates/component-macro/tests/expanded/resources-export_concurrent.rs
@@ -367,14 +367,13 @@ pub mod exports {
                     }
                 }
                 impl GuestA<'_> {
-                    pub fn call_constructor<S: wasmtime::AsContextMut>(
+                    pub async fn call_constructor<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<wasmtime::component::ResourceAny>,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<wasmtime::component::ResourceAny>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -382,20 +381,16 @@ pub mod exports {
                                 (wasmtime::component::ResourceAny,),
                             >::new_unchecked(self.funcs.constructor_a_constructor)
                         };
-                        let future = callee.call_concurrent(store.as_context_mut(), ());
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_static_a<S: wasmtime::AsContextMut>(
+                    pub async fn call_static_a<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<u32>,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<u32>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -403,21 +398,17 @@ pub mod exports {
                                 (u32,),
                             >::new_unchecked(self.funcs.static_a_static_a)
                         };
-                        let future = callee.call_concurrent(store.as_context_mut(), ());
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_method_a<S: wasmtime::AsContextMut>(
+                    pub async fn call_method_a<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: wasmtime::component::ResourceAny,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<u32>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<u32>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -425,12 +416,8 @@ pub mod exports {
                                 (u32,),
                             >::new_unchecked(self.funcs.method_a_method_a)
                         };
-                        let future = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,));
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(ret0)
                     }
                 }
             }
@@ -537,15 +524,14 @@ pub mod exports {
                     }
                 }
                 impl GuestA<'_> {
-                    pub fn call_constructor<S: wasmtime::AsContextMut>(
+                    pub async fn call_constructor<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: wasmtime::component::Resource<Y>,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<wasmtime::component::ResourceAny>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<wasmtime::component::ResourceAny>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -553,21 +539,16 @@ pub mod exports {
                                 (wasmtime::component::ResourceAny,),
                             >::new_unchecked(self.funcs.constructor_a_constructor)
                         };
-                        let future = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,));
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_static_a<S: wasmtime::AsContextMut>(
+                    pub async fn call_static_a<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<wasmtime::component::Resource<Y>>,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<wasmtime::component::Resource<Y>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -575,22 +556,18 @@ pub mod exports {
                                 (wasmtime::component::Resource<Y>,),
                             >::new_unchecked(self.funcs.static_a_static_a)
                         };
-                        let future = callee.call_concurrent(store.as_context_mut(), ());
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_method_a<S: wasmtime::AsContextMut>(
+                    pub async fn call_method_a<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: wasmtime::component::ResourceAny,
                         arg1: wasmtime::component::Resource<Y>,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<wasmtime::component::Resource<Y>>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<wasmtime::component::Resource<Y>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -601,12 +578,10 @@ pub mod exports {
                                 (wasmtime::component::Resource<Y>,),
                             >::new_unchecked(self.funcs.method_a_method_a)
                         };
-                        let future = callee
-                            .call_concurrent(store.as_context_mut(), (arg0, arg1));
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee
+                            .call_concurrent(accessor, (arg0, arg1))
+                            .await?;
+                        Ok(ret0)
                     }
                 }
             }
@@ -685,14 +660,13 @@ pub mod exports {
                     }
                 }
                 impl GuestA<'_> {
-                    pub fn call_constructor<S: wasmtime::AsContextMut>(
+                    pub async fn call_constructor<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<wasmtime::component::ResourceAny>,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<wasmtime::component::ResourceAny>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -700,11 +674,8 @@ pub mod exports {
                                 (wasmtime::component::ResourceAny,),
                             >::new_unchecked(self.funcs.constructor_a_constructor)
                         };
-                        let future = callee.call_concurrent(store.as_context_mut(), ());
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
+                        Ok(ret0)
                     }
                 }
             }
@@ -784,15 +755,14 @@ pub mod exports {
                     }
                 }
                 impl GuestB<'_> {
-                    pub fn call_constructor<S: wasmtime::AsContextMut>(
+                    pub async fn call_constructor<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: wasmtime::component::ResourceAny,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<wasmtime::component::ResourceAny>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<wasmtime::component::ResourceAny>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -800,12 +770,8 @@ pub mod exports {
                                 (wasmtime::component::ResourceAny,),
                             >::new_unchecked(self.funcs.constructor_b_constructor)
                         };
-                        let future = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,));
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(ret0)
                     }
                 }
             }

--- a/crates/component-macro/tests/expanded/simple-functions_concurrent.rs
+++ b/crates/component-macro/tests/expanded/simple-functions_concurrent.rs
@@ -178,35 +178,35 @@ pub mod foo {
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
             pub trait HostConcurrent: wasmtime::component::HasData + Send {
                 fn f1<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
                 fn f2<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     a: u32,
                 ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
                 fn f3<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     a: u32,
                     b: u32,
                 ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
                 fn f4<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = u32> + Send
                 where
                     Self: Sized;
                 fn f5<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = (u32, u32)> + Send
                 where
                     Self: Sized;
                 fn f6<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     a: u32,
                     b: u32,
                     c: u32,
@@ -229,7 +229,7 @@ pub mod foo {
                 let mut inst = linker.instance("foo:foo/simple")?;
                 inst.func_wrap_concurrent(
                     "f1",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::f1(accessor).await;
@@ -239,10 +239,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "f2",
-                    move |
-                        caller: &mut wasmtime::component::Accessor<T>,
-                        (arg0,): (u32,)|
-                    {
+                    move |caller: &wasmtime::component::Accessor<T>, (arg0,): (u32,)| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::f2(accessor, arg0).await;
@@ -253,7 +250,7 @@ pub mod foo {
                 inst.func_wrap_concurrent(
                     "f3",
                     move |
-                        caller: &mut wasmtime::component::Accessor<T>,
+                        caller: &wasmtime::component::Accessor<T>,
                         (arg0, arg1): (u32, u32)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
@@ -266,7 +263,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "f4",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::f4(accessor).await;
@@ -276,7 +273,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "f5",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::f5(accessor).await;
@@ -287,7 +284,7 @@ pub mod foo {
                 inst.func_wrap_concurrent(
                     "f6",
                     move |
-                        caller: &mut wasmtime::component::Accessor<T>,
+                        caller: &wasmtime::component::Accessor<T>,
                         (arg0, arg1, arg2): (u32, u32, u32)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
@@ -407,14 +404,13 @@ pub mod exports {
                     }
                 }
                 impl Guest {
-                    pub fn call_f1<S: wasmtime::AsContextMut>(
+                    pub async fn call_f1<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -422,17 +418,17 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.f1)
                         };
-                        callee.call_concurrent(store.as_context_mut(), ())
+                        let () = callee.call_concurrent(accessor, ()).await?;
+                        Ok(())
                     }
-                    pub fn call_f2<S: wasmtime::AsContextMut>(
+                    pub async fn call_f2<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: u32,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -440,18 +436,18 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.f2)
                         };
-                        callee.call_concurrent(store.as_context_mut(), (arg0,))
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(())
                     }
-                    pub fn call_f3<S: wasmtime::AsContextMut>(
+                    pub async fn call_f3<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: u32,
                         arg1: u32,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -459,16 +455,16 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.f3)
                         };
-                        callee.call_concurrent(store.as_context_mut(), (arg0, arg1))
+                        let () = callee.call_concurrent(accessor, (arg0, arg1)).await?;
+                        Ok(())
                     }
-                    pub fn call_f4<S: wasmtime::AsContextMut>(
+                    pub async fn call_f4<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<u32>,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<u32>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -476,20 +472,16 @@ pub mod exports {
                                 (u32,),
                             >::new_unchecked(self.f4)
                         };
-                        let future = callee.call_concurrent(store.as_context_mut(), ());
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_f5<S: wasmtime::AsContextMut>(
+                    pub async fn call_f5<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<(u32, u32)>,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<(u32, u32)>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -497,23 +489,19 @@ pub mod exports {
                                 ((u32, u32),),
                             >::new_unchecked(self.f5)
                         };
-                        let future = callee.call_concurrent(store.as_context_mut(), ());
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_f6<S: wasmtime::AsContextMut>(
+                    pub async fn call_f6<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: u32,
                         arg1: u32,
                         arg2: u32,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<(u32, u32, u32)>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<(u32, u32, u32)>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -521,12 +509,10 @@ pub mod exports {
                                 ((u32, u32, u32),),
                             >::new_unchecked(self.f6)
                         };
-                        let future = callee
-                            .call_concurrent(store.as_context_mut(), (arg0, arg1, arg2));
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee
+                            .call_concurrent(accessor, (arg0, arg1, arg2))
+                            .await?;
+                        Ok(ret0)
                     }
                 }
             }

--- a/crates/component-macro/tests/expanded/simple-lists_concurrent.rs
+++ b/crates/component-macro/tests/expanded/simple-lists_concurrent.rs
@@ -178,20 +178,20 @@ pub mod foo {
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
             pub trait HostConcurrent: wasmtime::component::HasData + Send {
                 fn simple_list1<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     l: wasmtime::component::__internal::Vec<u32>,
                 ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
                 fn simple_list2<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<u32>,
                 > + Send
                 where
                     Self: Sized;
                 fn simple_list3<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     a: wasmtime::component::__internal::Vec<u32>,
                     b: wasmtime::component::__internal::Vec<u32>,
                 ) -> impl ::core::future::Future<
@@ -203,7 +203,7 @@ pub mod foo {
                 where
                     Self: Sized;
                 fn simple_list4<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     l: wasmtime::component::__internal::Vec<
                         wasmtime::component::__internal::Vec<u32>,
                     >,
@@ -231,7 +231,7 @@ pub mod foo {
                 inst.func_wrap_concurrent(
                     "simple-list1",
                     move |
-                        caller: &mut wasmtime::component::Accessor<T>,
+                        caller: &wasmtime::component::Accessor<T>,
                         (arg0,): (wasmtime::component::__internal::Vec<u32>,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
@@ -244,7 +244,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "simple-list2",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::simple_list2(accessor).await;
@@ -255,7 +255,7 @@ pub mod foo {
                 inst.func_wrap_concurrent(
                     "simple-list3",
                     move |
-                        caller: &mut wasmtime::component::Accessor<T>,
+                        caller: &wasmtime::component::Accessor<T>,
                         (
                             arg0,
                             arg1,
@@ -279,7 +279,7 @@ pub mod foo {
                 inst.func_wrap_concurrent(
                     "simple-list4",
                     move |
-                        caller: &mut wasmtime::component::Accessor<T>,
+                        caller: &wasmtime::component::Accessor<T>,
                         (
                             arg0,
                         ): (
@@ -414,15 +414,14 @@ pub mod exports {
                     }
                 }
                 impl Guest {
-                    pub fn call_simple_list1<S: wasmtime::AsContextMut>(
+                    pub async fn call_simple_list1<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: wasmtime::component::__internal::Vec<u32>,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -430,18 +429,16 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.simple_list1)
                         };
-                        callee.call_concurrent(store.as_context_mut(), (arg0,))
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(())
                     }
-                    pub fn call_simple_list2<S: wasmtime::AsContextMut>(
+                    pub async fn call_simple_list2<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<
-                            wasmtime::component::__internal::Vec<u32>,
-                        >,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<u32>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -449,27 +446,23 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<u32>,),
                             >::new_unchecked(self.simple_list2)
                         };
-                        let future = callee.call_concurrent(store.as_context_mut(), ());
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_simple_list3<S: wasmtime::AsContextMut>(
+                    pub async fn call_simple_list3<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: wasmtime::component::__internal::Vec<u32>,
                         arg1: wasmtime::component::__internal::Vec<u32>,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<
-                            (
-                                wasmtime::component::__internal::Vec<u32>,
-                                wasmtime::component::__internal::Vec<u32>,
-                            ),
-                        >,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<
+                        (
+                            wasmtime::component::__internal::Vec<u32>,
+                            wasmtime::component::__internal::Vec<u32>,
+                        ),
+                    >
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -485,28 +478,25 @@ pub mod exports {
                                 ),
                             >::new_unchecked(self.simple_list3)
                         };
-                        let future = callee
-                            .call_concurrent(store.as_context_mut(), (arg0, arg1));
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee
+                            .call_concurrent(accessor, (arg0, arg1))
+                            .await?;
+                        Ok(ret0)
                     }
-                    pub fn call_simple_list4<S: wasmtime::AsContextMut>(
+                    pub async fn call_simple_list4<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: wasmtime::component::__internal::Vec<
                             wasmtime::component::__internal::Vec<u32>,
                         >,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<
-                            wasmtime::component::__internal::Vec<
-                                wasmtime::component::__internal::Vec<u32>,
-                            >,
+                    ) -> wasmtime::Result<
+                        wasmtime::component::__internal::Vec<
+                            wasmtime::component::__internal::Vec<u32>,
                         >,
-                    > + Send + 'static + use<S>
+                    >
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -522,12 +512,8 @@ pub mod exports {
                                 ),
                             >::new_unchecked(self.simple_list4)
                         };
-                        let future = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,));
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(ret0)
                     }
                 }
             }

--- a/crates/component-macro/tests/expanded/simple-wasi_concurrent.rs
+++ b/crates/component-macro/tests/expanded/simple-wasi_concurrent.rs
@@ -231,12 +231,12 @@ pub mod foo {
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
             pub trait HostConcurrent: wasmtime::component::HasData + Send {
                 fn create_directory_at<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = Result<(), Errno>> + Send
                 where
                     Self: Sized;
                 fn stat<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = Result<DescriptorStat, Errno>,
                 > + Send
@@ -258,7 +258,7 @@ pub mod foo {
                 let mut inst = linker.instance("foo:foo/wasi-filesystem")?;
                 inst.func_wrap_concurrent(
                     "create-directory-at",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::create_directory_at(accessor)
@@ -269,7 +269,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "stat",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::stat(accessor).await;

--- a/crates/component-macro/tests/expanded/smoke-default_concurrent.rs
+++ b/crates/component-macro/tests/expanded/smoke-default_concurrent.rs
@@ -164,19 +164,19 @@ const _: () = {
             let indices = TheWorldIndices::new(&instance.instance_pre(&store))?;
             indices.load(&mut store, instance)
         }
-        pub fn call_y<S: wasmtime::AsContextMut>(
+        pub async fn call_y<_T, _D>(
             &self,
-            mut store: S,
-        ) -> impl wasmtime::component::__internal::Future<
-            Output = wasmtime::Result<()>,
-        > + Send + 'static + use<S>
+            accessor: &wasmtime::component::Accessor<_T, _D>,
+        ) -> wasmtime::Result<()>
         where
-            <S as wasmtime::AsContext>::Data: Send + 'static,
+            _T: Send,
+            _D: wasmtime::component::HasData,
         {
             let callee = unsafe {
                 wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.y)
             };
-            callee.call_concurrent(store.as_context_mut(), ())
+            let () = callee.call_concurrent(accessor, ()).await?;
+            Ok(())
         }
     }
 };

--- a/crates/component-macro/tests/expanded/smoke-export_concurrent.rs
+++ b/crates/component-macro/tests/expanded/smoke-export_concurrent.rs
@@ -213,19 +213,19 @@ pub mod exports {
             }
         }
         impl Guest {
-            pub fn call_y<S: wasmtime::AsContextMut>(
+            pub async fn call_y<_T, _D>(
                 &self,
-                mut store: S,
-            ) -> impl wasmtime::component::__internal::Future<
-                Output = wasmtime::Result<()>,
-            > + Send + 'static + use<S>
+                accessor: &wasmtime::component::Accessor<_T, _D>,
+            ) -> wasmtime::Result<()>
             where
-                <S as wasmtime::AsContext>::Data: Send + 'static,
+                _T: Send,
+                _D: wasmtime::component::HasData,
             {
                 let callee = unsafe {
                     wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.y)
                 };
-                callee.call_concurrent(store.as_context_mut(), ())
+                let () = callee.call_concurrent(accessor, ()).await?;
+                Ok(())
             }
         }
     }

--- a/crates/component-macro/tests/expanded/smoke_concurrent.rs
+++ b/crates/component-macro/tests/expanded/smoke_concurrent.rs
@@ -165,7 +165,7 @@ pub mod imports {
     #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
     pub trait HostConcurrent: wasmtime::component::HasData + Send {
         fn y<T: 'static>(
-            accessor: &mut wasmtime::component::Accessor<T, Self>,
+            accessor: &wasmtime::component::Accessor<T, Self>,
         ) -> impl ::core::future::Future<Output = ()> + Send
         where
             Self: Sized;
@@ -185,7 +185,7 @@ pub mod imports {
         let mut inst = linker.instance("imports")?;
         inst.func_wrap_concurrent(
             "y",
-            move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+            move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                 wasmtime::component::__internal::Box::pin(async move {
                     let accessor = &mut unsafe { caller.with_data(host_getter) };
                     let r = <D as HostConcurrent>::y(accessor).await;

--- a/crates/component-macro/tests/expanded/unstable-features_concurrent.rs
+++ b/crates/component-macro/tests/expanded/unstable-features_concurrent.rs
@@ -82,7 +82,7 @@ pub enum Baz {}
 #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
 pub trait HostBazConcurrent: wasmtime::component::HasData + Send {
     fn foo<T: 'static>(
-        accessor: &mut wasmtime::component::Accessor<T, Self>,
+        accessor: &wasmtime::component::Accessor<T, Self>,
         self_: wasmtime::component::Resource<Baz>,
     ) -> impl ::core::future::Future<Output = ()> + Send
     where
@@ -198,7 +198,7 @@ pub struct TheWorld {}
 #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
 pub trait TheWorldImportsConcurrent: wasmtime::component::HasData + Send + HostBazConcurrent {
     fn foo<T: 'static>(
-        accessor: &mut wasmtime::component::Accessor<T, Self>,
+        accessor: &wasmtime::component::Accessor<T, Self>,
     ) -> impl ::core::future::Future<Output = ()> + Send
     where
         Self: Sized;
@@ -292,7 +292,7 @@ const _: () = {
                     linker
                         .func_wrap_concurrent(
                             "foo",
-                            move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                            move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                                 wasmtime::component::__internal::Box::pin(async move {
                                     let accessor = &mut unsafe {
                                         caller.with_data(host_getter)
@@ -309,7 +309,7 @@ const _: () = {
                         .func_wrap_concurrent(
                             "[method]baz.foo",
                             move |
-                                caller: &mut wasmtime::component::Accessor<T>,
+                                caller: &wasmtime::component::Accessor<T>,
                                 (arg0,): (wasmtime::component::Resource<Baz>,)|
                             {
                                 wasmtime::component::__internal::Box::pin(async move {
@@ -398,7 +398,7 @@ pub mod foo {
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
             pub trait HostBarConcurrent: wasmtime::component::HasData + Send {
                 fn foo<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     self_: wasmtime::component::Resource<Bar>,
                 ) -> impl ::core::future::Future<Output = ()> + Send
                 where
@@ -422,7 +422,7 @@ pub mod foo {
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
             pub trait HostConcurrent: wasmtime::component::HasData + Send + HostBarConcurrent {
                 fn foo<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
@@ -460,7 +460,7 @@ pub mod foo {
                     if options.experimental_interface_function {
                         inst.func_wrap_concurrent(
                             "foo",
-                            move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                            move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                                 wasmtime::component::__internal::Box::pin(async move {
                                     let accessor = &mut unsafe {
                                         caller.with_data(host_getter)
@@ -475,7 +475,7 @@ pub mod foo {
                         inst.func_wrap_concurrent(
                             "[method]bar.foo",
                             move |
-                                caller: &mut wasmtime::component::Accessor<T>,
+                                caller: &wasmtime::component::Accessor<T>,
                                 (arg0,): (wasmtime::component::Resource<Bar>,)|
                             {
                                 wasmtime::component::__internal::Box::pin(async move {

--- a/crates/component-macro/tests/expanded/unversioned-foo_concurrent.rs
+++ b/crates/component-macro/tests/expanded/unversioned-foo_concurrent.rs
@@ -195,7 +195,7 @@ pub mod foo {
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
             pub trait HostConcurrent: wasmtime::component::HasData + Send {
                 fn g<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = Result<(), Error>> + Send
                 where
                     Self: Sized;
@@ -215,7 +215,7 @@ pub mod foo {
                 let mut inst = linker.instance("foo:foo/a")?;
                 inst.func_wrap_concurrent(
                     "g",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::g(accessor).await;

--- a/crates/component-macro/tests/expanded/use-paths_concurrent.rs
+++ b/crates/component-macro/tests/expanded/use-paths_concurrent.rs
@@ -189,7 +189,7 @@ pub mod foo {
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
             pub trait HostConcurrent: wasmtime::component::HasData + Send {
                 fn a<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = Foo> + Send
                 where
                     Self: Sized;
@@ -209,7 +209,7 @@ pub mod foo {
                 let mut inst = linker.instance("foo:foo/a")?;
                 inst.func_wrap_concurrent(
                     "a",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::a(accessor).await;
@@ -232,7 +232,7 @@ pub mod foo {
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
             pub trait HostConcurrent: wasmtime::component::HasData + Send {
                 fn a<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = Foo> + Send
                 where
                     Self: Sized;
@@ -252,7 +252,7 @@ pub mod foo {
                 let mut inst = linker.instance("foo:foo/b")?;
                 inst.func_wrap_concurrent(
                     "a",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::a(accessor).await;
@@ -275,7 +275,7 @@ pub mod foo {
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
             pub trait HostConcurrent: wasmtime::component::HasData + Send {
                 fn a<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = Foo> + Send
                 where
                     Self: Sized;
@@ -295,7 +295,7 @@ pub mod foo {
                 let mut inst = linker.instance("foo:foo/c")?;
                 inst.func_wrap_concurrent(
                     "a",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::a(accessor).await;
@@ -320,7 +320,7 @@ pub mod d {
     #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
     pub trait HostConcurrent: wasmtime::component::HasData + Send {
         fn b<T: 'static>(
-            accessor: &mut wasmtime::component::Accessor<T, Self>,
+            accessor: &wasmtime::component::Accessor<T, Self>,
         ) -> impl ::core::future::Future<Output = Foo> + Send
         where
             Self: Sized;
@@ -340,7 +340,7 @@ pub mod d {
         let mut inst = linker.instance("d")?;
         inst.func_wrap_concurrent(
             "b",
-            move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+            move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                 wasmtime::component::__internal::Box::pin(async move {
                     let accessor = &mut unsafe { caller.with_data(host_getter) };
                     let r = <D as HostConcurrent>::b(accessor).await;

--- a/crates/component-macro/tests/expanded/variants_concurrent.rs
+++ b/crates/component-macro/tests/expanded/variants_concurrent.rs
@@ -450,40 +450,40 @@ pub mod foo {
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
             pub trait HostConcurrent: wasmtime::component::HasData + Send {
                 fn e1_arg<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     x: E1,
                 ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
                 fn e1_result<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = E1> + Send
                 where
                     Self: Sized;
                 fn v1_arg<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     x: V1,
                 ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
                 fn v1_result<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = V1> + Send
                 where
                     Self: Sized;
                 fn bool_arg<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     x: bool,
                 ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
                 fn bool_result<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = bool> + Send
                 where
                     Self: Sized;
                 fn option_arg<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     a: Option<bool>,
                     b: Option<()>,
                     c: Option<u32>,
@@ -494,7 +494,7 @@ pub mod foo {
                 where
                     Self: Sized;
                 fn option_result<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = (
                         Option<bool>,
@@ -508,7 +508,7 @@ pub mod foo {
                 where
                     Self: Sized;
                 fn casts<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     a: Casts1,
                     b: Casts2,
                     c: Casts3,
@@ -521,7 +521,7 @@ pub mod foo {
                 where
                     Self: Sized;
                 fn result_arg<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     a: Result<(), ()>,
                     b: Result<(), E1>,
                     c: Result<E1, ()>,
@@ -535,7 +535,7 @@ pub mod foo {
                 where
                     Self: Sized;
                 fn result_result<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = (
                         Result<(), ()>,
@@ -552,52 +552,52 @@ pub mod foo {
                 where
                     Self: Sized;
                 fn return_result_sugar<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = Result<i32, MyErrno>> + Send
                 where
                     Self: Sized;
                 fn return_result_sugar2<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = Result<(), MyErrno>> + Send
                 where
                     Self: Sized;
                 fn return_result_sugar3<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = Result<MyErrno, MyErrno>,
                 > + Send
                 where
                     Self: Sized;
                 fn return_result_sugar4<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = Result<(i32, u32), MyErrno>,
                 > + Send
                 where
                     Self: Sized;
                 fn return_option_sugar<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = Option<i32>> + Send
                 where
                     Self: Sized;
                 fn return_option_sugar2<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = Option<MyErrno>> + Send
                 where
                     Self: Sized;
                 fn result_simple<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = Result<u32, i32>> + Send
                 where
                     Self: Sized;
                 fn is_clone_arg<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                     a: IsClone,
                 ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
                 fn is_clone_return<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = IsClone> + Send
                 where
                     Self: Sized;
@@ -617,7 +617,7 @@ pub mod foo {
                 let mut inst = linker.instance("foo:foo/variants")?;
                 inst.func_wrap_concurrent(
                     "e1-arg",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (arg0,): (E1,)| {
+                    move |caller: &wasmtime::component::Accessor<T>, (arg0,): (E1,)| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::e1_arg(accessor, arg0).await;
@@ -627,7 +627,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "e1-result",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::e1_result(accessor).await;
@@ -637,7 +637,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "v1-arg",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (arg0,): (V1,)| {
+                    move |caller: &wasmtime::component::Accessor<T>, (arg0,): (V1,)| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::v1_arg(accessor, arg0).await;
@@ -647,7 +647,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "v1-result",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::v1_result(accessor).await;
@@ -657,10 +657,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "bool-arg",
-                    move |
-                        caller: &mut wasmtime::component::Accessor<T>,
-                        (arg0,): (bool,)|
-                    {
+                    move |caller: &wasmtime::component::Accessor<T>, (arg0,): (bool,)| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::bool_arg(accessor, arg0)
@@ -671,7 +668,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "bool-result",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::bool_result(accessor).await;
@@ -682,7 +679,7 @@ pub mod foo {
                 inst.func_wrap_concurrent(
                     "option-arg",
                     move |
-                        caller: &mut wasmtime::component::Accessor<T>,
+                        caller: &wasmtime::component::Accessor<T>,
                         (
                             arg0,
                             arg1,
@@ -717,7 +714,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "option-result",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::option_result(accessor).await;
@@ -728,7 +725,7 @@ pub mod foo {
                 inst.func_wrap_concurrent(
                     "casts",
                     move |
-                        caller: &mut wasmtime::component::Accessor<T>,
+                        caller: &wasmtime::component::Accessor<T>,
                         (
                             arg0,
                             arg1,
@@ -757,7 +754,7 @@ pub mod foo {
                 inst.func_wrap_concurrent(
                     "result-arg",
                     move |
-                        caller: &mut wasmtime::component::Accessor<T>,
+                        caller: &wasmtime::component::Accessor<T>,
                         (
                             arg0,
                             arg1,
@@ -795,7 +792,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "result-result",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::result_result(accessor).await;
@@ -805,7 +802,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "return-result-sugar",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::return_result_sugar(accessor)
@@ -816,7 +813,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "return-result-sugar2",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::return_result_sugar2(accessor)
@@ -827,7 +824,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "return-result-sugar3",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::return_result_sugar3(accessor)
@@ -838,7 +835,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "return-result-sugar4",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::return_result_sugar4(accessor)
@@ -849,7 +846,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "return-option-sugar",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::return_option_sugar(accessor)
@@ -860,7 +857,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "return-option-sugar2",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::return_option_sugar2(accessor)
@@ -871,7 +868,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "result-simple",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::result_simple(accessor).await;
@@ -882,7 +879,7 @@ pub mod foo {
                 inst.func_wrap_concurrent(
                     "is-clone-arg",
                     move |
-                        caller: &mut wasmtime::component::Accessor<T>,
+                        caller: &wasmtime::component::Accessor<T>,
                         (arg0,): (IsClone,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
@@ -895,7 +892,7 @@ pub mod foo {
                 )?;
                 inst.func_wrap_concurrent(
                     "is-clone-return",
-                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                    move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
                             let r = <D as HostConcurrent>::is_clone_return(accessor)
@@ -1553,15 +1550,14 @@ pub mod exports {
                     }
                 }
                 impl Guest {
-                    pub fn call_e1_arg<S: wasmtime::AsContextMut>(
+                    pub async fn call_e1_arg<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: E1,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1569,16 +1565,16 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.e1_arg)
                         };
-                        callee.call_concurrent(store.as_context_mut(), (arg0,))
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(())
                     }
-                    pub fn call_e1_result<S: wasmtime::AsContextMut>(
+                    pub async fn call_e1_result<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<E1>,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<E1>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1586,21 +1582,17 @@ pub mod exports {
                                 (E1,),
                             >::new_unchecked(self.e1_result)
                         };
-                        let future = callee.call_concurrent(store.as_context_mut(), ());
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_v1_arg<S: wasmtime::AsContextMut>(
+                    pub async fn call_v1_arg<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: V1,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1608,16 +1600,16 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.v1_arg)
                         };
-                        callee.call_concurrent(store.as_context_mut(), (arg0,))
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(())
                     }
-                    pub fn call_v1_result<S: wasmtime::AsContextMut>(
+                    pub async fn call_v1_result<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<V1>,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<V1>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1625,21 +1617,17 @@ pub mod exports {
                                 (V1,),
                             >::new_unchecked(self.v1_result)
                         };
-                        let future = callee.call_concurrent(store.as_context_mut(), ());
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_bool_arg<S: wasmtime::AsContextMut>(
+                    pub async fn call_bool_arg<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: bool,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1647,16 +1635,16 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.bool_arg)
                         };
-                        callee.call_concurrent(store.as_context_mut(), (arg0,))
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(())
                     }
-                    pub fn call_bool_result<S: wasmtime::AsContextMut>(
+                    pub async fn call_bool_result<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<bool>,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<bool>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1664,26 +1652,22 @@ pub mod exports {
                                 (bool,),
                             >::new_unchecked(self.bool_result)
                         };
-                        let future = callee.call_concurrent(store.as_context_mut(), ());
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_option_arg<S: wasmtime::AsContextMut>(
+                    pub async fn call_option_arg<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: Option<bool>,
                         arg1: Option<()>,
                         arg2: Option<u32>,
                         arg3: Option<E1>,
                         arg4: Option<f32>,
                         arg5: Option<Option<bool>>,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1698,29 +1682,30 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.option_arg)
                         };
-                        callee
+                        let () = callee
                             .call_concurrent(
-                                store.as_context_mut(),
+                                accessor,
                                 (arg0, arg1, arg2, arg3, arg4, arg5),
                             )
+                            .await?;
+                        Ok(())
                     }
-                    pub fn call_option_result<S: wasmtime::AsContextMut>(
+                    pub async fn call_option_result<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<
-                            (
-                                Option<bool>,
-                                Option<()>,
-                                Option<u32>,
-                                Option<E1>,
-                                Option<f32>,
-                                Option<Option<bool>>,
-                            ),
-                        >,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<
+                        (
+                            Option<bool>,
+                            Option<()>,
+                            Option<u32>,
+                            Option<E1>,
+                            Option<f32>,
+                            Option<Option<bool>>,
+                        ),
+                    >
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1737,28 +1722,24 @@ pub mod exports {
                                 ),
                             >::new_unchecked(self.option_result)
                         };
-                        let future = callee.call_concurrent(store.as_context_mut(), ());
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_casts<S: wasmtime::AsContextMut>(
+                    pub async fn call_casts<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: Casts1,
                         arg1: Casts2,
                         arg2: Casts3,
                         arg3: Casts4,
                         arg4: Casts5,
                         arg5: Casts6,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<
-                            (Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),
-                        >,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<
+                        (Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),
+                    >
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1766,19 +1747,17 @@ pub mod exports {
                                 ((Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),),
                             >::new_unchecked(self.casts)
                         };
-                        let future = callee
+                        let (ret0,) = callee
                             .call_concurrent(
-                                store.as_context_mut(),
+                                accessor,
                                 (arg0, arg1, arg2, arg3, arg4, arg5),
-                            );
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                            )
+                            .await?;
+                        Ok(ret0)
                     }
-                    pub fn call_result_arg<S: wasmtime::AsContextMut>(
+                    pub async fn call_result_arg<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: Result<(), ()>,
                         arg1: Result<(), E1>,
                         arg2: Result<E1, ()>,
@@ -1788,11 +1767,10 @@ pub mod exports {
                             wasmtime::component::__internal::String,
                             wasmtime::component::__internal::Vec<u8>,
                         >,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1810,32 +1788,33 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.result_arg)
                         };
-                        callee
+                        let () = callee
                             .call_concurrent(
-                                store.as_context_mut(),
+                                accessor,
                                 (arg0, arg1, arg2, arg3, arg4, arg5),
                             )
+                            .await?;
+                        Ok(())
                     }
-                    pub fn call_result_result<S: wasmtime::AsContextMut>(
+                    pub async fn call_result_result<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<
-                            (
-                                Result<(), ()>,
-                                Result<(), E1>,
-                                Result<E1, ()>,
-                                Result<(), ()>,
-                                Result<u32, V1>,
-                                Result<
-                                    wasmtime::component::__internal::String,
-                                    wasmtime::component::__internal::Vec<u8>,
-                                >,
-                            ),
-                        >,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<
+                        (
+                            Result<(), ()>,
+                            Result<(), E1>,
+                            Result<E1, ()>,
+                            Result<(), ()>,
+                            Result<u32, V1>,
+                            Result<
+                                wasmtime::component::__internal::String,
+                                wasmtime::component::__internal::Vec<u8>,
+                            >,
+                        ),
+                    >
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1855,20 +1834,16 @@ pub mod exports {
                                 ),
                             >::new_unchecked(self.result_result)
                         };
-                        let future = callee.call_concurrent(store.as_context_mut(), ());
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_return_result_sugar<S: wasmtime::AsContextMut>(
+                    pub async fn call_return_result_sugar<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<Result<i32, MyErrno>>,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<Result<i32, MyErrno>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1876,20 +1851,16 @@ pub mod exports {
                                 (Result<i32, MyErrno>,),
                             >::new_unchecked(self.return_result_sugar)
                         };
-                        let future = callee.call_concurrent(store.as_context_mut(), ());
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_return_result_sugar2<S: wasmtime::AsContextMut>(
+                    pub async fn call_return_result_sugar2<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<Result<(), MyErrno>>,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<Result<(), MyErrno>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1897,20 +1868,16 @@ pub mod exports {
                                 (Result<(), MyErrno>,),
                             >::new_unchecked(self.return_result_sugar2)
                         };
-                        let future = callee.call_concurrent(store.as_context_mut(), ());
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_return_result_sugar3<S: wasmtime::AsContextMut>(
+                    pub async fn call_return_result_sugar3<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<Result<MyErrno, MyErrno>>,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<Result<MyErrno, MyErrno>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1918,20 +1885,16 @@ pub mod exports {
                                 (Result<MyErrno, MyErrno>,),
                             >::new_unchecked(self.return_result_sugar3)
                         };
-                        let future = callee.call_concurrent(store.as_context_mut(), ());
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_return_result_sugar4<S: wasmtime::AsContextMut>(
+                    pub async fn call_return_result_sugar4<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<Result<(i32, u32), MyErrno>>,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<Result<(i32, u32), MyErrno>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1939,20 +1902,16 @@ pub mod exports {
                                 (Result<(i32, u32), MyErrno>,),
                             >::new_unchecked(self.return_result_sugar4)
                         };
-                        let future = callee.call_concurrent(store.as_context_mut(), ());
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_return_option_sugar<S: wasmtime::AsContextMut>(
+                    pub async fn call_return_option_sugar<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<Option<i32>>,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<Option<i32>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1960,20 +1919,16 @@ pub mod exports {
                                 (Option<i32>,),
                             >::new_unchecked(self.return_option_sugar)
                         };
-                        let future = callee.call_concurrent(store.as_context_mut(), ());
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_return_option_sugar2<S: wasmtime::AsContextMut>(
+                    pub async fn call_return_option_sugar2<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<Option<MyErrno>>,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<Option<MyErrno>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -1981,20 +1936,16 @@ pub mod exports {
                                 (Option<MyErrno>,),
                             >::new_unchecked(self.return_option_sugar2)
                         };
-                        let future = callee.call_concurrent(store.as_context_mut(), ());
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_result_simple<S: wasmtime::AsContextMut>(
+                    pub async fn call_result_simple<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<Result<u32, i32>>,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<Result<u32, i32>>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -2002,21 +1953,17 @@ pub mod exports {
                                 (Result<u32, i32>,),
                             >::new_unchecked(self.result_simple)
                         };
-                        let future = callee.call_concurrent(store.as_context_mut(), ());
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
+                        Ok(ret0)
                     }
-                    pub fn call_is_clone_arg<S: wasmtime::AsContextMut>(
+                    pub async fn call_is_clone_arg<_T, _D>(
                         &self,
-                        mut store: S,
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
                         arg0: IsClone,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<()>,
-                    > + Send + 'static + use<S>
+                    ) -> wasmtime::Result<()>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -2024,16 +1971,16 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.is_clone_arg)
                         };
-                        callee.call_concurrent(store.as_context_mut(), (arg0,))
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(())
                     }
-                    pub fn call_is_clone_return<S: wasmtime::AsContextMut>(
+                    pub async fn call_is_clone_return<_T, _D>(
                         &self,
-                        mut store: S,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<IsClone>,
-                    > + Send + 'static + use<S>
+                        accessor: &wasmtime::component::Accessor<_T, _D>,
+                    ) -> wasmtime::Result<IsClone>
                     where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                        _T: Send,
+                        _D: wasmtime::component::HasData,
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
@@ -2041,11 +1988,8 @@ pub mod exports {
                                 (IsClone,),
                             >::new_unchecked(self.is_clone_return)
                         };
-                        let future = callee.call_concurrent(store.as_context_mut(), ());
-                        async move {
-                            let (ret0,) = future.await?;
-                            Ok(ret0)
-                        }
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
+                        Ok(ret0)
                     }
                 }
             }

--- a/crates/component-macro/tests/expanded/worlds-with-types_concurrent.rs
+++ b/crates/component-macro/tests/expanded/worlds-with-types_concurrent.rs
@@ -203,23 +203,19 @@ const _: () = {
             foo::foo::i::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
-        pub fn call_f<S: wasmtime::AsContextMut>(
+        pub async fn call_f<_T, _D>(
             &self,
-            mut store: S,
-        ) -> impl wasmtime::component::__internal::Future<
-            Output = wasmtime::Result<(T, U, R)>,
-        > + Send + 'static + use<S>
+            accessor: &wasmtime::component::Accessor<_T, _D>,
+        ) -> wasmtime::Result<(T, U, R)>
         where
-            <S as wasmtime::AsContext>::Data: Send + 'static,
+            _T: Send,
+            _D: wasmtime::component::HasData,
         {
             let callee = unsafe {
                 wasmtime::component::TypedFunc::<(), ((T, U, R),)>::new_unchecked(self.f)
             };
-            let future = callee.call_concurrent(store.as_context_mut(), ());
-            async move {
-                let (ret0,) = future.await?;
-                Ok(ret0)
-            }
+            let (ret0,) = callee.call_concurrent(accessor, ()).await?;
+            Ok(ret0)
         }
     }
 };

--- a/crates/misc/component-async-tests/src/resource_stream.rs
+++ b/crates/misc/component-async-tests/src/resource_stream.rs
@@ -21,7 +21,7 @@ pub mod bindings {
 pub struct ResourceStreamX;
 
 impl bindings::local::local::resource_stream::HostXConcurrent for Ctx {
-    async fn foo<T>(accessor: &mut Accessor<T, Self>, x: Resource<ResourceStreamX>) -> Result<()> {
+    async fn foo<T>(accessor: &Accessor<T, Self>, x: Resource<ResourceStreamX>) -> Result<()> {
         accessor.with(|mut view| {
             _ = view.get().table().get(&x)?;
             Ok(())
@@ -38,7 +38,7 @@ impl bindings::local::local::resource_stream::HostX for Ctx {
 
 impl bindings::local::local::resource_stream::HostConcurrent for Ctx {
     async fn foo<T: 'static>(
-        accessor: &mut Accessor<T, Self>,
+        accessor: &Accessor<T, Self>,
         count: u32,
     ) -> wasmtime::Result<HostStream<Resource<ResourceStreamX>>> {
         struct Task {
@@ -48,7 +48,7 @@ impl bindings::local::local::resource_stream::HostConcurrent for Ctx {
         }
 
         impl<T> AccessorTask<T, Ctx, Result<()>> for Task {
-            async fn run(self, accessor: &mut Accessor<T, Ctx>) -> Result<()> {
+            async fn run(self, accessor: &Accessor<T, Ctx>) -> Result<()> {
                 let mut tx = Some(self.tx);
                 for _ in 0..self.count {
                     tx = accessor

--- a/crates/misc/component-async-tests/src/round_trip.rs
+++ b/crates/misc/component-async-tests/src/round_trip.rs
@@ -24,7 +24,7 @@ pub mod non_concurrent_export_bindings {
 }
 
 impl bindings::local::local::baz::HostConcurrent for Ctx {
-    async fn foo<T>(_: &mut Accessor<T, Self>, s: String) -> wasmtime::Result<String> {
+    async fn foo<T>(_: &Accessor<T, Self>, s: String) -> wasmtime::Result<String> {
         crate::util::sleep(Duration::from_millis(10)).await;
         Ok(format!("{s} - entered host - exited host"))
     }

--- a/crates/misc/component-async-tests/src/round_trip_direct.rs
+++ b/crates/misc/component-async-tests/src/round_trip_direct.rs
@@ -14,7 +14,7 @@ pub mod bindings {
 }
 
 impl bindings::RoundTripDirectImportsConcurrent for Ctx {
-    async fn foo<T>(_: &mut Accessor<T, Self>, s: String) -> wasmtime::Result<String> {
+    async fn foo<T>(_: &Accessor<T, Self>, s: String) -> wasmtime::Result<String> {
         crate::util::sleep(Duration::from_millis(10)).await;
         Ok(format!("{s} - entered host - exited host"))
     }

--- a/crates/misc/component-async-tests/src/round_trip_many.rs
+++ b/crates/misc/component-async-tests/src/round_trip_many.rs
@@ -30,7 +30,7 @@ use bindings::local::local::many::Stuff;
 
 impl bindings::local::local::many::HostConcurrent for Ctx {
     async fn foo<T>(
-        _: &mut Accessor<T, Self>,
+        _: &Accessor<T, Self>,
         a: String,
         b: u32,
         c: Vec<u8>,

--- a/crates/misc/component-async-tests/src/sleep.rs
+++ b/crates/misc/component-async-tests/src/sleep.rs
@@ -15,7 +15,7 @@ wasmtime::component::bindgen!({
 });
 
 impl local::local::sleep::HostConcurrent for Ctx {
-    async fn sleep_millis<T>(_: &mut Accessor<T, Self>, time_in_millis: u64) {
+    async fn sleep_millis<T>(_: &Accessor<T, Self>, time_in_millis: u64) {
         crate::util::sleep(Duration::from_millis(time_in_millis)).await;
     }
 }

--- a/crates/misc/component-async-tests/src/transmit.rs
+++ b/crates/misc/component-async-tests/src/transmit.rs
@@ -3,6 +3,6 @@ pub mod bindings {
         path: "wit",
         world: "transmit-callee",
         concurrent_exports: true,
-        async: true,
+        async: true
     });
 }

--- a/crates/misc/component-async-tests/src/yield_host.rs
+++ b/crates/misc/component-async-tests/src/yield_host.rs
@@ -44,7 +44,7 @@ impl bindings::local::local::ready::Host for Ctx {
 }
 
 impl bindings::local::local::ready::HostConcurrent for Ctx {
-    async fn when_ready<T>(accessor: &mut Accessor<T, Self>) {
+    async fn when_ready<T>(accessor: &Accessor<T, Self>) {
         let wakers = accessor.with(|mut view| view.get().wakers.clone());
         future::poll_fn(move |cx| {
             let mut wakers = wakers.lock().unwrap();

--- a/crates/wasi-http/src/p3/host/types.rs
+++ b/crates/wasi-http/src/p3/host/types.rs
@@ -120,7 +120,7 @@ impl<T, U> AccessorTask<T, WasiHttp<U>, wasmtime::Result<()>> for BodyTask
 where
     U: WasiHttpView + 'static,
 {
-    async fn run(self, store: &mut Accessor<T, WasiHttp<U>>) -> wasmtime::Result<()> {
+    async fn run(self, store: &Accessor<T, WasiHttp<U>>) -> wasmtime::Result<()> {
         let body = {
             let Ok(mut body) = self.body.lock() else {
                 bail!("lock poisoned");
@@ -740,7 +740,7 @@ where
     T: WasiHttpView + 'static,
 {
     async fn new<U: 'static>(
-        store: &mut Accessor<U, Self>,
+        store: &Accessor<U, Self>,
         headers: Resource<WithChildren<http::HeaderMap>>,
         contents: Option<HostStream<u8>>,
         trailers: TrailerFuture,
@@ -784,7 +784,7 @@ where
     }
 
     async fn body<U: 'static>(
-        store: &mut Accessor<U, Self>,
+        store: &Accessor<U, Self>,
         req: Resource<Request>,
     ) -> wasmtime::Result<Result<(HostStream<u8>, TrailerFuture), ()>> {
         store.with(|mut view| {
@@ -1067,7 +1067,7 @@ where
     T: WasiHttpView + 'static,
 {
     async fn new<U: 'static>(
-        store: &mut Accessor<U, Self>,
+        store: &Accessor<U, Self>,
         headers: Resource<WithChildren<http::HeaderMap>>,
         contents: Option<HostStream<u8>>,
         trailers: TrailerFuture,
@@ -1101,7 +1101,7 @@ where
     }
 
     async fn body<U: 'static>(
-        store: &mut Accessor<U, Self>,
+        store: &Accessor<U, Self>,
         res: Resource<Response>,
     ) -> wasmtime::Result<Result<(HostStream<u8>, TrailerFuture), ()>> {
         store.with(|mut view| {

--- a/crates/wasi-http/src/p3/proxy.rs
+++ b/crates/wasi-http/src/p3/proxy.rs
@@ -1,9 +1,5 @@
 use anyhow::Context as _;
-use futures::FutureExt;
-use std::future::Future;
-use std::pin::Pin;
-use wasmtime::AsContextMut;
-use wasmtime::component::Resource;
+use wasmtime::component::{Accessor, Resource};
 use wasmtime_wasi::p3::ResourceView;
 
 use crate::p3::bindings::Proxy;
@@ -12,30 +8,21 @@ use crate::p3::{Request, Response};
 
 impl Proxy {
     /// Call `handle` on [Proxy] getting a [Future] back.
-    pub fn handle<T: 'static, S: AsContextMut<Data = T>, R: Into<Request>>(
+    pub async fn handle<T, R: Into<Request>>(
         &self,
-        mut store: S,
+        store: &Accessor<T>,
         req: R,
-    ) -> wasmtime::Result<
-        Pin<
-            Box<
-                dyn Future<Output = wasmtime::Result<Result<Resource<Response>, ErrorCode>>>
-                    + Send
-                    + 'static,
-            >,
-        >,
-    >
+    ) -> wasmtime::Result<wasmtime::Result<Resource<Response>, ErrorCode>>
     where
         T: ResourceView + Send,
     {
-        let mut store = store.as_context_mut();
-        let table = store.data_mut().table();
-        let req = table
-            .push(req.into())
-            .context("failed to push request to table")?;
-        Ok(self
-            .wasi_http_handler()
-            .call_handle(&mut store, req)
-            .boxed())
+        let req = store.with(|mut store| {
+            store
+                .data_mut()
+                .table()
+                .push(req.into())
+                .context("failed to push request to table")
+        })?;
+        self.wasi_http_handler().call_handle(store, req).await
     }
 }

--- a/crates/wasi-http/tests/all/p3/outgoing.rs
+++ b/crates/wasi-http/tests/all/p3/outgoing.rs
@@ -34,9 +34,10 @@ async fn run(path: &str, server: &Server) -> anyhow::Result<()> {
     wasmtime_wasi_http::p3::add_only_http_to_linker(&mut linker)?;
     let instance = linker.instantiate_async(&mut store, &component).await?;
     let command = Command::new(&mut store, &instance)?;
-    let run = command.wasi_cli_run().call_run(&mut store);
     instance
-        .run(store, run)
+        .run_with(store, async |store| {
+            command.wasi_cli_run().call_run(store).await
+        })
         .await
         .context("failed to call `wasi:cli/run#run`")?
         .context("guest trapped")?

--- a/crates/wasi/src/p3/cli/host.rs
+++ b/crates/wasi/src/p3/cli/host.rs
@@ -23,7 +23,7 @@ where
     U: 'static,
     V: AsyncRead + Send + Sync + Unpin + 'static,
 {
-    async fn run(mut self, _: &mut Accessor<T, WasiCli<U>>) -> wasmtime::Result<()> {
+    async fn run(mut self, _: &Accessor<T, WasiCli<U>>) -> wasmtime::Result<()> {
         let mut tx = self.tx;
         let mut buf = BytesMut::with_capacity(8096);
         loop {
@@ -58,7 +58,7 @@ where
     U: 'static,
     V: AsyncWrite + Send + Sync + Unpin + 'static,
 {
-    async fn run(mut self, _: &mut Accessor<T, WasiCli<U>>) -> wasmtime::Result<()> {
+    async fn run(mut self, _: &Accessor<T, WasiCli<U>>) -> wasmtime::Result<()> {
         let mut buf = BytesMut::with_capacity(8096);
         let mut fut = self.data.read(buf);
         loop {
@@ -165,9 +165,7 @@ impl<T> stdin::HostConcurrent for WasiCli<T>
 where
     T: WasiCliView + 'static,
 {
-    async fn get_stdin<U: 'static>(
-        store: &mut Accessor<U, Self>,
-    ) -> wasmtime::Result<HostStream<u8>> {
+    async fn get_stdin<U: 'static>(store: &Accessor<U, Self>) -> wasmtime::Result<HostStream<u8>> {
         store.with(|mut view| {
             let instance = view.instance();
             let (tx, rx) = instance
@@ -187,7 +185,7 @@ where
     T: WasiCliView + 'static,
 {
     async fn set_stdout<U: 'static>(
-        store: &mut Accessor<U, Self>,
+        store: &Accessor<U, Self>,
         data: HostStream<u8>,
     ) -> wasmtime::Result<()> {
         store.with(|mut view| {
@@ -209,7 +207,7 @@ where
     T: WasiCliView + 'static,
 {
     async fn set_stderr<U: 'static>(
-        store: &mut Accessor<U, Self>,
+        store: &Accessor<U, Self>,
         data: HostStream<u8>,
     ) -> wasmtime::Result<()> {
         store.with(|mut view| {

--- a/crates/wasi/src/p3/clocks/host.rs
+++ b/crates/wasi/src/p3/clocks/host.rs
@@ -47,7 +47,7 @@ where
     T: WasiClocksView + 'static,
 {
     async fn wait_until<U>(
-        store: &mut Accessor<U, Self>,
+        store: &Accessor<U, Self>,
         when: monotonic_clock::Instant,
     ) -> wasmtime::Result<()> {
         let clock_now = store.with(|mut view| view.get().clocks().monotonic_clock.now());
@@ -58,7 +58,7 @@ where
     }
 
     async fn wait_for<U>(
-        _store: &mut Accessor<U, Self>,
+        _store: &Accessor<U, Self>,
         duration: monotonic_clock::Duration,
     ) -> wasmtime::Result<()> {
         if duration > 0 {

--- a/crates/wasi/src/p3/mod.rs
+++ b/crates/wasi/src/p3/mod.rs
@@ -152,10 +152,10 @@ pub struct AccessorTaskFn<F>(pub F);
 impl<T, U, R, F, Fut> AccessorTask<T, U, R> for AccessorTaskFn<F>
 where
     U: HasData,
-    F: FnOnce(&mut Accessor<T, U>) -> Fut + Send + 'static,
+    F: FnOnce(&Accessor<T, U>) -> Fut + Send + 'static,
     Fut: Future<Output = R> + Send,
 {
-    fn run(self, accessor: &mut Accessor<T, U>) -> impl Future<Output = R> + Send {
+    fn run(self, accessor: &Accessor<T, U>) -> impl Future<Output = R> + Send {
         self.0(accessor)
     }
 }
@@ -172,7 +172,7 @@ where
     O: Lower + Send + Sync + 'static,
     E: Lower + Send + Sync + 'static,
 {
-    async fn run(mut self, _: &mut Accessor<T, U>) -> wasmtime::Result<()> {
+    async fn run(mut self, _: &Accessor<T, U>) -> wasmtime::Result<()> {
         let mut tx = self.data;
         let res = loop {
             match self.rx.recv().await {

--- a/crates/wasi/src/p3/sockets/host/ip_name_lookup.rs
+++ b/crates/wasi/src/p3/sockets/host/ip_name_lookup.rs
@@ -14,7 +14,7 @@ where
     T: WasiSocketsView + 'static,
 {
     async fn resolve_addresses<U>(
-        store: &mut Accessor<U, Self>,
+        store: &Accessor<U, Self>,
         name: String,
     ) -> wasmtime::Result<Result<Vec<types::IpAddress>, ErrorCode>> {
         // `url::Host::parse` serves us two functions:

--- a/crates/wasi/src/p3/sockets/host/types/mod.rs
+++ b/crates/wasi/src/p3/sockets/host/types/mod.rs
@@ -14,7 +14,7 @@ impl<T> Host for WasiSocketsImpl<T> where T: WasiSocketsView {}
 
 impl<T> HostConcurrent for WasiSockets<T> where T: WasiSocketsView + 'static {}
 
-fn get_socket_addr_check<T, U>(store: &mut Accessor<T, WasiSockets<U>>) -> SocketAddrCheck
+fn get_socket_addr_check<T, U>(store: &Accessor<T, WasiSockets<U>>) -> SocketAddrCheck
 where
     U: WasiSocketsView + 'static,
 {
@@ -22,7 +22,7 @@ where
 }
 
 async fn is_addr_allowed<T, U>(
-    store: &mut Accessor<T, WasiSockets<U>>,
+    store: &Accessor<T, WasiSockets<U>>,
     addr: SocketAddr,
     reason: SocketAddrUse,
 ) -> bool

--- a/crates/wasi/src/p3/sockets/host/types/udp.rs
+++ b/crates/wasi/src/p3/sockets/host/types/udp.rs
@@ -12,7 +12,7 @@ use crate::p3::sockets::{SocketAddrUse, WasiSockets, WasiSocketsImpl, WasiSocket
 
 use super::is_addr_allowed;
 
-fn is_udp_allowed<T, U>(store: &mut Accessor<T, WasiSockets<U>>) -> bool
+fn is_udp_allowed<T, U>(store: &Accessor<T, WasiSockets<U>>) -> bool
 where
     U: WasiSocketsView + 'static,
 {
@@ -42,7 +42,7 @@ where
     T: WasiSocketsView + 'static,
 {
     async fn bind<U>(
-        store: &mut Accessor<U, Self>,
+        store: &Accessor<U, Self>,
         socket: Resource<UdpSocket>,
         local_address: IpSocketAddress,
     ) -> wasmtime::Result<Result<(), ErrorCode>> {
@@ -60,7 +60,7 @@ where
     }
 
     async fn connect<U>(
-        store: &mut Accessor<U, Self>,
+        store: &Accessor<U, Self>,
         socket: Resource<UdpSocket>,
         remote_address: IpSocketAddress,
     ) -> wasmtime::Result<Result<(), ErrorCode>> {
@@ -78,7 +78,7 @@ where
     }
 
     async fn send<U>(
-        store: &mut Accessor<U, Self>,
+        store: &Accessor<U, Self>,
         socket: Resource<UdpSocket>,
         data: Vec<u8>,
         remote_address: Option<IpSocketAddress>,
@@ -107,7 +107,7 @@ where
     }
 
     async fn receive<U>(
-        store: &mut Accessor<U, Self>,
+        store: &Accessor<U, Self>,
         socket: Resource<UdpSocket>,
     ) -> wasmtime::Result<Result<(Vec<u8>, IpSocketAddress), ErrorCode>> {
         if !is_udp_allowed(store) {

--- a/crates/wasi/tests/all/p3/mod.rs
+++ b/crates/wasi/tests/all/p3/mod.rs
@@ -137,9 +137,10 @@ async fn run(path: &str) -> anyhow::Result<()> {
     let instance = linker.instantiate_async(&mut store, &component).await?;
     let command =
         Command::new(&mut store, &instance).context("failed to instantiate `wasi:cli/command`")?;
-    let run = command.wasi_cli_run().call_run(&mut store);
     instance
-        .run(&mut store, run)
+        .run_with(&mut store, async |store| {
+            command.wasi_cli_run().call_run(store).await
+        })
         .await
         .context("failed to call `wasi:cli/run#run`")?
         .context("guest trapped")?

--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -202,7 +202,7 @@ const START_FLAG_ASYNC_CALLEE: u32 = wasmtime_environ::component::START_FLAG_ASY
 ///
 /// See [`Accessor::with`] for details.
 pub struct Access<'a, T: 'static, D: HasData = HasSelf<T>> {
-    accessor: &'a mut Accessor<T, D>,
+    accessor: &'a Accessor<T, D>,
     store: StoreContextMut<'a, T>,
 }
 
@@ -345,7 +345,7 @@ where
 // `Accessor` and functions like `Linker::func_wrap_concurrent` are
 // intentionally made to ensure that `Accessor` is ideally only used in the
 // context that TLS variables are actually set. For example host functions are
-// given `&mut Accessor`, not `Accessor`, and this prevents them from persisting
+// given `&Accessor`, not `Accessor`, and this prevents them from persisting
 // the value outside of a future. Within the future the TLS variables are all
 // guaranteed to be set while the future is being polled.
 //
@@ -384,13 +384,24 @@ impl<T, D> Accessor<T, D>
 where
     D: HasData,
 {
-    /// Run the specified closure, passing it mutable access to the store data.
+    /// Run the specified closure, passing it mutable access to the store.
     ///
-    /// Note that the return value of the closure must be `'static`, meaning it
-    /// cannot borrow from the store or its associated data.  If you need shared
-    /// access to something in the store data, it must be cloned (using
-    /// e.g. `Arc::clone` if appropriate).
-    pub fn with<R: 'static>(&mut self, fun: impl FnOnce(Access<'_, T, D>) -> R) -> R {
+    /// This function is one of the main building blocks of the [`Accessor`]
+    /// type. This yields synchronous, blocking, access to store via an
+    /// [`Access`]. The [`Access`] implements [`AsContextMut`] in addition to
+    /// providing the ability to access `D` via [`Access::get`]. Note that the
+    /// `fun` here is given only temporary access to the store and `T`/`D`
+    /// meaning that the return value `R` here is not allowed to capture borrows
+    /// into the two. If access is needed to data within `T` or `D` outside of
+    /// this closure then it must be `clone`d out, for example.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if it is call recursively with any other
+    /// accessor already in scope. For example if `with` is called within `fun`,
+    /// then this function will panic. It is up to the embedder to ensure that
+    /// this does not happen.
+    pub fn with<R>(&self, fun: impl FnOnce(Access<'_, T, D>) -> R) -> R {
         tls::get(|vmstore| {
             fun(Access {
                 store: self.token.as_context_mut(vmstore),
@@ -424,10 +435,7 @@ where
     /// In short, this works, but must be treated with care. The current main
     /// user, bindings generation, treats this with care.
     #[doc(hidden)]
-    pub fn with_data<D2: HasData>(
-        &mut self,
-        get_data: fn(&mut T) -> D2::Data<'_>,
-    ) -> Accessor<T, D2> {
+    pub fn with_data<D2: HasData>(&self, get_data: fn(&mut T) -> D2::Data<'_>) -> Accessor<T, D2> {
         Accessor {
             token: self.token,
             get_data,
@@ -435,7 +443,7 @@ where
         }
     }
 
-    /// Spawn a background task which will receive an `&mut Accessor<T, D>` and
+    /// Spawn a background task which will receive an `&Accessor<T, D>` and
     /// run concurrently with any other tasks in progress for the current
     /// instance.
     ///
@@ -444,7 +452,13 @@ where
     /// `stream` or `future` must run after the function returns.
     ///
     /// The returned [`AbortHandle`] may be used to cancel the task.
-    pub fn spawn(&mut self, task: impl AccessorTask<T, D, Result<()>>) -> AbortHandle
+    ///
+    /// # Panics
+    ///
+    /// Panics if called within a closure provided to the [`Accessor::with`]
+    /// function. This can only be called outside an active invocation of
+    /// [`Accessor::with`].
+    pub fn spawn(&self, task: impl AccessorTask<T, D, Result<()>>) -> AbortHandle
     where
         T: 'static,
     {
@@ -478,7 +492,7 @@ where
 // writing (1.84.1), and even with 1.85.0-beta it's not possible to specify
 // e.g. `Send` and `Sync` bounds on the `Future` type returned by an
 // `AsyncFnOnce`.  Also, using `F: Future<Output = Result<()>> + Send + Sync,
-// FN: FnOnce(&mut Accessor<T>) -> F + Send + Sync + 'static` fails with a type
+// FN: FnOnce(&Accessor<T>) -> F + Send + Sync + 'static` fails with a type
 // mismatch error when we try to pass it an async closure (e.g. `async move |_|
 // { ... }`).  So this seems to be the best we can do for the time being.
 pub trait AccessorTask<T, D, R>: Send + 'static
@@ -486,7 +500,7 @@ where
     D: HasData,
 {
     /// Run the task.
-    fn run(self, accessor: &mut Accessor<T, D>) -> impl Future<Output = R> + Send;
+    fn run(self, accessor: &Accessor<T, D>) -> impl Future<Output = R> + Send;
 }
 
 /// Represents the state of a waitable handle.
@@ -1218,13 +1232,10 @@ impl Instance {
     /// }))?;
     /// let instance = linker.instantiate_async(&mut store, &component).await?;
     /// let bar = instance.get_typed_func::<(), (HostFuture<bool>,)>(&mut store, "bar")?;
-    /// let call = bar.call_concurrent(&mut store, ());
     ///
-    /// // // NOT OK; this will panic if polled outside the event loop:
-    /// // let (future,) = call.await?;
-    ///
-    /// // OK, since we use `Instance::run` to poll `call` inside the event loop:
-    /// let (future,) = instance.run(&mut store, call).await??;
+    /// let (future,) = instance.run_with(&mut store, async |store| {
+    ///     bar.call_concurrent(store, ()).await
+    /// }).await??;
     ///
     /// let future = future.into_reader(&mut store);
     ///
@@ -1264,29 +1275,24 @@ impl Instance {
         self.poll_until(store.as_context_mut(), fut).await
     }
 
-    /// Run the specified task as part of this instance's event loop.
+    /// Run the specified closure `fun` to completion as part of this instance's
+    /// event loop.
     ///
-    /// Like [`Self::run`], this will poll a specified future as part of this
-    /// instance's event loop until it yields a result _or_ there are no more
-    /// tasks to run.  Unlike [`Self::run`], the future may close over an
-    /// [`Accessor`], which provides controlled access to the `Store` and its
-    /// data.
+    /// Like [`Self::run`], this will run `fun` as part of this instance's event
+    /// loop until it yields a result _or_ there are no more tasks to run.
+    /// Unlike [`Self::run`], `fun` is provided an [`Accessor`], which provides
+    /// controlled access to the `Store` and its data.
     ///
-    /// This enables a different control flow model than `Self::run` in that the
-    /// future has arbitrary access to the `Store` between `await` operations,
-    /// whereas with `run` the future has no access to the `Store`.  Either one
-    /// can be used to interleave `await` operations and `Store` access;
-    /// i.e. you can either:
+    /// This function can be used to invoke [`Func::call_concurrent`] for
+    /// example within the async closure provided here.
     ///
-    /// - Call `run` multiple times with access to the `Store` in between,
-    /// possibly moving resources, streams, etc. between the `Store` and the
-    /// futures passed to `run`.
+    /// # Example
     ///
     /// ```
     /// # use {
-    /// #   anyhow::Result,
+    /// #   anyhow::{Result},
     /// #   wasmtime::{
-    /// #     component::{ Component, Linker, Resource, ResourceTable },
+    /// #     component::{ Component, Linker, Resource, ResourceTable},
     /// #     Config, Engine, Store
     /// #   },
     /// # };
@@ -1303,90 +1309,37 @@ impl Instance {
     /// # let instance = linker.instantiate_async(&mut store, &component).await?;
     /// # let foo = instance.get_typed_func::<(Resource<MyResource>,), (Resource<MyResource>,)>(&mut store, "foo")?;
     /// # let bar = instance.get_typed_func::<(u32,), ()>(&mut store, "bar")?;
-    /// let resource = store.data_mut().table.push(MyResource(42))?;
-    /// let call = foo.call_concurrent(&mut store, (resource,));
-    /// let (another_resource,) = instance.run(&mut store, call).await??;
-    /// let value = store.data_mut().table.delete(another_resource)?;
-    /// let call = bar.call_concurrent(&mut store, (value.0,));
-    /// instance.run(&mut store, call).await??;
+    /// instance.run_with(&mut store, async |accessor| -> wasmtime::Result<_> {
+    ///    let resource = accessor.with(|mut access| access.get().table.push(MyResource(42)))?;
+    ///    let (another_resource,) = foo.call_concurrent(accessor, (resource,)).await?;
+    ///    let value = accessor.with(|mut access| access.get().table.delete(another_resource))?;
+    ///    bar.call_concurrent(accessor, (value.0,)).await?;
+    ///    Ok(())
+    /// }).await??;
     /// # Ok(())
     /// # }
     /// ```
-    ///
-    /// - Call `run_with` once and use `Accessor::with` to access the store from
-    /// within the future.
-    ///
-    /// ```
-    /// # use {
-    /// #   anyhow::{Result, Error},
-    /// #   wasmtime::{
-    /// #     component::{ Component, Linker, Resource, ResourceTable, Accessor },
-    /// #     Config, Engine, Store
-    /// #   },
-    /// # };
-    /// #
-    /// # struct MyResource(u32);
-    /// # struct Ctx { table: ResourceTable }
-    /// #
-    /// # async fn foo() -> Result<()> {
-    /// # let mut config = Config::new();
-    /// # let engine = Engine::new(&config)?;
-    /// # let mut store = Store::new(&engine, Ctx { table: ResourceTable::new() });
-    /// # let mut linker = Linker::new(&engine);
-    /// # let component = Component::new(&engine, "")?;
-    /// # let instance = linker.instantiate_async(&mut store, &component).await?;
-    /// # let foo = instance.get_typed_func::<(Resource<MyResource>,), (Resource<MyResource>,)>(&mut store, "foo")?;
-    /// # let bar = instance.get_typed_func::<(u32,), ()>(&mut store, "bar")?;
-    /// instance.run_with(&mut store, move |accessor: &mut Accessor<_>| Box::pin(async move {
-    ///    let (another_resource,) = accessor.with(|mut access| {
-    ///        let resource = access.get().table.push(MyResource(42))?;
-    ///        Ok::<_, Error>(foo.call_concurrent(access, (resource,)))
-    ///    })?.await?;
-    ///    accessor.with(|mut access| {
-    ///        let value = access.get().table.delete(another_resource)?;
-    ///        Ok::<_, Error>(bar.call_concurrent(access, (value.0,)))
-    ///    })?.await
-    /// })).await??;
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub async fn run_with<U, V, F>(
-        &self,
-        mut store: impl AsContextMut<Data = U>,
-        fun: F,
-    ) -> Result<V>
+    pub async fn run_with<T, R>(
+        self,
+        mut store: impl AsContextMut<Data = T>,
+        fun: impl AsyncFnOnce(&Accessor<T>) -> R,
+    ) -> Result<R>
     where
-        U: 'static,
-        F: FnOnce(&mut Accessor<U>) -> Pin<Box<dyn Future<Output = V> + Send + '_>>
-            + Send
-            + 'static,
+        T: 'static,
     {
         check_recursive_run();
-        let future = self.run_with_raw(&mut store, fun);
-        self.run(store, future).await
-    }
-
-    fn run_with_raw<U, V, F>(
-        self,
-        mut store: impl AsContextMut<Data = U>,
-        fun: F,
-    ) -> impl Future<Output = V> + 'static
-    where
-        U: 'static,
-        F: FnOnce(&mut Accessor<U>) -> Pin<Box<dyn Future<Output = V> + Send + '_>>
-            + Send
-            + 'static,
-    {
+        let mut store = store.as_context_mut();
         let token = StoreToken::new(store.as_context_mut());
-        async move {
-            let mut accessor = Accessor::new(token, self);
-            fun(&mut accessor).await
-        }
+        let future = async move {
+            let accessor = Accessor::new(token, self);
+            fun(&accessor).await
+        };
+        self.run(store, future).await
     }
 
     /// Spawn a background task to run as part of this instance's event loop.
     ///
-    /// The task will receive an `&mut Accessor<U>` and run concurrently with
+    /// The task will receive an `&Accessor<U>` and run concurrently with
     /// any other tasks in progress for the instance.
     ///
     /// Note that the task will only make progress if and when the event loop
@@ -1408,7 +1361,7 @@ impl Instance {
     fn spawn_with_accessor<T, D>(
         self,
         mut store: StoreContextMut<T>,
-        mut accessor: Accessor<T, D>,
+        accessor: Accessor<T, D>,
         task: impl AccessorTask<T, D, Result<()>>,
     ) -> AbortHandle
     where
@@ -1421,7 +1374,7 @@ impl Instance {
         // hook calls to poll and possibly spawn more background tasks on each
         // iteration.
         let (handle, future) =
-            AbortHandle::run(async move { HostTaskOutput::Result(task.run(&mut accessor).await) });
+            AbortHandle::run(async move { HostTaskOutput::Result(task.run(&accessor).await) });
         self.concurrent_state_mut(store.0)
             .push_future(Box::pin(async move {
                 future.await.unwrap_or(HostTaskOutput::Result(Ok(())))
@@ -2512,7 +2465,7 @@ impl Instance {
     }
 
     /// Wrap the specified host function in a future which will call it, passing
-    /// it an `&mut Accessor<T>`.
+    /// it an `&Accessor<T>`.
     ///
     /// See the `Accessor` documentation for details.
     pub(crate) fn wrap_call<T: 'static, F, R>(
@@ -2522,7 +2475,7 @@ impl Instance {
     ) -> impl Future<Output = Result<R>> + 'static
     where
         T: 'static,
-        F: FnOnce(&mut Accessor<T>) -> Pin<Box<dyn Future<Output = Result<R>> + Send + '_>>
+        F: FnOnce(&Accessor<T>) -> Pin<Box<dyn Future<Output = Result<R>> + Send + '_>>
             + Send
             + Sync
             + 'static,

--- a/crates/wasmtime/src/runtime/component/func/host.rs
+++ b/crates/wasmtime/src/runtime/component/func/host.rs
@@ -72,7 +72,7 @@ impl HostFunc {
     pub(crate) fn from_concurrent<T: 'static, F, P, R>(func: F) -> Arc<HostFunc>
     where
         T: 'static,
-        F: Fn(&mut Accessor<T>, P) -> Pin<Box<dyn Future<Output = Result<R>> + Send + '_>>
+        F: Fn(&Accessor<T>, P) -> Pin<Box<dyn Future<Output = Result<R>> + Send + '_>>
             + Send
             + Sync
             + 'static,
@@ -168,7 +168,7 @@ impl HostFunc {
     where
         T: 'static,
         F: for<'a> Fn(
-                &'a mut Accessor<T>,
+                &'a Accessor<T>,
                 &'a [Val],
                 &'a mut [Val],
             ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>

--- a/crates/wasmtime/src/runtime/component/linker.rs
+++ b/crates/wasmtime/src/runtime/component/linker.rs
@@ -506,7 +506,7 @@ impl<T: 'static> LinkerInstance<'_, T> {
     /// The `F` function here is intended to be:
     ///
     /// ```ignore
-    /// F: AsyncFn(&mut Accessor<T>, Params) -> Result<Return>
+    /// F: AsyncFn(&Accessor<T>, Params) -> Result<Return>
     /// ```
     ///
     /// however the returned future must be `Send` which is not possible to
@@ -548,10 +548,7 @@ impl<T: 'static> LinkerInstance<'_, T> {
     pub fn func_wrap_concurrent<Params, Return, F>(&mut self, name: &str, f: F) -> Result<()>
     where
         T: 'static,
-        F: Fn(
-                &mut Accessor<T>,
-                Params,
-            ) -> Pin<Box<dyn Future<Output = Result<Return>> + Send + '_>>
+        F: Fn(&Accessor<T>, Params) -> Pin<Box<dyn Future<Output = Result<Return>> + Send + '_>>
             + Send
             + Sync
             + 'static,
@@ -714,7 +711,7 @@ impl<T: 'static> LinkerInstance<'_, T> {
     where
         T: 'static,
         F: for<'a> Fn(
-                &'a mut Accessor<T>,
+                &'a Accessor<T>,
                 &'a [Val],
                 &'a mut [Val],
             ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -505,8 +505,11 @@ impl RunCommand {
                     let result = if let Ok(command) =
                         wasmtime_wasi::p3::bindings::Command::new(&mut *store, &instance)
                     {
-                        let run = command.wasi_cli_run().call_run(&mut *store);
-                        instance.run(&mut *store, run).await?
+                        instance
+                            .run_with(&mut *store, async |store| {
+                                command.wasi_cli_run().call_run(store).await
+                            })
+                            .await?
                     } else {
                         wasmtime_wasi::p2::bindings::Command::new(&mut *store, &instance)?
                             .wasi_cli_run()

--- a/tests/all/component_model/import.rs
+++ b/tests/all/component_model/import.rs
@@ -833,8 +833,11 @@ async fn test_stack_and_heap_args_and_rets(concurrent: bool) -> Result<()> {
     let run = instance.get_typed_func::<(), ()>(&mut store, "run")?;
 
     if concurrent {
-        let call = run.call_concurrent(&mut store, ());
-        instance.run(&mut store, call).await??;
+        instance
+            .run_with(&mut store, async move |accessor| {
+                run.call_concurrent(accessor, ()).await
+            })
+            .await??;
     } else {
         run.call_async(&mut store, ()).await?;
     }
@@ -954,8 +957,11 @@ async fn test_stack_and_heap_args_and_rets(concurrent: bool) -> Result<()> {
     let run = instance.get_func(&mut store, "run").unwrap();
 
     if concurrent {
-        let call = run.call_concurrent(&mut store, Vec::new());
-        instance.run(&mut store, call).await??;
+        instance
+            .run_with(&mut store, async |store| {
+                run.call_concurrent(store, Vec::new()).await
+            })
+            .await??;
     } else {
         run.call_async(&mut store, &[], &mut []).await?;
     }

--- a/tests/all/pulley.rs
+++ b/tests/all/pulley.rs
@@ -485,20 +485,32 @@ async fn pulley_provenance_test_async_components() -> Result<()> {
         let instance = linker.instantiate_async(&mut store, &component).await?;
 
         let run = instance.get_typed_func::<(), ()>(&mut store, "run-stackless")?;
-        let run = run.call_concurrent(&mut store, ());
-        instance.run(&mut store, run).await??;
+        instance
+            .run_with(&mut store, async move |accessor| {
+                run.call_concurrent(accessor, ()).await
+            })
+            .await??;
 
         let run = instance.get_typed_func::<(), ()>(&mut store, "run-stackful")?;
-        let run = run.call_concurrent(&mut store, ());
-        instance.run(&mut store, run).await??;
+        instance
+            .run_with(&mut store, async move |accessor| {
+                run.call_concurrent(accessor, ()).await
+            })
+            .await??;
 
         let run = instance.get_typed_func::<(), ()>(&mut store, "run-stackless-stackless")?;
-        let run = run.call_concurrent(&mut store, ());
-        instance.run(&mut store, run).await??;
+        instance
+            .run_with(&mut store, async move |accessor| {
+                run.call_concurrent(accessor, ()).await
+            })
+            .await??;
 
         let run = instance.get_typed_func::<(), ()>(&mut store, "run-stackful-stackful")?;
-        let run = run.call_concurrent(&mut store, ());
-        instance.run(&mut store, run).await??;
+        instance
+            .run_with(&mut store, async move |accessor| {
+                run.call_concurrent(accessor, ()).await
+            })
+            .await??;
     }
 
     Ok(())


### PR DESCRIPTION
After discussion with Joel we've concluded that while `&mut Accessor<T, D>` was originally added to model host functions it is also appropriate to use it to model embedder-rooted invocations of items such as wasm as well. Effectively the conclusion we reached was that `*::call_concurrent` should be taking `&Accessor`, not `StoreContextMut`. This has a number of benefits to it over the previous iteration:

* This makes exports behave more like imports where `Accessor` means "you're in the concurrent world".

* This makes exports have an `async fn` signature which is easier to read and understand.

* This automatically enforces the guarantee that the returned future is only polled within the main event loop because the future is always considered to close over the `&Accessor` provided meaning it statically cannot live outside of the event loop.

* This paves the way forward to future refactorings to avoid storing so much state within a `Store<T>` and instead try to store state directly in futures themselves. This should make cancellation more natural and eventually also remove `'static` bounds on params/results. Furthermore this should make it easier to avoid spawning tasks internally by storing state in futures instead of spawned tasks.

In doing this one of the main questions we were faced with was what to do about `&mut Accessor<T, D>`, namely the `mut` part. With a mutable accessor it would be only possible to call one function concurrently. One option considered was to add combinators like `Accessor::join` and `Accessor::race` but in the end we decided to avoid going that direction and instead switch to `&Accessor<T, D>` everywhere, freely enabling aliasing of the accessor. This has the downside that `Accessor::with` is now a relatively dangerous function in that it can panic, but idiomatic usage of it is not expected to panic as the distinction between the `async` and sync boundary of `Accessor` vs `StoreContextMut` is expected to naturally make the recursive panic condition of `with` rare to come up in practice.

Concrete changes in this commit are:

* `Accessor::with` now requires `&self`.
* `Accessor::spawn` now requires `&self`.
* Host functions are now given `&Accessor`, not `&mut Accessor`.
* `{Typed,}Func::call_concurrent` is now an `async fn` which takes an `&Accessor` instead of `StoreContextMut`.
* Guest bindings generation for concurrent invocations now looks exactly like async bindings generation except for replacing `StoreContextMut` with `Accessor`.

Note that this commit does not yet update the internal implementations of these functions to benefit from the new abilities that taking `&Accessor` implies. Instead that's deferred to a future update as necessary. Instead this is only updating the public API of the `wasmtime` crate to enable these refactorings in the future.

Also note that this does not yet update all functions to take `&Accessor`. Notably futures and streams still need to be updated.

cc #11224

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
