### PR TITLE
Migrate `StreamWriter` methods to `&mut self`

### DIFF
--- a/crates/misc/component-async-tests/src/resource_stream.rs
+++ b/crates/misc/component-async-tests/src/resource_stream.rs
@@ -49,11 +49,11 @@ impl bindings::local::local::resource_stream::HostConcurrent for Ctx {
 
         impl<T> AccessorTask<T, Ctx, Result<()>> for Task {
             async fn run(self, accessor: &Accessor<T, Ctx>) -> Result<()> {
-                let mut tx = Some(self.tx);
+                let mut tx = self.tx;
                 for _ in 0..self.count {
                     let item =
                         accessor.with(|mut view| view.get().table().push(ResourceStreamX))?;
-                    tx = tx.take().unwrap().write_all(accessor, Some(item)).await.0;
+                    tx.write_all(accessor, Some(item)).await;
                 }
                 Ok(())
             }

--- a/crates/misc/component-async-tests/tests/scenario/transmit.rs
+++ b/crates/misc/component-async-tests/tests/scenario/transmit.rs
@@ -360,8 +360,9 @@ async fn test_transmit_with<Test: TransmitTest + 'static>(component: &str) -> Re
         ReadNone(Option<StreamReader<Option<String>>>),
     }
 
-    let (control_tx, control_rx) = instance.stream::<_, _, Option<_>>(&mut store)?;
-    let (caller_stream_tx, caller_stream_rx) = instance.stream::<_, _, Option<_>>(&mut store)?;
+    let (mut control_tx, control_rx) = instance.stream::<_, _, Option<_>>(&mut store)?;
+    let (mut caller_stream_tx, caller_stream_rx) =
+        instance.stream::<_, _, Option<_>>(&mut store)?;
     let (caller_future1_tx, caller_future1_rx) = instance.future(|| unreachable!(), &mut store)?;
     let (_caller_future2_tx, caller_future2_rx) = instance.future(|| unreachable!(), &mut store)?;
 
@@ -376,17 +377,28 @@ async fn test_transmit_with<Test: TransmitTest + 'static>(component: &str) -> Re
             let mut complete = false;
 
             futures.push(
-                control_tx
-                    .write_all(accessor, Some(Control::ReadStream("a".into())))
-                    .map(|(w, _)| Ok(Event::ControlWriteA(w)))
-                    .boxed(),
+                async move {
+                    control_tx
+                        .write_all(accessor, Some(Control::ReadStream("a".into())))
+                        .await;
+                    let w = if control_tx.is_closed() {
+                        None
+                    } else {
+                        Some(control_tx)
+                    };
+                    Ok(Event::ControlWriteA(w))
+                }
+                .boxed(),
             );
 
             futures.push(
-                caller_stream_tx
-                    .write_all(accessor, Some(String::from("a")))
-                    .map(|_| Ok(Event::WriteA))
-                    .boxed(),
+                async move {
+                    caller_stream_tx
+                        .write_all(accessor, Some(String::from("a")))
+                        .await;
+                    Ok(Event::WriteA)
+                }
+                .boxed(),
             );
 
             futures.push(
@@ -416,10 +428,14 @@ async fn test_transmit_with<Test: TransmitTest + 'static>(component: &str) -> Re
                     }
                     Event::ControlWriteA(tx) => {
                         futures.push(
-                            tx.unwrap()
-                                .write_all(accessor, Some(Control::ReadFuture("b".into())))
-                                .map(|(w, _)| Ok(Event::ControlWriteB(w)))
-                                .boxed(),
+                            async move {
+                                let mut tx = tx.unwrap();
+                                tx.write_all(accessor, Some(Control::ReadFuture("b".into())))
+                                    .await;
+                                let w = if tx.is_closed() { None } else { Some(tx) };
+                                Ok(Event::ControlWriteB(w))
+                            }
+                            .boxed(),
                         );
                     }
                     Event::WriteA => {
@@ -435,10 +451,14 @@ async fn test_transmit_with<Test: TransmitTest + 'static>(component: &str) -> Re
                     }
                     Event::ControlWriteB(tx) => {
                         futures.push(
-                            tx.unwrap()
-                                .write_all(accessor, Some(Control::WriteStream("c".into())))
-                                .map(|(w, _)| Ok(Event::ControlWriteC(w)))
-                                .boxed(),
+                            async move {
+                                let mut tx = tx.unwrap();
+                                tx.write_all(accessor, Some(Control::WriteStream("c".into())))
+                                    .await;
+                                let w = if tx.is_closed() { None } else { Some(tx) };
+                                Ok(Event::ControlWriteC(w))
+                            }
+                            .boxed(),
                         );
                     }
                     Event::WriteB(delivered) => {
@@ -454,10 +474,13 @@ async fn test_transmit_with<Test: TransmitTest + 'static>(component: &str) -> Re
                     }
                     Event::ControlWriteC(tx) => {
                         futures.push(
-                            tx.unwrap()
-                                .write_all(accessor, Some(Control::WriteFuture("d".into())))
-                                .map(|_| Ok(Event::ControlWriteD))
-                                .boxed(),
+                            async move {
+                                let mut tx = tx.unwrap();
+                                tx.write_all(accessor, Some(Control::WriteFuture("d".into())))
+                                    .await;
+                                Ok(Event::ControlWriteD)
+                            }
+                            .boxed(),
                         );
                     }
                     Event::ReadC(None, _) => unreachable!(),

--- a/crates/wasi/src/p3/mod.rs
+++ b/crates/wasi/src/p3/mod.rs
@@ -251,11 +251,10 @@ where
                     break Ok(());
                 }
                 Some(Ok(buf)) => {
-                    let fut = tx.write_all(store, buf.into());
-                    let (Some(tail), _) = fut.await else {
+                    tx.write_all(store, buf.into()).await;
+                    if tx.is_closed() {
                         break Ok(());
-                    };
-                    tx = tail;
+                    }
                 }
                 Some(Err(err)) => {
                     // TODO: Close the stream with an error context

--- a/crates/wasi/src/p3/sockets/host/types/tcp.rs
+++ b/crates/wasi/src/p3/sockets/host/types/tcp.rs
@@ -177,10 +177,10 @@ where
                     .push(TcpSocket::from_state(state, self.family))
                     .context("failed to push socket to table")
             })?;
-            let (Some(tail), _) = tx.write(store, Some(socket)).await else {
+            tx.write(store, Some(socket)).await;
+            if tx.is_closed() {
                 return Ok(());
-            };
-            tx = tail;
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
