### PR TITLE
Add `&Accessor<T, D>` to all future/stream APIs

### DIFF
--- a/crates/misc/component-async-tests/Cargo.toml
+++ b/crates/misc/component-async-tests/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-futures = { workspace = true }
+futures = { workspace = true, features = ['async-await'] }
 env_logger = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = [

--- a/crates/misc/component-async-tests/src/resource_stream.rs
+++ b/crates/misc/component-async-tests/src/resource_stream.rs
@@ -51,13 +51,9 @@ impl bindings::local::local::resource_stream::HostConcurrent for Ctx {
             async fn run(self, accessor: &Accessor<T, Ctx>) -> Result<()> {
                 let mut tx = Some(self.tx);
                 for _ in 0..self.count {
-                    tx = accessor
-                        .with(|mut view| {
-                            let item = view.get().table().push(ResourceStreamX)?;
-                            Ok::<_, anyhow::Error>(tx.take().unwrap().write_all(Some(item)))
-                        })?
-                        .await
-                        .0;
+                    let item =
+                        accessor.with(|mut view| view.get().table().push(ResourceStreamX))?;
+                    tx = tx.take().unwrap().write_all(accessor, Some(item)).await.0;
                 }
                 Ok(())
             }

--- a/crates/misc/component-async-tests/tests/scenario/transmit.rs
+++ b/crates/misc/component-async-tests/tests/scenario/transmit.rs
@@ -427,7 +427,7 @@ async fn test_transmit_with<Test: TransmitTest + 'static>(component: &str) -> Re
                             caller_future1_tx
                                 .take()
                                 .unwrap()
-                                .write("b".into())
+                                .write(accessor, "b".into())
                                 .map(Event::WriteB)
                                 .map(Ok)
                                 .boxed(),
@@ -467,7 +467,7 @@ async fn test_transmit_with<Test: TransmitTest + 'static>(component: &str) -> Re
                             callee_future1_rx
                                 .take()
                                 .unwrap()
-                                .read()
+                                .read(accessor)
                                 .map(Event::ReadD)
                                 .map(Ok)
                                 .boxed(),

--- a/crates/misc/component-async-tests/tests/scenario/transmit.rs
+++ b/crates/misc/component-async-tests/tests/scenario/transmit.rs
@@ -377,14 +377,14 @@ async fn test_transmit_with<Test: TransmitTest + 'static>(component: &str) -> Re
 
             futures.push(
                 control_tx
-                    .write_all(Some(Control::ReadStream("a".into())))
+                    .write_all(accessor, Some(Control::ReadStream("a".into())))
                     .map(|(w, _)| Ok(Event::ControlWriteA(w)))
                     .boxed(),
             );
 
             futures.push(
                 caller_stream_tx
-                    .write_all(Some(String::from("a")))
+                    .write_all(accessor, Some(String::from("a")))
                     .map(|_| Ok(Event::WriteA))
                     .boxed(),
             );
@@ -417,7 +417,7 @@ async fn test_transmit_with<Test: TransmitTest + 'static>(component: &str) -> Re
                     Event::ControlWriteA(tx) => {
                         futures.push(
                             tx.unwrap()
-                                .write_all(Some(Control::ReadFuture("b".into())))
+                                .write_all(accessor, Some(Control::ReadFuture("b".into())))
                                 .map(|(w, _)| Ok(Event::ControlWriteB(w)))
                                 .boxed(),
                         );
@@ -436,7 +436,7 @@ async fn test_transmit_with<Test: TransmitTest + 'static>(component: &str) -> Re
                     Event::ControlWriteB(tx) => {
                         futures.push(
                             tx.unwrap()
-                                .write_all(Some(Control::WriteStream("c".into())))
+                                .write_all(accessor, Some(Control::WriteStream("c".into())))
                                 .map(|(w, _)| Ok(Event::ControlWriteC(w)))
                                 .boxed(),
                         );
@@ -447,7 +447,7 @@ async fn test_transmit_with<Test: TransmitTest + 'static>(component: &str) -> Re
                             callee_stream_rx
                                 .take()
                                 .unwrap()
-                                .read(None)
+                                .read(accessor, None)
                                 .map(|(r, b)| Ok(Event::ReadC(r, b)))
                                 .boxed(),
                         );
@@ -455,7 +455,7 @@ async fn test_transmit_with<Test: TransmitTest + 'static>(component: &str) -> Re
                     Event::ControlWriteC(tx) => {
                         futures.push(
                             tx.unwrap()
-                                .write_all(Some(Control::WriteFuture("d".into())))
+                                .write_all(accessor, Some(Control::WriteFuture("d".into())))
                                 .map(|_| Ok(Event::ControlWriteD))
                                 .boxed(),
                         );
@@ -482,7 +482,7 @@ async fn test_transmit_with<Test: TransmitTest + 'static>(component: &str) -> Re
                             callee_stream_rx
                                 .take()
                                 .unwrap()
-                                .read(None)
+                                .read(accessor, None)
                                 .map(|(r, _)| Ok(Event::ReadNone(r)))
                                 .boxed(),
                         );

--- a/crates/wasi-http/src/p3/body.rs
+++ b/crates/wasi-http/src/p3/body.rs
@@ -408,7 +408,7 @@ impl http_body::Body for IncomingResponseBody {
 }
 
 pub(crate) async fn handle_guest_trailers<T, D>(
-    accessor: &Accessor<T, D>,
+    store: &Accessor<T, D>,
     guest_trailers: FutureReader<GuestTrailers>,
     host_trailers: oneshot::Sender<Result<http::HeaderMap, Option<ErrorCode>>>,
 ) -> wasmtime::Result<()>
@@ -416,9 +416,9 @@ where
     D: HasData,
     for<'a> D::Data<'a>: ResourceView,
 {
-    match guest_trailers.read().await {
+    match guest_trailers.read(store).await {
         Some(Ok(Some(trailers))) => {
-            let trailers = accessor.with(|mut store| {
+            let trailers = store.with(|mut store| {
                 let mut binding = store.get();
                 let table = binding.table();
                 table.delete(trailers).context("failed to delete trailers")

--- a/crates/wasi/src/p3/mod.rs
+++ b/crates/wasi/src/p3/mod.rs
@@ -237,7 +237,7 @@ where
     O: Lower + Send + Sync + 'static,
     E: Lower + Send + Sync + 'static,
 {
-    async fn run(mut self, _: &Accessor<T, U>) -> wasmtime::Result<()> {
+    async fn run(mut self, store: &Accessor<T, U>) -> wasmtime::Result<()> {
         let mut tx = self.data;
         let res = loop {
             match self.rx.recv().await {
@@ -246,7 +246,7 @@ where
                     break Ok(());
                 }
                 Some(Ok(buf)) => {
-                    let fut = tx.write_all(buf.into());
+                    let fut = tx.write_all(store, buf.into());
                     let (Some(tail), _) = fut.await else {
                         break Ok(());
                     };
@@ -259,7 +259,7 @@ where
                 }
             }
         };
-        self.result.write(res).await;
+        self.result.write(store, res).await;
         Ok(())
     }
 }

--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -1251,54 +1251,6 @@ impl Instance {
     /// `Instance::spawn` to ensure they are polled as part of the correct event
     /// loop.
     ///
-    /// Consider the following examples:
-    ///
-    /// ```
-    /// # use {
-    /// #   anyhow::{anyhow, Result},
-    /// #   wasmtime::{
-    /// #     component::{ Component, Linker, HostFuture },
-    /// #     Config, Engine, Store
-    /// #   },
-    /// # };
-    /// #
-    /// # async fn foo() -> Result<()> {
-    /// # let mut config = Config::new();
-    /// # let engine = Engine::new(&config)?;
-    /// # let mut store = Store::new(&engine, ());
-    /// # let mut linker = Linker::new(&engine);
-    /// # let component = Component::new(&engine, "")?;
-    /// linker.root().func_wrap_concurrent("foo", |accessor, (future,): (HostFuture<bool>,)| Box::pin(async move {
-    ///     let future = accessor.with(|view| future.into_reader(view));
-    ///     // We can `.await` this directly (i.e. without using
-    ///     // `Instance::{run,run_with,spawn}`) since we're running in a host
-    ///     // function:
-    ///     Ok((future.read().await.ok_or_else(|| anyhow!("read failed"))?,))
-    /// }))?;
-    /// let instance = linker.instantiate_async(&mut store, &component).await?;
-    /// let bar = instance.get_typed_func::<(), (HostFuture<bool>,)>(&mut store, "bar")?;
-    ///
-    /// let (future,) = instance.run_with(&mut store, async |store| {
-    ///     bar.call_concurrent(store, ()).await
-    /// }).await??;
-    ///
-    /// let future = future.into_reader(&mut store);
-    ///
-    /// // // NOT OK; this will panic if polled outside the event loop:
-    /// // let _result = future.read().await;
-    ///
-    /// // OK, since we use `Instance::run` to poll the `Future` returned by
-    /// // `FutureReader::read`. Here we wrap that future in an async block for
-    /// // illustration, although it's redundant for a simple case like this. In
-    /// // a more complex scenario, we could use composition, loops, conditionals,
-    /// // etc.
-    /// let _result = instance.run(&mut store, Box::pin(async move {
-    ///     future.read().await
-    /// })).await?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    ///
     /// Note that this function will return a "deadlock" error in either of the
     /// following scenarios:
     ///

--- a/crates/wasmtime/src/runtime/component/func.rs
+++ b/crates/wasmtime/src/runtime/component/func.rs
@@ -16,9 +16,7 @@ use wasmtime_environ::component::{
 };
 
 #[cfg(feature = "component-model-async")]
-use crate::component::HasData;
-#[cfg(feature = "component-model-async")]
-use crate::component::concurrent::{self, Accessor, PreparedCall};
+use crate::component::concurrent::{self, AsAccessor, PreparedCall};
 #[cfg(feature = "component-model-async")]
 use core::future::Future;
 #[cfg(feature = "component-model-async")]
@@ -329,15 +327,12 @@ impl Func {
     /// `Instance::spawn` to poll it from within the event loop.  See
     /// [`Instance::run`] for examples.
     #[cfg(feature = "component-model-async")]
-    pub async fn call_concurrent<T, D>(
+    pub async fn call_concurrent(
         self,
-        accessor: &Accessor<T, D>,
+        accessor: impl AsAccessor<Data: Send>,
         params: Vec<Val>,
-    ) -> Result<Vec<Val>>
-    where
-        T: Send,
-        D: HasData,
-    {
+    ) -> Result<Vec<Val>> {
+        let accessor = accessor.as_accessor();
         let result = accessor.with(|mut access| {
             let store = access.as_context_mut();
             assert!(

--- a/crates/wasmtime/src/runtime/component/func/typed.rs
+++ b/crates/wasmtime/src/runtime/component/func/typed.rs
@@ -17,9 +17,7 @@ use wasmtime_environ::component::{
 };
 
 #[cfg(feature = "component-model-async")]
-use crate::component::HasData;
-#[cfg(feature = "component-model-async")]
-use crate::component::concurrent::{self, Accessor, PreparedCall};
+use crate::component::concurrent::{self, AsAccessor, PreparedCall};
 
 /// A statically-typed version of [`Func`] which takes `Params` as input and
 /// returns `Return`.
@@ -262,17 +260,16 @@ where
     /// `Instance::spawn` to poll it from within the event loop.  See
     /// [`Instance::run`] for examples.
     #[cfg(feature = "component-model-async")]
-    pub async fn call_concurrent<T, D>(
+    pub async fn call_concurrent(
         self,
-        accessor: &Accessor<T, D>,
+        accessor: impl AsAccessor<Data: Send>,
         params: Params,
     ) -> Result<Return>
     where
-        T: Send,
-        D: HasData,
         Params: 'static,
         Return: 'static,
     {
+        let accessor = accessor.as_accessor();
         let result = accessor.with(|mut store| {
             let mut store = store.as_context_mut();
             assert!(

--- a/crates/wasmtime/src/runtime/component/mod.rs
+++ b/crates/wasmtime/src/runtime/component/mod.rs
@@ -119,9 +119,9 @@ mod values;
 pub use self::component::{Component, ComponentExportIndex};
 #[cfg(feature = "component-model-async")]
 pub use self::concurrent::{
-    AbortHandle, Access, Accessor, AccessorTask, ErrorContext, FutureReader, FutureWriter,
-    HostFuture, HostStream, ReadBuffer, StreamReader, StreamWriter, VMComponentAsyncStore,
-    VecBuffer, Watch, WriteBuffer,
+    AbortHandle, Access, Accessor, AccessorTask, AsAccessor, ErrorContext, FutureReader,
+    FutureWriter, HostFuture, HostStream, ReadBuffer, StreamReader, StreamWriter,
+    VMComponentAsyncStore, VecBuffer, Watch, WriteBuffer,
 };
 pub use self::func::{
     ComponentNamedList, ComponentType, Func, Lift, Lower, TypedFunc, WasmList, WasmStr,


### PR DESCRIPTION
Follow-up work from `Func` and `TypedFunc`, powered by prior refactorings in wasi-http to enable this.