### PR TITLE
Chip away at streams-without-accessors in wasi-http

### DIFF
--- a/crates/wasi-http/src/p3/response.rs
+++ b/crates/wasi-http/src/p3/response.rs
@@ -1,24 +1,23 @@
 use core::iter;
 
 use std::future::Future;
-use std::pin::Pin;
 use std::sync::Arc;
 
 use anyhow::{Context as _, bail};
-use bytes::Bytes;
-use futures::{FutureExt as _, StreamExt as _};
+use bytes::{Bytes, BytesMut};
+use futures::StreamExt as _;
 use http::{HeaderMap, StatusCode};
 use http_body_util::combinators::BoxBody;
 use http_body_util::{BodyExt, BodyStream, StreamBody};
 use tokio::sync::{mpsc, oneshot};
-use wasmtime::component::{FutureWriter, Resource};
+use wasmtime::component::{Accessor, FutureWriter, HasData, Resource, StreamReader};
 use wasmtime::{AsContextMut, StoreContextMut};
 use wasmtime_wasi::p3::{AbortOnDropHandle, ResourceView, WithChildren};
 
 use crate::p3::bindings::http::types::ErrorCode;
 use crate::p3::{
-    Body, BodyFrame, ContentLength, DEFAULT_BUFFER_CAPACITY, OutgoingResponseBody,
-    OutgoingTrailerFuture, empty_body,
+    Body, BodyFrame, BodyGuestContents, ContentLength, DEFAULT_BUFFER_CAPACITY,
+    OutgoingResponseBody, OutgoingTrailerFuture, empty_body,
 };
 
 /// The concrete type behind a `wasi:http/types/response` resource.
@@ -50,33 +49,6 @@ async fn receive_trailers(
     }
 }
 
-async fn handle_guest_trailers<T: ResourceView + 'static>(
-    rx: OutgoingTrailerFuture,
-    tx: oneshot::Sender<Option<Result<WithChildren<HeaderMap>, ErrorCode>>>,
-) -> ResponsePromiseClosure<T> {
-    let Some(trailers) = rx.await else {
-        return Box::new(|_| Ok(()));
-    };
-    match trailers {
-        Ok(Some(trailers)) => Box::new(|mut store| {
-            let table = store.data_mut().table();
-            let trailers = table
-                .delete(trailers)
-                .context("failed to delete trailers")?;
-            _ = tx.send(Some(Ok(trailers)));
-            Ok(())
-        }),
-        Ok(None) => Box::new(|_| {
-            _ = tx.send(None);
-            Ok(())
-        }),
-        Err(err) => Box::new(|_| {
-            _ = tx.send(Some(Err(err)));
-            Ok(())
-        }),
-    }
-}
-
 /// Closure returned by promise returned by [`Response::into_http`]
 pub type ResponsePromiseClosure<T> =
     Box<dyn for<'a> FnOnce(StoreContextMut<'a, T>) -> wasmtime::Result<()> + Send + Sync + 'static>;
@@ -100,8 +72,7 @@ impl Response {
         res: Resource<Response>,
     ) -> wasmtime::Result<(
         http::Response<BoxBody<Bytes, Option<ErrorCode>>>,
-        Option<FutureWriter<Result<(), ErrorCode>>>,
-        Option<Pin<Box<dyn Future<Output = ResponsePromiseClosure<T>> + Send + 'static>>>,
+        ResponseIo,
     )>
     where
         T: ResourceView + Send + 'static,
@@ -125,14 +96,13 @@ impl Response {
         mut store: impl AsContextMut<Data = T>,
     ) -> anyhow::Result<(
         http::Response<BoxBody<Bytes, Option<ErrorCode>>>,
-        Option<FutureWriter<Result<(), ErrorCode>>>,
-        Option<Pin<Box<dyn Future<Output = ResponsePromiseClosure<T>> + Send + 'static>>>,
+        ResponseIo,
     )> {
         let response = http::Response::try_from(self)?;
         let (response, body) = response.into_parts();
-        let (body, tx, promise) = match body {
+        let (body, io) = match body {
             Body::Guest {
-                contents: None,
+                contents: BodyGuestContents::None,
                 buffer: None | Some(BodyFrame::Trailers(Ok(None))),
                 content_length: Some(ContentLength { limit, sent }),
                 ..
@@ -140,14 +110,14 @@ impl Response {
                 bail!("guest response Content-Length mismatch, limit: {limit}, sent: {sent}")
             }
             Body::Guest {
-                contents: None,
+                contents: BodyGuestContents::None,
                 trailers: None,
                 buffer: Some(BodyFrame::Trailers(Ok(None))),
                 tx,
                 ..
-            } => (empty_body().boxed(), Some(tx), None),
+            } => (empty_body().boxed(), ResponseIo::new_only_tx(tx)),
             Body::Guest {
-                contents: None,
+                contents: BodyGuestContents::None,
                 trailers: None,
                 buffer: Some(BodyFrame::Trailers(Ok(Some(trailers)))),
                 tx,
@@ -163,12 +133,11 @@ impl Response {
                     empty_body()
                         .with_trailers(async move { Some(Ok(trailers)) })
                         .boxed(),
-                    Some(tx),
-                    None,
+                    ResponseIo::new_only_tx(tx),
                 )
             }
             Body::Guest {
-                contents: None,
+                contents: BodyGuestContents::None,
                 trailers: None,
                 buffer: Some(BodyFrame::Trailers(Err(err))),
                 tx,
@@ -177,11 +146,10 @@ impl Response {
                 empty_body()
                     .with_trailers(async move { Some(Err(Some(err))) })
                     .boxed(),
-                Some(tx),
-                None,
+                ResponseIo::new_only_tx(tx),
             ),
             Body::Guest {
-                contents: None,
+                contents: BodyGuestContents::None,
                 trailers: Some(trailers),
                 buffer: None,
                 tx,
@@ -191,11 +159,17 @@ impl Response {
                 let body = empty_body()
                     .with_trailers(receive_trailers(trailers_rx))
                     .boxed();
-                let fut = handle_guest_trailers(trailers, trailers_tx).boxed();
-                (body, Some(tx), Some(fut))
+                (
+                    body,
+                    ResponseIo {
+                        body: None,
+                        tx: Some(tx),
+                        trailers: Some((trailers, trailers_tx)),
+                    },
+                )
             }
             Body::Guest {
-                contents: Some(mut contents),
+                contents: BodyGuestContents::Some(contents),
                 trailers: Some(trailers),
                 buffer,
                 tx,
@@ -208,38 +182,25 @@ impl Response {
                     Some(BodyFrame::Trailers(..)) => bail!("guest body is corrupted"),
                     None => Bytes::default(),
                 };
+
                 let body = OutgoingResponseBody::new(contents_rx, buffer, content_length)
                     .with_trailers(receive_trailers(trailers_rx))
                     .boxed();
-                let fut = async move {
-                    loop {
-                        let (tail, mut rx_buffer) = contents.await;
-                        let buffer = rx_buffer.split();
-                        if !buffer.is_empty() {
-                            if let Err(..) = contents_tx.send(buffer.freeze()).await {
-                                break;
-                            }
-                            rx_buffer.reserve(DEFAULT_BUFFER_CAPACITY);
-                        }
-                        if let Some(tail) = tail {
-                            contents = tail.read(rx_buffer).boxed();
-                        } else {
-                            debug_assert!(rx_buffer.is_empty());
-                            break;
-                        }
-                    }
-                    drop(contents_tx);
-                    handle_guest_trailers(trailers, trailers_tx).await
-                }
-                .boxed();
-                (body, Some(tx), Some(fut))
+                (
+                    body,
+                    ResponseIo {
+                        body: Some((contents, contents_tx)),
+                        tx: Some(tx),
+                        trailers: Some((trailers, trailers_tx)),
+                    },
+                )
             }
             Body::Guest { .. } => bail!("guest body is corrupted"),
             Body::Consumed
             | Body::Host {
                 stream: None,
                 buffer: Some(BodyFrame::Trailers(Ok(None))),
-            } => (empty_body().boxed(), None, None),
+            } => (empty_body().boxed(), ResponseIo::none()),
             Body::Host {
                 stream: None,
                 buffer: Some(BodyFrame::Trailers(Ok(Some(trailers)))),
@@ -254,8 +215,7 @@ impl Response {
                     empty_body()
                         .with_trailers(async move { Some(Ok(trailers)) })
                         .boxed(),
-                    None,
-                    None,
+                    ResponseIo::none(),
                 )
             }
             Body::Host {
@@ -265,13 +225,12 @@ impl Response {
                 empty_body()
                     .with_trailers(async move { Some(Err(Some(err))) })
                     .boxed(),
-                None,
-                None,
+                ResponseIo::none(),
             ),
             Body::Host {
                 stream: Some(stream),
                 buffer: None,
-            } => (stream.map_err(Some).boxed(), None, None),
+            } => (stream.map_err(Some).boxed(), ResponseIo::none()),
             Body::Host {
                 stream: Some(stream),
                 buffer: Some(BodyFrame::Data(buffer)),
@@ -280,11 +239,104 @@ impl Response {
                     futures::stream::iter(iter::once(Ok(http_body::Frame::data(buffer))))
                         .chain(BodyStream::new(stream.map_err(Some))),
                 )),
-                None,
-                None,
+                ResponseIo::none(),
             ),
             Body::Host { .. } => bail!("host body is corrupted"),
         };
-        Ok((http::Response::from_parts(response, body), tx, promise))
+        Ok((http::Response::from_parts(response, body), io))
+    }
+}
+
+/// Return structure from [`Response::resource_into_http`] and
+/// [`Resource::into_http`] to perform I/O in the store.
+///
+/// This is primarily used with its [`ResponseIo::run`] method to finish guest
+/// I/O for the body, if necessary.
+pub struct ResponseIo {
+    body: Option<(StreamReader<BytesMut>, mpsc::Sender<Bytes>)>,
+    trailers: Option<(
+        OutgoingTrailerFuture,
+        oneshot::Sender<Option<Result<WithChildren<HeaderMap>, ErrorCode>>>,
+    )>,
+    tx: Option<FutureWriter<Result<(), ErrorCode>>>,
+}
+
+impl ResponseIo {
+    fn none() -> ResponseIo {
+        ResponseIo {
+            body: None,
+            tx: None,
+            trailers: None,
+        }
+    }
+
+    fn new_only_tx(tx: FutureWriter<Result<(), ErrorCode>>) -> ResponseIo {
+        ResponseIo {
+            body: None,
+            tx: Some(tx),
+            trailers: None,
+        }
+    }
+
+    /// Runs the body of this response's I/O, namely forwarding the guest
+    /// body/trailers.
+    ///
+    /// The provided `io_result` is transmitted to the guest once I/O is
+    /// complete.
+    pub async fn run<T, D>(
+        mut self,
+        accessor: &Accessor<T, D>,
+        io_result: impl Future<Output = Result<(), ErrorCode>>,
+    ) -> wasmtime::Result<()>
+    where
+        T: ResourceView + 'static,
+        D: HasData,
+    {
+        if let Some((contents, contents_tx)) = self.body.take() {
+            let (mut tail, mut rx_buffer) = contents
+                .read(BytesMut::with_capacity(DEFAULT_BUFFER_CAPACITY))
+                .await;
+            loop {
+                let buffer = rx_buffer.split();
+                if !buffer.is_empty() {
+                    if let Err(..) = contents_tx.send(buffer.freeze()).await {
+                        break;
+                    }
+                    rx_buffer.reserve(DEFAULT_BUFFER_CAPACITY);
+                }
+                if let Some(rx) = tail {
+                    (tail, rx_buffer) = rx.read(rx_buffer).await;
+                } else {
+                    debug_assert!(rx_buffer.is_empty());
+                    break;
+                }
+            }
+            drop(contents_tx);
+        }
+
+        if let Some((trailers, trailers_tx)) = self.trailers.take() {
+            match trailers.await {
+                Some(Ok(Some(trailers))) => {
+                    let trailers = accessor.with(|mut store| {
+                        let table = store.data_mut().table();
+                        table.delete(trailers).context("failed to delete trailers")
+                    })?;
+                    _ = trailers_tx.send(Some(Ok(trailers)));
+                }
+                Some(Ok(None)) => {
+                    _ = trailers_tx.send(None);
+                }
+                Some(Err(err)) => {
+                    _ = trailers_tx.send(Some(Err(err)));
+                }
+                None => {}
+            }
+        }
+
+        let io_result = io_result.await;
+        if let Some(tx) = self.tx.take() {
+            tx.write(io_result).await;
+        }
+        Ok(())
     }
 }


### PR DESCRIPTION
This is similar to #229 in that it's preparation for adding `Accessor` arguments to future/stream methods. This replaces
`Body::Guest::contents` with a `StreamReader<BytesMut>` instead of an in-progress `'static` future. The major consequences of this are:

* `Response::into_http` now returns a lump "do this I/O in the store" object instead of separate values and/or generic futures.
* Guest-to-guest bodies no longer work if a `body` handle is dropped, notably a tombstone is left because reads cannot be cancelled at this time.
* Some test behavior changed because reads are not submitted immediately but are instead deferred to when the body is actually accessed.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
